### PR TITLE
Feature/future peformance and tcl submissions report

### DIFF
--- a/config/reports/submissionsReport.js
+++ b/config/reports/submissionsReport.js
@@ -98,6 +98,9 @@ export default {
 
           FILTER ( ?verstuurd >= "${dateFrom}"^^xsd:dateTime )
         }
+
+        FILTER(REGEX(str(?g), """http://mu.semte.ch/graphs/organizations/.*/LoketLB-toezichtGebruiker"""))
+
         GRAPH ?h {
           ?type skos:prefLabel ?typeDossier .
           ?bestuurseenheid skos:prefLabel ?bestuurseenheidLabel ;
@@ -160,7 +163,6 @@ export default {
            ?bestuursorgaan besluit:classificatie/skos:prefLabel ?bestuursorgaanClassificatieLabel.
           }
         }
-
       }
     `;
 

--- a/config/reports/submissionsReport.js
+++ b/config/reports/submissionsReport.js
@@ -22,8 +22,8 @@ export default {
       PREFIX prov: <http://www.w3.org/ns/prov#>
       PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
 
-      SELECT ?s ?file WHERE { 
-        GRAPH ?g { 
+      SELECT ?s ?file WHERE {
+        GRAPH ?g {
           ?s a meb:Submission ;
             nmo:sentDate ?verstuurd ;
             prov:generated ?formData .
@@ -70,9 +70,24 @@ export default {
       PREFIX eli: <http://data.europa.eu/eli/ontology#>
       PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 
-      SELECT ?s ?verstuurd ?typeDossier ?typeReglementOfVerordening ?soortBelasting ?bestuurseenheidLabel ?typeBestuur ?datumZitting ?statusLabel ?angemaaktDoor ?gewijzigdDoor ?link ?bot ?bestuursorgaan ?bestuursorgaanLabel ?bestuursorgaanClassificatieLabel
-       WHERE { 
-        GRAPH ?g { 
+      SELECT ?s
+        ?verstuurd
+        ?typeDossier
+        ?typeReglementOfVerordening
+        ?soortBelasting
+        ?bestuurseenheidLabel
+        ?typeBestuur
+        ?datumZitting
+        ?statusLabel
+        ?angemaaktDoor
+        ?gewijzigdDoor
+        ?link
+        ?bot
+        ?bestuursorgaan
+        ?bestuursorgaanLabel
+        ?bestuursorgaanClassificatieLabel
+       WHERE {
+        GRAPH ?g {
           ?s a meb:Submission ;
             nmo:sentDate ?verstuurd ;
             pav:createdBy ?bestuurseenheid ;


### PR DESCRIPTION
Little TCL + preparation for performance and its introduction of the publication graph. 
We will sync over deltas, this introduces a publication graph. If we can optimize the queries in the report, we should do it now. Note, one day I expect this report to move somewhere else. 
Note: no changes of the reports expected