### PR TITLE
Feature/subsidy plan samenleven Table

### DIFF
--- a/config/migrations/2022/20220302141524-plan-samenleven/20220302141603-prepare-plan-samenleven.sparql
+++ b/config/migrations/2022/20220302141524-plan-samenleven/20220302141603-prepare-plan-samenleven.sparql
@@ -1,0 +1,59 @@
+
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX subsidie: <http://data.vlaanderen.be/ns/subsidie#>
+PREFIX gleif: <https://www.gleif.org/ontology/Base/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX cpsv: <http://purl.org/vocab/cpsv#>
+PREFIX common: <http://www.w3.org/2007/uwa/context/common.owl#>
+PREFIX xkos: <http://rdf-vocabulary.ddialliance.org/xkos#>
+PREFIX qb: <http://purl.org/linked-data/cube#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public>{
+    <http://lblod.data.info/id/subsidy-measure-offers/a2d920b2-d266-4555-b023-63632997c406>
+      a <http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelAanbod>;
+      mu:uuid "a2d920b2-d266-4555-b023-63632997c406";
+      dct:title """Plan Samenleven""";
+      skos:prefLabel """Plan Samenleven""";
+      skos:related <https://www.plansamenleven.be>;
+      cpsv:follows <http://data.lblod.info/id/subsidy-procedural-steps/42d5b4d0-458f-4dcc-93e0-9a6cfd44a6f0>;
+      lblodSubsidie:heeftReeks <http://lblod.data.info/id/subsidy-measure-offer-series/ec1c74eb-f62e-4c35-82d1-c79616471e3e>.
+
+    <http://data.lblod.info/id/subsidy-procedural-steps/42d5b4d0-458f-4dcc-93e0-9a6cfd44a6f0> a subsidie:Subsidieprocedurestap;
+      mu:uuid "42d5b4d0-458f-4dcc-93e0-9a6cfd44a6f0";
+      dct:description """Indienen Voorstel""";
+      mobiliteit:periode <http://data.lblod.info/id/periodes/f455172d-3f27-45b1-b2ab-95f5c99d3a5f>.
+
+    <http://lblod.data.info/id/subsidy-measure-offer-series/ec1c74eb-f62e-4c35-82d1-c79616471e3e> a lblodSubsidie:SubsidiemaatregelAanbodReeks;
+      mu:uuid "ec1c74eb-f62e-4c35-82d1-c79616471e3e";
+      dct:title "Oproep 2022"@nl;
+      dct:description "01/07/2022 — 30/06/2023"@nl ;
+      common:active <http://lblod.data.info/id/subsidie-application-flows/ba31009e-21ec-4ad1-89d7-f18dfd7e3890> ;
+      mobiliteit:periode <http://data.lblod.info/id/periodes/111b848b-0590-42f2-a659-c91a9a5f7a0b> ;
+      lblodSubsidie:heeftSubsidieprocedurestap <http://data.lblod.info/id/subsidy-procedural-steps/42d5b4d0-458f-4dcc-93e0-9a6cfd44a6f0>.
+
+    <http://lblod.data.info/id/subsidie-application-flows/ba31009e-21ec-4ad1-89d7-f18dfd7e3890> a lblodSubsidie:ApplicationFlow;
+      mu:uuid "ba31009e-21ec-4ad1-89d7-f18dfd7e3890";
+      xkos:belongsTo <http://lblod.data.info/id/subsidy-measure-offer-series/ec1c74eb-f62e-4c35-82d1-c79616471e3e>;
+      xkos:next <http://lblod.data.info/id/subsidie-application-flow-steps/c6d7a8d4-dc51-48f1-9d44-507f8cc02c85>.
+
+    <http://lblod.data.info/id/subsidie-application-flow-steps/c6d7a8d4-dc51-48f1-9d44-507f8cc02c85> a lblodSubsidie:ApplicationStep;
+      mu:uuid "c6d7a8d4-dc51-48f1-9d44-507f8cc02c85";
+      qb:order 0;
+      dct:references <http://data.lblod.info/id/subsidy-procedural-steps/42d5b4d0-458f-4dcc-93e0-9a6cfd44a6f0>;
+      dct:isPartOf <http://lblod.data.info/id/subsidie-application-flows/ba31009e-21ec-4ad1-89d7-f18dfd7e3890>;
+      dct:source <config://forms/plan-samenleven/proposal/versions/20220302124605/form.ttl>.
+
+    <http://data.lblod.info/id/periodes/111b848b-0590-42f2-a659-c91a9a5f7a0b> a <http://data.europa.eu/m8g/PeriodOfTime>;
+      mu:uuid "111b848b-0590-42f2-a659-c91a9a5f7a0b";
+      <http://data.europa.eu/m8g/startTime> "2022-07-01T03:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+      <http://data.europa.eu/m8g/endTime> "2023-06-30T21:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>.
+
+    <http://data.lblod.info/id/periodes/f455172d-3f27-45b1-b2ab-95f5c99d3a5f> a <http://data.europa.eu/m8g/PeriodOfTime>;
+      mu:uuid "f455172d-3f27-45b1-b2ab-95f5c99d3a5f";
+      <http://data.europa.eu/m8g/startTime> "2022-03-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+      <http://data.europa.eu/m8g/endTime> "2022-05-31T21:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>.
+  }
+}

