### PR TITLE
Add the new `POST /files` endpoint

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -112,6 +112,11 @@ defmodule Dispatcher do
   patch "/files/*path" do
     Proxy.forward conn, path, "http://resource/files/"
   end
+  post "/files/*path" do
+    Proxy.forward conn, path, "http://file/files/"
+  end
+  # TODO: find all usage of this endpoint and replace it with `POST /files`
+  # This is kept to maintain compatibility with code that uses the "old" endpoint.
   post "/file-service/files/*path" do
     Proxy.forward conn, path, "http://file/files/"
   end


### PR DESCRIPTION
Both `@lblod/ember-vo-mu-file-upload` and appuniversum use the `/files` endpoint to upload new files (by default).