### PR TITLE
Fix missing creator triple on old subsidies

### DIFF
--- a/config/migrations/20210903081759-add-missing-creator-subsidies.sparql
+++ b/config/migrations/20210903081759-add-missing-creator-subsidies.sparql
@@ -1,0 +1,15 @@
+PREFIX subsidie: <http://data.vlaanderen.be/ns/subsidie#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT {
+  GRAPH ?g {
+    ?smc dct:creator ?lastModifiedBy .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?smc a subsidie:SubsidiemaatregelConsumptie ;
+      ext:lastModifiedBy ?lastModifiedBy .
+    FILTER NOT EXISTS { ?smc dct:creator ?creator . }
+  }
+}


### PR DESCRIPTION
It only affects subsidies created before the new flow, we assume it has been fixed since.