--- a/config/migrations/2022/20220302141524-plan-samenleven/20220317092606-add-plan-samenleven-subsidy-concepts.sparql
+++ b/config/migrations/2022/20220302141524-plan-samenleven/20220317092606-add-plan-samenleven-subsidy-concepts.sparql
@@ -1,0 +1,259 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX objective: <http://data.lblod.info/vocabularies/plan-samenleven-subsidies/objective/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX range: <http://data.lblod.info/vocabularies/plan-samenleven-subsidies/range/>
+PREFIX contribution: <http://data.lblod.info/vocabularies/plan-samenleven-subsidies/contribution/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c>
+        a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://www.w3.org/2004/02/skos/core#ConceptScheme>;
+        mu:uuid "646b3381-9a63-48d3-8686-4d877502db8c" ;
+        skos:prefLabel "Plan Samenleven doelstellingen rules"@en .
+
+    <http://data.lblod.info/id/subsidies/rules/7f7f1d20-942d-48ac-85a0-748db7f3d835> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "7f7f1d20-942d-48ac-85a0-748db7f3d835" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Veiligheid en leefbaarheid'@nl ;
+        dct:description 'Ontwikkelen van een lokaal actieplan voor de aanpak van negatieve polarisatie en zetten in op de uitrol ervan.'@nl ;
+        range:label "lokaal actieplan";
+        range:maximum "1"^^xsd:integer;
+        contribution:multiplier "12500"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/f8be95d1-b262-4a7c-8bfb-e77c115d42c6> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "f8be95d1-b262-4a7c-8bfb-e77c115d42c6" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Nederlands'@nl ;
+        dct:description 'Volwassen anderstaligen nemen deel aan een oefenkans.'@nl ;
+        range:label "volwassen anderstaligen";
+        range:maximum "2250"^^xsd:integer;
+        contribution:multiplier "60"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/ba162648-8286-4c36-bce3-03b816069b28> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "ba162648-8286-4c36-bce3-03b816069b28" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Competenties'@nl ;
+        dct:description 'Begeleiden van personen met een diploma van buiten de EU naar verkorte opleidingstrajecten.'@nl ;
+        range:label "begeleide personen";
+        range:maximum "23"^^xsd:integer;
+        contribution:multiplier "600"^^xsd:integer.
+    
+    <http://data.lblod.info/id/subsidies/rules/15217ddf-e56a-4529-9352-f0c82d433546> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "15217ddf-e56a-4529-9352-f0c82d433546" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Competenties'@nl ;
+        dct:description 'Begeleiden van kwetsbare kinderen in het secundair onderwijs naar hogere studies.'@nl ;
+        range:label "kwetsbare kinderen";
+        range:maximum "150"^^xsd:integer;
+        contribution:multiplier "650"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/55a23203-794a-4680-8223-cae33b01ad8e> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "55a23203-794a-4680-8223-cae33b01ad8e" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Competenties'@nl ;
+        dct:description 'Begeleiden van ongekwalificeerde uitstromers naar een kwalificerend traject.'@nl ;
+        range:label "ongekwalificeerde uitstromers";
+        range:maximum "150"^^xsd:integer;
+        contribution:multiplier "650"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/bd57a052-8744-402b-bdcb-19d0c386ff54> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "bd57a052-8744-402b-bdcb-19d0c386ff54" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Werk'@nl ;
+        dct:description 'Begeleiden van nieuwkomers, mensen met een handicap en 55plussers naar de arbeidsmarkt.'@nl ;
+        range:label "begeleide nieuwkomers";
+        range:maximum "150"^^xsd:integer;
+        contribution:multiplier "650"^^xsd:integer.
+        
+
+    <http://data.lblod.info/id/subsidies/rules/a7643e23-3eee-477c-baf4-bd1eb93d9aa5> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "a7643e23-3eee-477c-baf4-bd1eb93d9aa5" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        range:label "personen met een handicap";
+        range:maximum "38"^^xsd:integer;
+        contribution:multiplier "650"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/88388d78-f277-43ee-963e-6e111fc28d46> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "88388d78-f277-43ee-963e-6e111fc28d46" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        range:label "55-plussers";
+        range:maximum "75"^^xsd:integer;
+        contribution:multiplier "650"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/6b8a5a4e-c1f8-40c7-9a23-7b589aede212> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "6b8a5a4e-c1f8-40c7-9a23-7b589aede212" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Werk'@nl ;
+        dct:description 'Begeleiden van nieuwkomers, vrouwen en personen met een handicap naar ondernemerschap'@nl ;
+        range:label "begeleide nieuwkomers";
+        range:maximum "75"^^xsd:integer;
+        contribution:multiplier "650"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/8bae2cec-4b7c-4e16-acc2-e747d9e3b853> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "8bae2cec-4b7c-4e16-acc2-e747d9e3b853" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        range:label "vrouwen";
+        range:maximum "30"^^xsd:integer;
+        contribution:multiplier "650"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/619edfa8-0004-45d3-af51-7faf71d477d5> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "619edfa8-0004-45d3-af51-7faf71d477d5" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        range:label "personen met een handicap";
+        range:maximum "15"^^xsd:integer;
+        contribution:multiplier "650"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/ec887ea5-83ee-4782-866c-1ddedd6d7ed0> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "ec887ea5-83ee-4782-866c-1ddedd6d7ed0" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Werk'@nl ;
+        dct:description 'Inzet van mentoren die jonge personen van buitenlandse herkomst begeleiden naar werk.'@nl ;
+        range:label "begeleide personen van buitenlandse herkomst";
+        range:maximum "300"^^xsd:integer;
+        contribution:multiplier "320"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/80dd881d-9706-40be-8f0b-fe97d69fa00d> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "80dd881d-9706-40be-8f0b-fe97d69fa00d" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Netwerk'@nl ;
+        dct:description 'Jongeren van buitenlandse herkomst en jongeren met een handicap in contact brengen met sport.'@nl ;
+        range:label "jongeren van buitenlandse herkomst";
+        range:maximum "150"^^xsd:integer;
+        contribution:multiplier "210"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/c5719bb2-e567-433c-ae6b-f99ff5c98897> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "c5719bb2-e567-433c-ae6b-f99ff5c98897" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        range:label "personen met een handicap";
+        range:maximum "30"^^xsd:integer;
+        contribution:multiplier "210"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/5faefdda-75aa-45cd-acd4-1ee051e806fd> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "5faefdda-75aa-45cd-acd4-1ee051e806fd" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Netwerk'@nl ;
+        dct:description 'Kwetsbare jongeren in contact brengen met opleidingen, stages, jobs en ondernemerschap'@nl ;
+        range:label "kwetbare jongeren";
+        range:maximum "180"^^xsd:integer;
+        contribution:multiplier "210"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/2b415839-747b-4514-a3f2-d02ca4303be4> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "2b415839-747b-4514-a3f2-d02ca4303be4" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Netwerk'@nl ;
+        dct:description 'Inzetten van brugfiguren die de brug maken tussen kwetsbare gezinnen en onderwijs.'@nl ;
+        range:label "kwetsbare gezinnen";
+        range:maximum "300"^^xsd:integer;
+        contribution:multiplier "320"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/7fbac258-3c1c-44a1-8db0-ffcdcb6a3113> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "7fbac258-3c1c-44a1-8db0-ffcdcb6a3113" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Non-discriminatie'@nl ;
+        dct:description 'Ontwikkelen van lokale actieplannen voor de aanpak van straatintimidatie en de uitrol ervan.'@nl ;
+        range:label "lokaal actieplan";
+        range:maximum "1"^^xsd:integer;
+        contribution:multiplier "25000"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/0b0d5a3a-0c10-4acf-9a94-fd4e881444bc> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "0b0d5a3a-0c10-4acf-9a94-fd4e881444bc" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Non-discriminatie'@nl ;
+        dct:description 'Vormen van professionals en burgers volgens het omstaanders-principe'@nl ;
+        range:label "gevormde professionals";
+        range:maximum "150"^^xsd:integer;
+        contribution:multiplier "90"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/f7c0a231-e418-4f38-8f73-3815a22f518b> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "f7c0a231-e418-4f38-8f73-3815a22f518b" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        range:label "gevormde burgers";
+        range:maximum "150"^^xsd:integer;
+        contribution:multiplier "90"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/a419be41-704b-488d-b7c1-86d50a8a46ce> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "a419be41-704b-488d-b7c1-86d50a8a46ce" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Non-discriminatie'@nl ;
+        dct:description 'Ontwikkelen van lokale actieplannen voor de toegankelijkheid van publieke gebouwen en de uitrol ervan.'@nl ;
+        range:label "lokaal actieplan";
+        range:maximum "1"^^xsd:integer;
+        contribution:multiplier "25000"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/fea603c6-dc87-4c09-bb85-3520cc1c495d> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "fea603c6-dc87-4c09-bb85-3520cc1c495d" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel 'Non-discriminatie'@nl ;
+        dct:description 'Inzetten van correspondentietesten om discriminatie te meten'@nl ;
+        range:label "bestuur dat correspondentietesten inzet";
+        range:maximum "1"^^xsd:integer;
+        contribution:multiplier "25000"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/f732ab43-ea22-4590-b3a4-6617cff64777> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "f732ab43-ea22-4590-b3a4-6617cff64777" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel '1 gemeenschap'@nl ;
+        dct:description 'Begeleiden van gezinnen om de sociale mix in scholen te bevorderen'@nl ;
+        range:label "begeleide gezinnen";
+        range:maximum "300"^^xsd:integer;
+        contribution:multiplier "170"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/5fcf7a3a-04b7-46e7-9449-2088656c555b> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "5fcf7a3a-04b7-46e7-9449-2088656c555b" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel '1 gemeenschap'@nl ;
+        dct:description 'Begeleiden van jongeren van buitenlandse herkomst en personen met een handicap tot een lerarenopleiding.'@nl ;
+        range:label "jongeren van buitenlandse herkomst";
+        range:maximum "15"^^xsd:integer;
+        contribution:multiplier "650"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/2f7db13f-b710-4b94-92c8-efcf8eac1ead> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "2f7db13f-b710-4b94-92c8-efcf8eac1ead" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        range:label "jongeren met een handicap";
+        range:maximum "8"^^xsd:integer;
+        contribution:multiplier "650"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/fd1882a8-996c-42a8-8774-0a7a453f5c70> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "fd1882a8-996c-42a8-8774-0a7a453f5c70" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel '1 gemeenschap'@nl ;
+        dct:description 'Inzetten van pleinmakers in sociale woonwijken om het sociaal weefsel te versterken.'@nl ;
+        range:label "pleinmakers";
+        range:maximum "4"^^xsd:integer;
+        contribution:multiplier "5800"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/2952c920-fbe5-403a-a267-c94c0813f85f> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "2952c920-fbe5-403a-a267-c94c0813f85f" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel '1 gemeenschap'@nl ;
+        dct:description 'Jongeren van buitenlandse herkomst en jongeren met een handicap in contact brengen met jeugdwerk.'@nl ;
+        range:label "jongeren van buitenlandse herkomst";
+        range:maximum "150"^^xsd:integer;
+        contribution:multiplier "210"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/17afa0d1-c0be-4800-a9bc-9f48506346eb> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "17afa0d1-c0be-4800-a9bc-9f48506346eb" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        range:label "jongeren met een handicap";
+        range:maximum "30"^^xsd:integer;
+        contribution:multiplier "210"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/e4effa35-4453-426a-95af-17767e23ed64> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "e4effa35-4453-426a-95af-17767e23ed64" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        skos:prefLabel '1 gemeenschap'@nl ;
+        dct:description 'Jongeren van buitenlandse herkomst en jongeren met een handicap in contact brengen met cultuur.'@nl ;
+        range:label "jongeren van buitenlandse herkomst";
+        range:maximum "150"^^xsd:integer;
+        contribution:multiplier "210"^^xsd:integer.
+
+    <http://data.lblod.info/id/subsidies/rules/56e523bd-ad3c-4648-94b0-df6d9e72c7b0> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>, <http://data.lblod.info/vocabularies/plan-living-together-subsidies/PlanLivingTogetherSubsidyWithdrawalRule>;
+        mu:uuid "56e523bd-ad3c-4648-94b0-df6d9e72c7b0" ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/646b3381-9a63-48d3-8686-4d877502db8c> ;
+        range:label "jongeren met een handicap";
+        range:maximum "150"^^xsd:integer;
+        contribution:multiplier "210"^^xsd:integer.
+  }
+}

