### PR TITLE
Feature: introduction Erediensten into Loket

### DIFF
--- a/config/migrations/2022/20220125143444-Introduction-Erediensten/20220125143444-Erendiensten-From-OP-DEV.graph
+++ b/config/migrations/2022/20220125143444-Introduction-Erediensten/20220125143444-Erendiensten-From-OP-DEV.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2022/20220125143444-Introduction-Erediensten/20220125143445-Map-Eredienst-To-Loket-Compatibel-Model.sparql
+++ b/config/migrations/2022/20220125143444-Introduction-Erediensten/20220125143445-Map-Eredienst-To-Loket-Compatibel-Model.sparql
@@ -1,0 +1,85 @@
+PREFIX erediensten: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX organisatie: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX ma: <http://www.w3.org/ns/ma-ont#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+
+    # Map **tijdspecialisatie** Bestuursoorgaan
+    ?tijdspecialisatie
+      # From generiek:isTijdspecialisatieVan
+      mandaat:isTijdspecialisatieVan ?bestuursorgaan.
+
+    # Map Bestuursoorgaan classificatie
+    ?classificationBestuursorgaan
+      a ext:BestuursorgaanClassificatieCode.
+
+    # Map Bestuursoorgaan
+    ?bestuursorgaan
+      # From org:classification
+      besluit:classificatie ?classificationBestuursorgaan.
+
+    # Map Bestuurseenheid classificatie
+    ?classificationEredienst a
+        ext:BestuurseenheidClassificatieCode.
+
+    # Map Eredienst
+    ?eredienst
+      a besluit:Bestuurseenheid;
+      # From org:classification
+      besluit:classificatie ?classificationEredienst;
+      # From adms:identifier/generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator
+      dct:identifier ?KBONummer;
+      # From adms:identifier/generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator
+      ext:kbonummer ?KBONummer.
+
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+
+    # Selecting relevant data from an Eredienst
+    ?eredienst
+      a erediensten:BestuurVanDeEredienst;
+      org:classification ?classificationEredienst;
+      # Nested resource in OP
+      adms:identifier ?identifierEredienst.
+
+    # Selecting relevant data from Identifier
+    ?identifierEredienst
+      a adms:Identifier;
+      skos:notation "KBO nummer";
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator ?KBONummer.
+
+    # Selecting relevant data from Eredienst classificatie
+    ?classificationEredienst
+      a organisatie:BestuurseenheidClassificatieCode.
+
+    # Selecting relevant data from Bestuursoorgaan
+    ?bestuursorgaan
+      a besluit:Bestuursorgaan;
+      org:classification ?classificationBestuursorgaan;
+      # OP does not deliver a prefLabel
+      # skos:prefLabel ?prefLabelBestuursorgaan;
+      besluit:bestuurt ?eredienst. # Link to current Eredienst
+
+    # Selecting relevant data from Bestuursorgaan classificatie
+    ?classificationBestuursorgaan
+      a organisatie:BestuursorgaanClassificatieCode.
+
+    # Selecting relevant data from **tijdspecialisatie** Bestuursoorgaan
+    ?tijdspecialisatie
+      a besluit:Bestuursorgaan;
+      generiek:isTijdspecialisatieVan ?bestuursorgaan. # Link to current bestuursorgaan
+  }
+}

