### PR TITLE
Fix/update smc status

### DIFF
--- a/config/migrations/20210607104847-fix-multiple-statuses-on-smc.sparql
+++ b/config/migrations/20210607104847-fix-multiple-statuses-on-smc.sparql
@@ -1,0 +1,35 @@
+# This migration is designed to fix SMC having multiple statuses due to
+# https://github.com/lblod/subsidy-application-flow-management-service/commit/94a33cf30dd827b219d0083bf78cd3f37ab3a8cc
+
+# The idea is, as we added statuses without removing older ones:
+# - If the status is "Aanvraag ingediend", we keep it and remove the previous ones ("Actief" and "Concept")
+# - If the status is "Actief", we keep it and remove the previous one (concept)
+
+# The order of the queries below is important.
+
+PREFIX adms: <http://www.w3.org/ns/adms#>
+
+DELETE {
+  GRAPH ?g {
+    ?smc adms:status <http://lblod.data.gift/concepts/c849ca98-455d-4f31-9e95-a3d9d06e4497> . # Actief
+    ?smc adms:status <http://lblod.data.gift/concepts/6373b454-22b6-4b65-b98f-3d86541f2fcf> . # Concept
+  }
+} WHERE {
+  GRAPH ?g {
+    ?smc a <http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelConsumptie> ;
+      adms:status <http://lblod.data.gift/concepts/2ea29fbf-6d46-4f08-9343-879282a9f484> . # Aanvraag ingediend
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?smc adms:status <http://lblod.data.gift/concepts/6373b454-22b6-4b65-b98f-3d86541f2fcf> . # Concept
+  }
+} WHERE {
+  GRAPH ?g {
+    ?smc a <http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelConsumptie> ;
+      adms:status <http://lblod.data.gift/concepts/c849ca98-455d-4f31-9e95-a3d9d06e4497> . # Actief
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -427,7 +427,7 @@ services:
     restart: always
     logging: *default-logging
   subsidy-application-flow-management:
-    image: lblod/subsidy-application-flow-management-service:0.2.0-beta
+    image: lblod/subsidy-application-flow-management-service:0.2.1-beta
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
In the new flow, when updating a SMC status, we were only adding a new one and not removing the old one. This PR fixes the root cause in the flow service as well as the data of SMCs having multiple statuses.