--- a/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.json
+++ b/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.json
@@ -38,6 +38,21 @@
           }
         ]
       },
+      {
+        "s-prefix": "lblodSubsidie:planLivingTogetherTable",
+        "properties": [
+          {
+            "s-prefix": "planSamenleven:planLivingTogetherEntry",
+            "properties": [
+              "planSamenleven:description",
+              "planSamenleven:currentRange",
+              "planSamenleven:plannedRange",
+              "planSamenleven:contribution",
+              "planSamenleven:priority"
+            ]
+          }
+        ]
+      },
       "planSamenleven:hasCollaborationWithOtherLBNonEu",
       "planSamenleven:usesSocialImpactBound",
       "planSamenleven:usesSocialImpactBoundProposal",

--- a/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.json
+++ b/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.json
@@ -1,0 +1,54 @@
+{
+  "source": {
+    "prefixes": [
+      "PREFIX mu: <http://mu.semte.ch/vocabularies/core/>",
+      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
+      "PREFIX dct: <http://purl.org/dc/terms/>",
+      "PREFIX skos: <http://www.w3.org/2004/02/skos/core#>",
+      "PREFIX subsidie: <http://data.vlaanderen.be/ns/subsidie#>",
+      "PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>",
+      "PREFIX pav: <http://purl.org/pav/>",
+      "PREFIX schema: <http://schema.org/>",
+      "PREFIX foaf: <http://xmlns.com/foaf/0.1/>",
+      "PREFIX gleif: <https://www.gleif.org/ontology/Base/>",
+      "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>",
+      "PREFIX adms: <http://www.w3.org/ns/adms#>",
+      "PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>",
+      "PREFIX planSamenleven: <http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/>"
+    ],
+    "properties": [
+      {
+        "s-prefix": "schema:contactPoint",
+        "properties": [
+          "foaf:firstName",
+          "foaf:familyName",
+          "schema:telephone",
+          "schema:email"
+        ]
+      },
+      {
+        "s-prefix": "schema:bankAccount",
+        "properties": [
+          "schema:identifier",
+          {
+            "s-prefix": "dct:hasPart",
+            "properties": [
+              "rdf:type"
+            ]
+          }
+        ]
+      },
+      "planSamenleven:hasCollaborationWithOtherLBNonEu",
+      "planSamenleven:usesSocialImpactBound",
+      "planSamenleven:usesSocialImpactBoundProposal",
+      "planSamenleven:proposesMentorship",
+      "planSamenleven:mentorshipAction",
+      "planSamenleven:mentorshipActionDetails"
+    ],
+    "meta": {
+      "schemes": [
+        "http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2"
+      ]
+    }
+  }
+}

