### PR TITLE
Add kbonummer and check performance change

### DIFF
--- a/config/reports/bestuurseenhedenReport.js
+++ b/config/reports/bestuurseenhedenReport.js
@@ -16,10 +16,13 @@ export default {
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
       
-      select distinct ?uri ?name ?type ?province where {
+      select distinct ?uri ?name ?kbonummer ?type ?province where {
         ?uri a besluit:Bestuurseenheid.
         OPTIONAL {
           ?uri skos:prefLabel ?name.
+        }
+        OPTIONAL {
+          ?uri ext:kbonummer ?kbonummer.
         }
         OPTIONAL {
           ?uri ext:inProvincie ?provinceURI.

--- a/config/reports/bestuurseenhedenReport.js
+++ b/config/reports/bestuurseenhedenReport.js
@@ -40,7 +40,8 @@ export default {
       name: bestuurseenheid.name ? bestuurseenheid.name.value : '',
       type: bestuurseenheid.type ? bestuurseenheid.type.value : '',
       province: bestuurseenheid.province ? bestuurseenheid.province.value : '',
+      kbonummer: bestuurseenheid.kbonummer ? bestuurseenheid.kbonummer.value: ''
     }));
-    await generateReportFromData(data, ['uri', 'name', 'type', 'province'], reportData);
+    await generateReportFromData(data, ['uri', 'name', 'kbonummer', 'type', 'province'], reportData);
   }
 };


### PR DESCRIPTION
added following snippet to query, executed it 8 times to get a more accurate average but numbers are all over the place.end-result is +/- 7% increase but would rather add some margin and say it is somewhere between 5% to 9% increase 

 ```sql
  OPTIONAL {
    ?uri ext:kbonummer ?kbonummer.
  }
 ```

Original ( in milliseconds ) | modified ( in milliseconds )
-- | --
338 | 345
282 | 346
327 | 329
313 | 335
286 | 310
300 | 328
293 | 339
322 | 313

Original Average: 307

Modified Average: 330

Average difference: 23

Percentage increase: 6.96%
