### PR TITLE
Changed mandataris rangorde type to string

### DIFF
--- a/config/migrations/2022/20220720125447-remove-language-tags-mandataris-rangorde.sparql
+++ b/config/migrations/2022/20220720125447-remove-language-tags-mandataris-rangorde.sparql
@@ -1,0 +1,22 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mandatarissen: <http://data.lblod.info/id/mandatarissen/>
+
+DELETE {
+  GRAPH ?g {
+    ?mandataris mandaat:rangorde ?rangorde .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?mandataris mandaat:rangorde ?rangordeStripped .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?mandataris rdf:type mandaat:Mandataris .
+    ?mandataris mandaat:rangorde ?rangorde .
+    BIND (STR(?rangorde) AS ?rangordeStripped)
+  }
+}
+

--- a/config/resources/slave-mandaat-domain.lisp
+++ b/config/resources/slave-mandaat-domain.lisp
@@ -87,7 +87,7 @@
 
 (define-resource mandataris ()
   :class (s-prefix "mandaat:Mandataris")
-  :properties `((:rangorde :language-string ,(s-prefix "mandaat:rangorde"))
+  :properties `((:rangorde :string ,(s-prefix "mandaat:rangorde"))
                 (:start :datetime ,(s-prefix "mandaat:start"))
                 (:einde :datetime ,(s-prefix "mandaat:einde"))
                 (:datum-eedaflegging :datetime ,(s-prefix "ext:datumEedaflegging"))


### PR DESCRIPTION
This PR changes the type of the mandataris rangorde to a simple string instead of a `language-string`.

Because of a bug in Virtuoso, strings with language tag can, in some cases, not be removed from the triplestore. See https://github.com/openlink/virtuoso-opensource/issues/1055. To workaround this issue, these particular language tags can be removed with the help of a migration, and served correctly after a change in the relevant resource configuration. Some changes in the frontend are on the way too (see https://github.com/lblod/frontend-loket/pull/138).