### PR TITLE
Bugfix/correct submissions ready for export

### DIFF
--- a/config/delta-producer/submissions/prepare/config.json
+++ b/config/delta-producer/submissions/prepare/config.json
@@ -59,12 +59,20 @@
       "eenheid": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/80310756-ce0a-4a1b-9b8e-7c01b6cc7a2d"
     },
     {
-      "orgaan": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36a82ba0-7ff1-4697-a9dd-2e94df73b721",
+      "orgaan": "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007",
       "eenheid": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002"
     },
     {
       "orgaan": "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528",
       "eenheid": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9"
+    },
+    {
+      "orgaan": "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528",
+      "eenheid": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089"
+    },
+    {
+      "orgaan": "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943",
+      "eenheid": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089"
     }
   ],
   "regulationTypes": [

--- a/config/migrations/2022/20220215134611-prepare-besluitenlijsten-for-export/20220217125823-mark-decisions-of-besluit-type-besluitenlijst.sparql
+++ b/config/migrations/2022/20220215134611-prepare-besluitenlijsten-for-export/20220217125823-mark-decisions-of-besluit-type-besluitenlijst.sparql
@@ -1,0 +1,85 @@
+PREFIX meb:     <http://rdf.myexperiment.org/ontologies/base/>
+PREFIX adms:    <http://www.w3.org/ns/adms#>
+PREFIX prov:    <http://www.w3.org/ns/prov#>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+PREFIX eli:     <http://data.europa.eu/eli/ontology#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX pav:     <http://purl.org/pav/>
+prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX schema:  <http://schema.org/>
+PREFIX dct:     <http://purl.org/dc/terms/>
+
+INSERT {
+  GRAPH ?h {
+    ?sub schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+    ?form schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+    ?decisionType schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+    ?submissionDocument schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+    ?submissionDocumentStatus schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+    ?authenticityType schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+    ?taxType schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+    ?chartOfAccount schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+    ?file schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+    ?submissionFile schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+    ?submissionDocumentFile schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+    ?formDataFile schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+  }
+  GRAPH ?j {
+    ?concept schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?sub a meb:Submission ;
+        adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> ; # SENT
+        prov:generated ?form ;
+        pav:createdBy ?bestuurseenheid ;
+        dct:subject ?submissionDocument .
+
+
+    ?form <http://lblod.data.gift/vocabularies/besluit/authenticityType> |
+          <http://mu.semte.ch/vocabularies/ext/regulationType> |
+          <http://mu.semte.ch/vocabularies/ext/decisionType> |
+          <http://mu.semte.ch/vocabularies/ext/taxType> |
+          <http://data.europa.eu/eli/ontology#passed_by>/<http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan>/<http://data.vlaanderen.be/ns/besluit#bestuurt>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?concept.
+
+    ?form
+        ext:decisionType <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee> ; # Besluitenlijst
+        eli:passed_by ?bestuursorgaan .
+
+    OPTIONAL { ?submissionDocument adms:status ?submissionDocumentStatus . }
+    OPTIONAL { ?form <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> ?formDataFile . }
+    OPTIONAL { ?sub <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> ?submissionFile. }
+    OPTIONAL { ?submissionDocument <http://purl.org/dc/terms/source> ?submissionDocumentFile }
+
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    VALUES (?bestuursorgaanClassificatieCode ?bestuurseenheidClassificatieCode) {
+        ( <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> )
+         ( <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> )
+         ( <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> )
+    }
+
+    ?bestuursorgaan mandaat:isTijdspecialisatieVan/besluit:classificatie ?bestuursorgaanClassificatieCode .
+    ?bestuurseenheid besluit:classificatie ?bestuurseenheidClassificatieCode .
+    }
+
+  GRAPH ?i {
+    ?concept <http://www.w3.org/2004/02/skos/core#inScheme> |
+             <http://www.w3.org/2004/02/skos/core#topConceptOf> ?conceptScheme.
+
+    FILTER ( ?conceptScheme IN (
+      <http://lblod.data.gift/concept-schemes/5cecec47-ba66-4d7a-ac9d-a1e7962ca4e2>,
+      <http://lblod.data.gift/concept-schemes/ac9bc402-c8e6-41fd-ad57-fad15622e560>,
+      <https://data.vlaanderen.be/id/conceptscheme/BesluitType>,
+      <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType>,
+      <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode>,
+      <http://lblod.data.gift/concept-schemes/b65b15ba-6755-4cd2-bd07-2c2cf3c0e4d3>,
+      <http://lblod.data.gift/concept-schemes/c93ccd41-aee7-488f-86d3-038de890d05a>,
+      <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5>
+    ))
+  }
+  BIND(?g as ?h)
+  BIND(?i as ?j)
+}

--- a/config/migrations/2022/20220215134611-prepare-besluitenlijsten-for-export/20220217125824-move-attachements.sparql
+++ b/config/migrations/2022/20220215134611-prepare-besluitenlijsten-for-export/20220217125824-move-attachements.sparql
@@ -1,0 +1,66 @@
+PREFIX schema: <http://schema.org/>
+PREFIX pav: <http://purl.org/pav/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX lblodBesluit: <http://lblod.data.gift/vocabularies/besluit/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX eli: <http://data.europa.eu/eli/ontology#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+INSERT {
+  GRAPH ?h {
+    ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+  }
+}
+WHERE {
+  {
+    ?submission schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> ;
+      nie:hasPart |
+      nie:hasPart/^nie:dataSource |
+      dct:hasPart/^nie:dataSource |
+      nie:hasPart/^nie:dataSource/^nie:dataSource |
+      prov:generated/dct:hasPart |
+      prov:generated/dct:hasPart/nie:dataSource ?attachment .
+
+
+    ?submission pav:createdBy ?bestuurseenheid;
+      prov:generated ?form.
+
+    ?form
+        ext:decisionType <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee> ; # Besluitenlijst
+        eli:passed_by ?bestuursorgaan .
+
+
+    VALUES (?bestuursorgaanClassificatieCode ?bestuurseenheidClassificatieCode) {
+        ( <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> )
+         ( <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> )
+         ( <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> )
+    }
+
+    ?bestuursorgaan mandaat:isTijdspecialisatieVan/besluit:classificatie ?bestuursorgaanClassificatieCode .
+    ?bestuurseenheid besluit:classificatie ?bestuurseenheidClassificatieCode .
+
+  }
+  UNION
+  {
+    ?submission schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> ;
+      dct:subject/dct:source ?attachment.
+    ?attachment dct:type ?type .
+
+    FILTER (?type IN (
+      <http://data.lblod.gift/concepts/meta-file-type>,
+      <http://data.lblod.gift/concepts/form-data-file-type>,
+      <http://data.lblod.gift/concepts/form-file-type>
+    ))
+  }
+
+    GRAPH ?g {
+      ?attachment a ?attachmentType .
+    }
+    FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))
+
+  BIND(?g as ?h)
+}


### PR DESCRIPTION
This commit corrects issues in the configuration so besluitenlijsten gets exported for ocmw and welzijsvereningingen.
+ a migration

Eventually we will need a healing process for this too, so we only update the rules if things were missed