--- a/config/migrations/2022/20220125143444-Introduction-Erediensten/20220125143446-Add-Mock-Users.sparql
+++ b/config/migrations/2022/20220125143444-Introduction-Erediensten/20220125143446-Add-Mock-Users.sparql
@@ -1,0 +1,50 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX erediensten: <http://data.lblod.info/vocabularies/erediensten/>
+
+INSERT {
+  GRAPH ?orgGraph {
+     ?persoon a foaf:Person;
+           mu:uuid ?uuidPersoon;
+           foaf:firstName ?classificatie;
+           foaf:familyName ?naam;
+           foaf:member ?bestuurseenheid ;
+           foaf:account ?account.
+     ?account a foaf:OnlineAccount;
+           mu:uuid ?uuidAccount;
+           foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+           ext:sessionRole "LoketLB-toezichtGebruiker", "LoketLB-bbcdrGebruiker", "LoketLB-mandaatGebruiker", "LoketLB-berichtenGebruiker", "LoketLB-leidinggevendenGebruiker", "LoketLB-personeelsbeheer", "LoketLB-subsidies".
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+     ?persoon a foaf:Person;
+           mu:uuid ?uuidPersoon;
+           foaf:firstName ?classificatie;
+           foaf:familyName ?naam;
+           foaf:member ?bestuurseenheid ;
+           foaf:account ?account.
+     ?account a foaf:OnlineAccount;
+           mu:uuid ?uuidAccount;
+           foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+           ext:sessionRole "LoketLB-toezichtGebruiker", "LoketLB-bbcdrGebruiker", "LoketLB-mandaatGebruiker", "LoketLB-berichtenGebruiker", "LoketLB-leidinggevendenGebruiker", "LoketLB-personeelsbeheer", "LoketLB-subsidies".
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+     ?bestuurseenheid
+        a besluit:Bestuurseenheid, erediensten:BestuurVanDeEredienst;
+        mu:uuid ?uuidBestuurseenheid;
+        skos:prefLabel ?naam;
+        besluit:classificatie/skos:prefLabel ?classificatie.
+
+     BIND(CONCAT(?classificatie, " ", ?naam) as ?volledigeNaam)
+     BIND(MD5(?volledigeNaam) as ?uuidPersoon)
+     BIND(MD5(CONCAT(?volledigeNaam,"ACCOUNT")) as ?uuidAccount)
+     BIND(IRI(CONCAT("http://data.lblod.info/id/persoon/", ?uuidPersoon)) AS ?persoon)
+     BIND(IRI(CONCAT("http://data.lblod.info/id/account/", ?uuidAccount)) AS ?account)
+     BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?uuidBestuurseenheid)) AS ?orgGraph)
+  }
+}

--- a/config/migrations/2022/20220125143444-Introduction-Erediensten/20220125143446-Add-Mock-Users.sparql
+++ b/config/migrations/2022/20220125143444-Introduction-Erediensten/20220125143446-Add-Mock-Users.sparql
@@ -18,7 +18,7 @@ INSERT {
      ?account a foaf:OnlineAccount;
            mu:uuid ?uuidAccount;
            foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
-           ext:sessionRole "LoketLB-toezichtGebruiker", "LoketLB-bbcdrGebruiker", "LoketLB-mandaatGebruiker", "LoketLB-berichtenGebruiker", "LoketLB-leidinggevendenGebruiker", "LoketLB-personeelsbeheer", "LoketLB-subsidies".
+           ext:sessionRole "LoketLB-toezichtGebruiker".
   }
   GRAPH <http://mu.semte.ch/graphs/public> {
      ?persoon a foaf:Person;
@@ -30,7 +30,7 @@ INSERT {
      ?account a foaf:OnlineAccount;
            mu:uuid ?uuidAccount;
            foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
-           ext:sessionRole "LoketLB-toezichtGebruiker", "LoketLB-bbcdrGebruiker", "LoketLB-mandaatGebruiker", "LoketLB-berichtenGebruiker", "LoketLB-leidinggevendenGebruiker", "LoketLB-personeelsbeheer", "LoketLB-subsidies".
+           ext:sessionRole "LoketLB-toezichtGebruiker".
   }
 } WHERE {
   GRAPH <http://mu.semte.ch/graphs/public> {


### PR DESCRIPTION
Introduces migrations to make "Erediensten" available into Loket (mock-login), harvested from Organisatieportaal.
More info can be found on the Ticket in Jira

> R/T [DL-3197](https://binnenland.atlassian.net/browse/DL-3197)