### PR TITLE
Add migration to clean up extra uuids

### DIFF
--- a/config/migrations/2022/20220624095713-remove-extra-uuids.sparql
+++ b/config/migrations/2022/20220624095713-remove-extra-uuids.sparql
@@ -1,0 +1,83 @@
+# Due to some error while reconciliating persons a long time ago, we ended up having resources with 2 uuids
+# In those queries we clean them by :
+#  - Getting the resources with at least two different uuids
+#  - Removing the uuids that don't match with the one in the URI (for ease of writing the query + clarity)
+
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+DELETE {
+  GRAPH ?g {
+    ?s mu:uuid ?uuid2 .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s a <http://www.w3.org/ns/person#Person> ;
+      mu:uuid ?uuid1, ?uuid2 .
+  }
+
+  BIND(STRAFTER(str(?s), "http://data.lblod.info/id/personen/") as ?uriUuid)
+
+  FILTER (?uuid1 != ?uuid2)
+  FILTER (?uriUuid != ?uuid2)
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s mu:uuid ?uuid2 .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s a <http://www.w3.org/ns/adms#Identifier> ;
+      mu:uuid ?uuid1, ?uuid2 .
+  }
+
+  BIND(STRAFTER(str(?s), "http://data.lblod.info/id/identificatoren/") as ?uriUuid)
+
+  FILTER (?uuid1 != ?uuid2)
+  FILTER (?uriUuid != ?uuid2)
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s mu:uuid ?uuid2 .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s a <http://data.vlaanderen.be/ns/persoon#Geboorte> ;
+      mu:uuid ?uuid1, ?uuid2 .
+  }
+
+  # URIs of birth dates can be /geboorte/ or /geboortes/ , trick to take both cases into account
+  BIND(STRAFTER(str(?s), "http://data.lblod.info/id/geboorte") as ?tmpUriUuid)
+  BIND(STRAFTER(?tmpUriUuid, "/") as ?uriUuid)
+
+  FILTER (?uuid1 != ?uuid2)
+  FILTER (?uriUuid != ?uuid2)
+}
+
+;
+
+# There are only two exceptions with birth dates that have different uuids in different graphs
+
+DELETE {
+  GRAPH ?g {
+    ?birthUri mu:uuid ?badUuid .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?birthUri mu:uuid ?goodUuid .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?birthUri mu:uuid ?badUuid .
+  }
+
+  VALUES (?birthUri ?badUuid ?goodUuid) {
+    (<http://data.lblod.info/id/geboorte/7cd8a52f68318666347d60c32528ee6032c9048488db24b4ff9aafd176eec0d3> "5CED5394D5BECA000A000555" "7cd8a52f68318666347d60c32528ee6032c9048488db24b4ff9aafd176eec0d3")
+    (<http://data.lblod.info/id/geboortes/5C8107B3D5BECA0009000100> "5C8101BBD5BECA00090000EE" "5C8107B3D5BECA0009000100")
+  }
+}


### PR DESCRIPTION
See DL-3878 for context

I decided to remove uuids that didn't match with the uuid in the URI (instead of randomly) because it didn't take more time to write and it'll be easier for devs later one to not get confused. It also made it easier to ensure we'll still have at least one uuid left.

To double check my results, I used the following queries:
- Data with two uuids
```
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>

SELECT DISTINCT * where {
  ?s a ?type ;
    mu:uuid ?uuid1, ?uuid2 .

  FILTER (?type IN (
    <http://www.w3.org/ns/person#Person>,
    <http://www.w3.org/ns/adms#Identifier>,
    <http://data.vlaanderen.be/ns/persoon#Geboorte>
  ))

  FILTER (?uuid1 < ?uuid2)
}
```
- Data with no uuid
```
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>

SELECT DISTINCT * where {
  ?s a ?type .

  FILTER (?type IN (
    <http://www.w3.org/ns/person#Person>,
    <http://www.w3.org/ns/adms#Identifier>,
    <http://data.vlaanderen.be/ns/persoon#Geboorte>
  ))

FILTER NOT EXISTS { ?s mu:uuid ?uuid }
}
ORDER BY ?s
```