--- a/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
+++ b/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
@@ -194,7 +194,7 @@ fields:30fdc26c-7f61-403f-a7da-507c2b90e750 a form:Field ;
 fields:85515be8-407e-41ac-a97d-66df37685e7c a form:Field ;
     mu:uuid "85515be8-407e-41ac-a97d-66df37685e7c";
     sh:name "Willen jullie als gemeente gebruik maken van het instrument 'Social Impact Bond'?" ;
-    sh:order 51 ;
+    sh:order 60 ;
     sh:path planSamenleven:usesSocialImpactBound ;
     form:validations
         [ a form:ConceptSchemeConstraint ;
@@ -216,7 +216,7 @@ fields:85515be8-407e-41ac-a97d-66df37685e7c a form:Field ;
 fields:1d72bc54-2d6f-4331-a0be-9f2769cce0c9 a form:ConditionalFieldGroup ;
     mu:uuid "1d72bc54-2d6f-4331-a0be-9f2769cce0c9";
     form:conditions
-      [ a form:ContainsCodelistValue ;
+      [ a form:SingleCodelistValue ;
         form:grouping form:Bag ;
         sh:path planSamenleven:usesSocialImpactBound ;
         form:conceptScheme <http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2> ;
@@ -231,7 +231,7 @@ fields:1d72bc54-2d6f-4331-a0be-9f2769cce0c9 a form:ConditionalFieldGroup ;
 fields:53c583fe-e4c0-4c43-b693-ec318008910b a form:Field ;
     mu:uuid "53c583fe-e4c0-4c43-b693-ec318008910b";
     sh:name "Geef hier aan wat het concrete voorstel is voor jullie gemeente voor de 'Social Impact Bond'." ;
-    sh:order 52 ;
+    sh:order 70 ;
     sh:path planSamenleven:usesSocialImpactBoundProposal ;
     form:validations
       [ a form:RequiredConstraint ;
@@ -255,7 +255,7 @@ fields:53c583fe-e4c0-4c43-b693-ec318008910b a form:Field ;
 fields:4cfdb602-4b1c-4891-a3c3-cb70e1244132 a form:Field ;
     mu:uuid "4cfdb602-4b1c-4891-a3c3-cb70e1244132";
     sh:name "Willen jullie als gemeente het mentorschap opnemen over een bepaalde actie?" ;
-    sh:order 52 ;
+    sh:order 80 ;
     sh:path planSamenleven:proposesMentorship ;
     form:validations
         [ a form:ConceptSchemeConstraint ;
@@ -277,7 +277,7 @@ fields:4cfdb602-4b1c-4891-a3c3-cb70e1244132 a form:Field ;
 fields:86aab42b-4b79-43e6-8e65-59af22ff1566 a form:ConditionalFieldGroup ;
     mu:uuid "86aab42b-4b79-43e6-8e65-59af22ff1566";
     form:conditions
-      [ a form:ContainsCodelistValue ;
+      [ a form:SingleCodelistValue ;
         form:grouping form:Bag ;
         sh:path planSamenleven:proposesMentorship ;
         form:conceptScheme <http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2> ;
@@ -291,7 +291,7 @@ fields:86aab42b-4b79-43e6-8e65-59af22ff1566 a form:ConditionalFieldGroup ;
 fields:26f5b41d-a410-4c0d-b1a8-60208fe2bb49 a form:Field ;
     mu:uuid "26f5b41d-a410-4c0d-b1a8-60208fe2bb49";
     sh:name "Geef hier aan voor welke actie dit van toepassing is:" ;
-    sh:order 54 ;
+    sh:order 90 ;
     sh:path planSamenleven:mentorshipAction ;
     form:validations
     [ a form:RequiredConstraint ;
@@ -309,7 +309,7 @@ fields:26f5b41d-a410-4c0d-b1a8-60208fe2bb49 a form:Field ;
 fields:a545a2d0-aa48-4667-83d1-29a1c0d2c75c a form:Field ;
     mu:uuid "a545a2d0-aa48-4667-83d1-29a1c0d2c75c";
     sh:name "Op welke manier hebben jullie expertise rond deze actie verzameld? Motiveer waarom en hoe jullie deze rol als mentor zouden opnemen." ;
-    sh:order 55 ;
+    sh:order 100 ;
     sh:path planSamenleven:mentorshipActionDetails ;
     form:validations
       [ a form:RequiredConstraint ;

--- a/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
+++ b/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
@@ -42,6 +42,7 @@ fields:590ec414-829e-4232-88eb-95c205773fae a form:PropertyGroup;
     sh:description "Financiële stimulans";
     sh:order 4;
     sh:name "Financiële stimulans" ;
+    form:help """<a href=\"https://www.plansamenleven.be\" target=\"_blank\">Hier</a> vind je meer info over deze financiële stimulansen""";
     sh:group fields:4558f2d6-1ba4-4211-beb9-5e3a4b65b975 .
 
 
@@ -237,7 +238,14 @@ fields:53c583fe-e4c0-4c43-b693-ec318008910b a form:Field ;
       form:grouping form:Bag ;
       sh:resultMessage "Dit veld is verplicht."@nl;
       sh:path planSamenleven:usesSocialImpactBoundProposal
-      ] ;
+      ] ,
+      [ a form:MaxLength ;
+          form:max 2500;
+          form:grouping form:MatchEvery ;
+          sh:resultMessage "Gelieve hat aantal tekens te beperken tot 2500."@nl;
+          sh:path planSamenleven:mentorshipActionDetails
+      ]
+      ;
     form:displayType displayTypes:textArea ;
     sh:group fields:590ec414-829e-4232-88eb-95c205773fae .
 
@@ -305,10 +313,17 @@ fields:a545a2d0-aa48-4667-83d1-29a1c0d2c75c a form:Field ;
     sh:path planSamenleven:mentorshipActionDetails ;
     form:validations
       [ a form:RequiredConstraint ;
-      form:grouping form:Bag ;
-      sh:resultMessage "Dit veld is verplicht."@nl;
-      sh:path planSamenleven:mentorshipActionDetails
-      ] ;
+          form:grouping form:Bag ;
+          sh:resultMessage "Dit veld is verplicht."@nl;
+          sh:path planSamenleven:mentorshipActionDetails
+      ],
+      [ a form:MaxLength ;
+          form:max 2500;
+          form:grouping form:MatchEvery ;
+          sh:resultMessage "Gelieve hat aantal tekens te beperken tot 2500."@nl;
+          sh:path planSamenleven:mentorshipActionDetails
+      ]
+      ;
     form:displayType displayTypes:textArea ;
     sh:group fields:590ec414-829e-4232-88eb-95c205773fae .
 

--- a/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
+++ b/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
@@ -1,0 +1,379 @@
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix fieldGroups: <http://data.lblod.info/field-groups/> .
+@prefix fields: <http://data.lblod.info/fields/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix schema: <http://schema.org/>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>.
+@prefix planSamenleven: <http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+
+##########################################################
+# Property groups
+##########################################################
+
+fields:4558f2d6-1ba4-4211-beb9-5e3a4b65b975 a form:PropertyGroup;
+    mu:uuid "4558f2d6-1ba4-4211-beb9-5e3a4b65b975";
+    sh:description "parent property-group, used to group fields and property-groups together";
+    sh:order 1 .
+
+fields:2232cd10-01d6-4f67-966a-2c22932437b4 a form:PropertyGroup;
+    mu:uuid "2232cd10-01d6-4f67-966a-2c22932437b4";
+    sh:description "contact information";
+    sh:order 2;
+    sh:name "Contactgegevens contactpersoon" ;
+    form:help "Dit is de persoon die gecontacteerd wordt bij de opvolging van dit dossier." ;
+    sh:group fields:4558f2d6-1ba4-4211-beb9-5e3a4b65b975 .
+
+fields:386530d7-b4b4-41c9-8146-e2d8d629d77f a form:PropertyGroup;
+    mu:uuid "386530d7-b4b4-41c9-8146-e2d8d629d77f";
+    sh:description "payment";
+    sh:order 3;
+    sh:name "Betaling" ;
+    sh:group fields:4558f2d6-1ba4-4211-beb9-5e3a4b65b975 .
+
+fields:590ec414-829e-4232-88eb-95c205773fae a form:PropertyGroup;
+    mu:uuid "590ec414-829e-4232-88eb-95c205773fae";
+    sh:description "Financiële stimulans";
+    sh:order 4;
+    sh:name "Financiële stimulans" ;
+    sh:group fields:4558f2d6-1ba4-4211-beb9-5e3a4b65b975 .
+
+
+##########################################################
+# Contact info
+##########################################################
+
+fields:e19e245a-c24b-4fb5-84b8-a7e2744ce9a0 a form:Field ;
+    mu:uuid "e19e245a-c24b-4fb5-84b8-a7e2744ce9a0";
+    sh:name "Voornaam contactpersoon" ;
+    sh:order 30 ;
+    sh:path ( schema:contactPoint foaf:firstName ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint foaf:firstName ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:2232cd10-01d6-4f67-966a-2c22932437b4 .
+
+fields:82258a58-6c67-4b0a-a26d-0676b88886ad a form:Field ;
+    mu:uuid "82258a58-6c67-4b0a-a26d-0676b88886ad";
+    sh:name "Familienaam contactpersoon" ;
+    sh:order 31 ;
+    sh:path ( schema:contactPoint foaf:familyName ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint foaf:familyName ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:2232cd10-01d6-4f67-966a-2c22932437b4 .
+
+fields:6285341d-a0ad-4933-bb5f-c49016b0f935 a form:Field ;
+    mu:uuid "6285341d-a0ad-4933-bb5f-c49016b0f935";
+    sh:name "Telefoonnummer" ;
+    sh:order 32 ;
+    sh:path ( schema:contactPoint schema:telephone ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint schema:telephone ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidPhoneNumber ;
+        form:grouping form:MatchEvery ;
+        form:defaultCountry "BE" ;
+        sh:path ( schema:contactPoint schema:telephone ) ;
+        sh:resultMessage "Geef een geldig telefoonnummer in."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:2232cd10-01d6-4f67-966a-2c22932437b4 .
+
+fields:31c743c7-b243-4ca7-a6c1-dc5f03cb5afb a form:Field ;
+    mu:uuid "31c743c7-b243-4ca7-a6c1-dc5f03cb5afb";
+    sh:name "Mailadres" ;
+    sh:order 33 ;
+    sh:path ( schema:contactPoint schema:email ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint schema:email ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidEmail ;
+        form:grouping form:MatchEvery ;
+        sh:path ( schema:contactPoint schema:email ) ;
+        sh:resultMessage "Geef een geldig e-mailadres op."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:2232cd10-01d6-4f67-966a-2c22932437b4 .
+
+##########################################################
+# Bank account
+##########################################################
+
+fields:9b706641-f834-4f91-87ab-d490f7aa0ed7 a form:Field ;
+    mu:uuid "9b706641-f834-4f91-87ab-d490f7aa0ed7";
+    sh:name "Rekeningnummer uitbetaling" ;
+    form:help "IBAN: BE00 0000 0000 0000" ;
+    sh:order 41 ;
+    sh:path ( schema:bankAccount schema:identifier ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:bankAccount schema:identifier ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidIBAN ;
+        form:grouping form:MatchEvery ;
+        sh:path ( schema:bankAccount schema:identifier ) ;
+        sh:resultMessage "Geef een geldig IBAN op."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:386530d7-b4b4-41c9-8146-e2d8d629d77f .
+
+fields:5f2ae097-ce97-4a52-a5db-501cf9e114c4 a form:Field ;
+    mu:uuid "5f2ae097-ce97-4a52-a5db-501cf9e114c4";
+    sh:name "Voeg een bevestingsbrief toe dat dit rekeningnummer gebruikt mag worden, ondertekend door de burgemeester en medeondertekend door de financieel directeur." ;
+    form:help "Deze brief moet enkel toegevoegd worden als dit niet het rekeningnummer is waarop het aandeel van het gemeentefonds wordt gestort." ;
+    sh:order 42 ;
+    sh:path ( schema:bankAccount dct:hasPart ) ;
+    form:displayType displayTypes:files ;
+    sh:group fields:386530d7-b4b4-41c9-8146-e2d8d629d77f .
+
+##########################################################
+# Hidden field required for all variations of URL or FILE
+# input field which require validation.
+# It makes sure there is a type attached to hasPart object.
+# This enables correct validation in both front and backend.
+##########################################################
+
+fields:ccb94821-be31-43fa-87df-ef64e3c4ce45 a form:Field ;
+    mu:uuid "ccb94821-be31-43fa-87df-ef64e3c4ce45" ;
+    sh:name "Type RemoteDataObject or FileDataObject [hidden input]" ;
+    sh:order 43 ;
+    sh:path ( schema:bankAccount dct:hasPart rdf:type );
+    sh:group fields:386530d7-b4b4-41c9-8146-e2d8d629d77f .
+
+##########################################################
+# Financiële stimulans: samenwerking non eu
+##########################################################
+fields:30fdc26c-7f61-403f-a7da-507c2b90e750 a form:Field ;
+    mu:uuid "30fdc26c-7f61-403f-a7da-507c2b90e750";
+    sh:name "Gaan jullie als gemeente met meer dan 7.500 inwoners van niet-EU herkomst een samenwerking aan met een kleiner lokaal bestuur?" ;
+    sh:order 50 ;
+    sh:path planSamenleven:hasCollaborationWithOtherLBNonEu ;
+    form:validations
+        [ a form:ConceptSchemeConstraint ;
+            form:grouping form:Bag ;
+            sh:path planSamenleven:hasCollaborationWithOtherLBNonEu ;
+            form:conceptScheme <http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2> ;
+            sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+        ],
+        [ a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht."@nl;
+            sh:path planSamenleven:hasCollaborationWithOtherLBNonEu
+        ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2"}""" ;
+    form:displayType displayTypes:conceptSchemeRadioButtons ;
+    sh:group fields:590ec414-829e-4232-88eb-95c205773fae .
+
+##########################################################
+# Financiële stimulans: social impact bound
+##########################################################
+fields:85515be8-407e-41ac-a97d-66df37685e7c a form:Field ;
+    mu:uuid "85515be8-407e-41ac-a97d-66df37685e7c";
+    sh:name "Willen jullie als gemeente gebruik maken van het instrument 'Social Impact Bond'?" ;
+    sh:order 51 ;
+    sh:path planSamenleven:usesSocialImpactBound ;
+    form:validations
+        [ a form:ConceptSchemeConstraint ;
+            form:grouping form:Bag ;
+            sh:path planSamenleven:usesSocialImpactBound ;
+            form:conceptScheme <http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2> ;
+            sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+        ],
+        [ a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht."@nl;
+            sh:path planSamenleven:usesSocialImpactBound
+        ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2"}""" ;
+    form:displayType displayTypes:conceptSchemeRadioButtons ;
+    sh:group fields:590ec414-829e-4232-88eb-95c205773fae;
+    form:hasConditionalFieldGroup fields:1d72bc54-2d6f-4331-a0be-9f2769cce0c9 .
+
+fields:1d72bc54-2d6f-4331-a0be-9f2769cce0c9 a form:ConditionalFieldGroup ;
+    mu:uuid "1d72bc54-2d6f-4331-a0be-9f2769cce0c9";
+    form:conditions
+      [ a form:ContainsCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path planSamenleven:usesSocialImpactBound ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2> ;
+        form:customValue <http://lblod.data.gift/concepts/9ffe7dd4-42b7-4af3-bdba-ccd080195715>
+      ] ;
+    form:hasFieldGroup fieldGroups:b3b32ccd-25b9-42c2-bc8a-712958e0ff4d .
+
+##########################################################
+# Financiële stimulans: social impact bound Proposal
+##########################################################
+
+fields:53c583fe-e4c0-4c43-b693-ec318008910b a form:Field ;
+    mu:uuid "53c583fe-e4c0-4c43-b693-ec318008910b";
+    sh:name "Geef hier aan wat het concrete voorstel is voor jullie gemeente voor de 'Social Impact Bond'." ;
+    sh:order 52 ;
+    sh:path planSamenleven:usesSocialImpactBoundProposal ;
+    form:validations
+      [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht."@nl;
+      sh:path planSamenleven:usesSocialImpactBoundProposal
+      ] ;
+    form:displayType displayTypes:textArea ;
+    sh:group fields:590ec414-829e-4232-88eb-95c205773fae .
+
+##########################################################
+# Financiële stimulans: proposesMentorship
+##########################################################
+fields:4cfdb602-4b1c-4891-a3c3-cb70e1244132 a form:Field ;
+    mu:uuid "4cfdb602-4b1c-4891-a3c3-cb70e1244132";
+    sh:name "Willen jullie als gemeente het mentorschap opnemen over een bepaalde actie?" ;
+    sh:order 52 ;
+    sh:path planSamenleven:proposesMentorship ;
+    form:validations
+        [ a form:ConceptSchemeConstraint ;
+            form:grouping form:Bag ;
+            sh:path planSamenleven:proposesMentorship ;
+            form:conceptScheme <http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2> ;
+            sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+        ],
+        [ a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht."@nl;
+            sh:path planSamenleven:proposesMentorship
+        ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2"}""" ;
+    form:displayType displayTypes:conceptSchemeRadioButtons ;
+    sh:group fields:590ec414-829e-4232-88eb-95c205773fae;
+    form:hasConditionalFieldGroup fields:86aab42b-4b79-43e6-8e65-59af22ff1566 .
+
+fields:86aab42b-4b79-43e6-8e65-59af22ff1566 a form:ConditionalFieldGroup ;
+    mu:uuid "86aab42b-4b79-43e6-8e65-59af22ff1566";
+    form:conditions
+      [ a form:ContainsCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path planSamenleven:proposesMentorship ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2> ;
+        form:customValue <http://lblod.data.gift/concepts/9ffe7dd4-42b7-4af3-bdba-ccd080195715>
+      ] ;
+    form:hasFieldGroup fieldGroups:c27c749a-309f-4f6a-b7b9-c7cb34728965 .
+
+##########################################################
+# Financiële stimulans: mentorshipAction
+##########################################################
+fields:26f5b41d-a410-4c0d-b1a8-60208fe2bb49 a form:Field ;
+    mu:uuid "26f5b41d-a410-4c0d-b1a8-60208fe2bb49";
+    sh:name "Geef hier aan voor welke actie dit van toepassing is:" ;
+    sh:order 54 ;
+    sh:path planSamenleven:mentorshipAction ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path planSamenleven:mentorshipAction ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:590ec414-829e-4232-88eb-95c205773fae .
+
+##########################################################
+# Financiële stimulans: mentorshipActionDetails
+##########################################################
+
+fields:a545a2d0-aa48-4667-83d1-29a1c0d2c75c a form:Field ;
+    mu:uuid "a545a2d0-aa48-4667-83d1-29a1c0d2c75c";
+    sh:name "Op welke manier hebben jullie expertise rond deze actie verzameld? Motiveer waarom en hoe jullie deze rol als mentor zouden opnemen." ;
+    sh:order 55 ;
+    sh:path planSamenleven:mentorshipActionDetails ;
+    form:validations
+      [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht."@nl;
+      sh:path planSamenleven:mentorshipActionDetails
+      ] ;
+    form:displayType displayTypes:textArea ;
+    sh:group fields:590ec414-829e-4232-88eb-95c205773fae .
+
+##########################################################
+# Field groups
+##########################################################
+
+##########################################################
+# Main
+##########################################################
+fieldGroups:main a form:FieldGroup ;
+    mu:uuid "70eebdf0-14dc-47f7-85df-e1cfd41c3855" ;
+    form:hasField
+
+        ### First name contact person
+        fields:e19e245a-c24b-4fb5-84b8-a7e2744ce9a0 ,
+
+        ### First name contact person
+        fields:82258a58-6c67-4b0a-a26d-0676b88886ad ,
+
+        ### Phone
+        fields:6285341d-a0ad-4933-bb5f-c49016b0f935 ,
+
+        ### Email
+        fields:31c743c7-b243-4ca7-a6c1-dc5f03cb5afb ,
+
+        ### Bank account number ###
+        fields:9b706641-f834-4f91-87ab-d490f7aa0ed7 ,
+
+        ### Confirmation letter ###
+        fields:5f2ae097-ce97-4a52-a5db-501cf9e114c4 ,
+
+        ### hasCollaborationWithOtherLBNonEu ###
+        fields:30fdc26c-7f61-403f-a7da-507c2b90e750 ,
+
+        ### planSamenleven:usesSocialImpactBound ###
+        fields:85515be8-407e-41ac-a97d-66df37685e7c ,
+
+        ### planSamenleven:proposesMentorship ###
+        fields:4cfdb602-4b1c-4891-a3c3-cb70e1244132 .
+
+##########################################################
+# Branch: usesSocialImpactBound == ja
+##########################################################
+
+fieldGroups:b3b32ccd-25b9-42c2-bc8a-712958e0ff4d a form:FieldGroup ;
+    mu:uuid "b3b32ccd-25b9-42c2-bc8a-712958e0ff4d" ;
+
+    ### planSamenleven:usesSocialImpactBoundProposal ###
+    form:hasField fields:53c583fe-e4c0-4c43-b693-ec318008910b .
+
+##########################################################
+# Branch: proposesMentorship == ja
+##########################################################
+
+fieldGroups:c27c749a-309f-4f6a-b7b9-c7cb34728965 a form:FieldGroup ;
+    mu:uuid "c27c749a-309f-4f6a-b7b9-c7cb34728965" ;
+    form:hasField
+
+    ### planSamenleven:mentorschipAction ###
+    fields:26f5b41d-a410-4c0d-b1a8-60208fe2bb49 ,
+
+    ### planSamenleven:mentorschipActionDetails ###
+    fields:a545a2d0-aa48-4667-83d1-29a1c0d2c75c .
+
+form:6b70a6f0-cce2-4afe-81f5-5911f45b0b27 a form:Form ;
+    mu:uuid "6b70a6f0-cce2-4afe-81f5-5911f45b0b27" ;
+    form:hasFieldGroup fieldGroups:main .

--- a/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
+++ b/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
@@ -37,10 +37,17 @@ fields:386530d7-b4b4-41c9-8146-e2d8d629d77f a form:PropertyGroup;
     sh:name "Betaling" ;
     sh:group fields:4558f2d6-1ba4-4211-beb9-5e3a4b65b975 .
 
+fields:1351b517-2c69-4179-be27-b684739dc006 a form:PropertyGroup;
+    mu:uuid "1351b517-2c69-4179-be27-b684739dc006";
+    sh:description "objectives";
+    sh:order 4;
+    sh:name "Op welke doelstellingen wenst het bestuur in te zetten?" ;
+    sh:group fields:4558f2d6-1ba4-4211-beb9-5e3a4b65b975 .
+
 fields:590ec414-829e-4232-88eb-95c205773fae a form:PropertyGroup;
     mu:uuid "590ec414-829e-4232-88eb-95c205773fae";
     sh:description "Financiële stimulans";
-    sh:order 4;
+    sh:order 5;
     sh:name "Financiële stimulans" ;
     form:help """<a href=\"https://www.plansamenleven.be\" target=\"_blank\">Hier</a> vind je meer info over deze financiële stimulansen""";
     sh:group fields:4558f2d6-1ba4-4211-beb9-5e3a4b65b975 .
@@ -163,6 +170,25 @@ fields:ccb94821-be31-43fa-87df-ef64e3c4ce45 a form:Field ;
     sh:order 43 ;
     sh:path ( schema:bankAccount dct:hasPart rdf:type );
     sh:group fields:386530d7-b4b4-41c9-8146-e2d8d629d77f .
+
+
+##########################################################
+# policy goals: Plan Living together table
+##########################################################
+
+fields:a07b54fd-ac60-4968-94ee-65bb1bd702fd a form:Field ;
+    mu:uuid "a07b54fd-ac60-4968-94ee-65bb1bd702fd";
+    sh:name "Algemene beleidsdoelstellingen" ;
+    sh:order 45 ;
+    sh:path lblodSubsidie:planLivingTogetherTable ;
+    form:options """{}""" ;
+    form:displayType displayTypes:planLivingTogetherTable ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Gelieve de tabel correct in te vullen." ;
+      sh:path ( lblodSubsidie:planLivingTogetherTable lblodSubsidie:validPlanLivingTogetherTable ) ] ;
+    sh:group fields:1351b517-2c69-4179-be27-b684739dc006 .
 
 ##########################################################
 # Financiële stimulans: samenwerking non eu
@@ -353,6 +379,9 @@ fieldGroups:main a form:FieldGroup ;
         ### Bank account number ###
         fields:9b706641-f834-4f91-87ab-d490f7aa0ed7 ,
 
+        ### Plan Living Together Table
+        fields:a07b54fd-ac60-4968-94ee-65bb1bd702fd ,
+
         ### Confirmation letter ###
         fields:5f2ae097-ce97-4a52-a5db-501cf9e114c4 ,
 
@@ -361,6 +390,7 @@ fieldGroups:main a form:FieldGroup ;
 
         ### hasCollaborationWithOtherLBNonEu ###
         fields:30fdc26c-7f61-403f-a7da-507c2b90e750 ,
+        
 
         ### planSamenleven:usesSocialImpactBound ###
         fields:85515be8-407e-41ac-a97d-66df37685e7c ,

--- a/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
+++ b/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
@@ -243,7 +243,7 @@ fields:53c583fe-e4c0-4c43-b693-ec318008910b a form:Field ;
           form:max 2500;
           form:grouping form:MatchEvery ;
           sh:resultMessage "Gelieve hat aantal tekens te beperken tot 2500."@nl;
-          sh:path planSamenleven:mentorshipActionDetails
+          sh:path planSamenleven:usesSocialImpactBoundProposal
       ]
       ;
     form:displayType displayTypes:textArea ;

--- a/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
+++ b/config/subsidy-application-management/forms/plan-samenleven/proposal/versions/20220302124605/form.ttl
@@ -356,6 +356,9 @@ fieldGroups:main a form:FieldGroup ;
         ### Confirmation letter ###
         fields:5f2ae097-ce97-4a52-a5db-501cf9e114c4 ,
 
+        ### Confirmation letter: hidden ###
+        fields:ccb94821-be31-43fa-87df-ef64e3c4ce45,
+
         ### hasCollaborationWithOtherLBNonEu ###
         fields:30fdc26c-7f61-403f-a7da-507c2b90e750 ,
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging:
 
 services:
   loket:
-    image: lblod/frontend-loket:0.57.0
+    image: lblod/frontend-loket:0.58.0
     links:
       - identifier:backend
     labels:


### PR DESCRIPTION
Added table to plan samenleven subsidy
- The form.ttl & form.json for plan samenleven subsidy have a new property group 'objectives' and to that property group a Table has been added as field.
- subsidy rule migration has been added that contains all rows and values for the table similar to climate subsidy table
note that the values are hardcoded in submission-form-fields