### PR TITLE
remove logging from producers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -372,8 +372,6 @@ services:
     volumes:
       - ./config/producer/mandatarissen:/config
       - ./data/files:/share
-    labels:
-      - "logging=true"
     restart: always
     logging: *default-logging
   loket-leidinggevenden-producer:
@@ -384,8 +382,6 @@ services:
     volumes:
       - ./config/producer/leidinggevenden:/config
       - ./data/files:/share
-    labels:
-      - "logging=true"
     restart: always
     logging: *default-logging
   mandataris-archive:


### PR DESCRIPTION
from an audit standpoint it doesn't really make sense to store traffic generated by these services, in addition they seem to create quite large logs.