### PR TITLE
Remove delta config for person reconciliation service

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -162,23 +162,6 @@ export default [
   },
   {
     match: {
-      predicate: {
-        type: 'uri',
-        value: 'http://www.w3.org/ns/adms#identifier'
-      }
-    },
-    callback: {
-      url: 'http://person-reconciliation/delta',
-      method: 'POST'
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true
-    }
-  },
-  {
-    match: {
       // anything
     },
     callback: {


### PR DESCRIPTION
Remove the delta rule triggering the person reconciliation service, because it causes issues in the frontend. 

The main problem is that a person newly created can be instantly deleted, inducing errors when trying to attach a mandataris to it.