### PR TITLE
Hotfix: increase max-sort-row even more

### DIFF
--- a/data/db/virtuoso.ini
+++ b/data/db/virtuoso.ini
@@ -118,7 +118,7 @@ MaxDirtyBuffers            = 130000
 ;MaxDirtyBuffers          = 6000
 
 ;; Introduced after bug with export service
-MaxSortedTopRows = 40000
+MaxSortedTopRows = 100000
 
 [HTTPServer]
 ServerPort                  = 8890


### PR DESCRIPTION
There are more than 40000 mandatarissen to sort on.