### PR TITLE
Added e-inclusion form with only textual adjustments

### DIFF
--- a/config/migrations/2022/20220829160000-e-inclusion-updates/20220829163000-update-e-inclusion-form.sparql
+++ b/config/migrations/2022/20220829160000-e-inclusion-updates/20220829163000-update-e-inclusion-form.sparql
@@ -1,0 +1,13 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+      <http://lblod.data.info/id/subsidie-application-flow-steps/c38d4ab1-17b0-4281-81d7-7bd0001f6053> dct:source <config://forms/e-inclusion/proposal/versions/20220804090000/form.ttl>.
+  }
+}
+;
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+      <http://lblod.data.info/id/subsidie-application-flow-steps/c38d4ab1-17b0-4281-81d7-7bd0001f6053> dct:source <config://forms/e-inclusion/proposal/versions/20220829090000-textual-adjustments/form.ttl>.
+  }
+}

--- a/config/subsidy-application-management/forms/e-inclusion/proposal/versions/20220829090000-textual-adjustments/form.json
+++ b/config/subsidy-application-management/forms/e-inclusion/proposal/versions/20220829090000-textual-adjustments/form.json
@@ -1,0 +1,52 @@
+{
+    "source": {
+      "prefixes": [
+        "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
+        "PREFIX dct: <http://purl.org/dc/terms/>",
+        "PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>",
+        "PREFIX schema: <http://schema.org/>",
+        "PREFIX foaf: <http://xmlns.com/foaf/0.1/>",
+        "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>"
+      ],
+      "properties": [
+        "lblodSubsidie:amount",
+        "lblodSubsidie:currentEInclusionActions",
+        "lblodSubsidie:actionShortDescription",
+        "lblodSubsidie:actionFullDescription",
+        "lblodSubsidie:targetedAudience",
+        "lblodSubsidie:targetedAudienceOther",
+        {
+          "s-prefix": "schema:contactPoint",
+          "properties": [
+            "foaf:firstName",
+            "foaf:familyName",
+            "schema:telephone",
+            "schema:email",
+            "schema:jobTitle"
+          ]
+        },
+        {
+          "s-prefix": "schema:bankAccount",
+          "properties": [
+            "schema:identifier",
+            {
+              "s-prefix": "dct:hasPart",
+              "properties": ["rdf:type"]
+            }
+          ]
+        },
+        {
+          "s-prefix": "lblodSubsidie:hasAdditionalAction",
+          "properties": [
+            "rdf:type",
+            "lblodSubsidie:additionalActionType",
+            "lblodSubsidie:additionalActionShortDescription",
+            "lblodSubsidie:additionalActionFullDescription",
+            "lblodSubsidie:additionalActionTargetedAudience",
+            "lblodSubsidie:additionalActionTargetedAudienceOther"
+          ]
+        }
+      ]
+    }
+  }
+  

--- a/config/subsidy-application-management/forms/e-inclusion/proposal/versions/20220829090000-textual-adjustments/form.ttl
+++ b/config/subsidy-application-management/forms/e-inclusion/proposal/versions/20220829090000-textual-adjustments/form.ttl
@@ -1,0 +1,492 @@
+@prefix lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos:	<http://www.w3.org/2004/02/skos/core#> .
+@prefix mu:	<http://mu.semte.ch/vocabularies/core/> .
+@prefix cpsv:	<http://purl.org/vocab/cpsv#> .
+@prefix dct:	<http://purl.org/dc/terms/> .
+@prefix xkos:	<http://rdf-vocabulary.ddialliance.org/xkos#> .
+@prefix m8g:	<http://data.europa.eu/m8g/> .
+@prefix dcat:	<http://www.w3.org/ns/dcat#> .
+@prefix lang:	<http://publications.europa.eu/resource/authority/language/> .
+@prefix belgif:	<http://vocab.belgif.be/ns/publicservice#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix schema: <http://schema.org/>.
+
+##########################################################
+# form
+##########################################################
+ext:form a form:Form, form:TopLevelForm ;
+    form:includes ext:firstNameF;
+    form:includes ext:lastNameF;
+    form:includes ext:telephoneF;
+    form:includes ext:mailF;
+    form:includes ext:functionF;
+    form:includes ext:ibanF;
+    form:includes ext:confirmationLetterF;
+    form:includes ext:hiddenLetterF;
+    form:includes ext:amountF;
+    form:includes ext:currentActionsF;
+    form:includes ext:actionShortDescriptionF;
+    form:includes ext:actionFullDescriptionF;
+    form:includes ext:targetedAudienceF;
+    form:includes ext:targetedAudienceOtherF;
+    form:includes ext:additionalActionsL.
+
+##########################################################
+#  property-group: contact
+##########################################################
+ext:contactPg a form:PropertyGroup;
+    sh:name "Contactgegevens contactpersoon" ;
+    form:help "Dit is de persoon die gecontacteerd wordt bij de opvolging van dit dossier.";
+    sh:order 1 .
+
+  ##########################################################
+  #  field: first name
+  ##########################################################
+  ext:firstNameF a form:Field ;
+    sh:order 1 ;
+    sh:name "Voornaam contactpersoon";
+    sh:path ( schema:contactPoint foaf:firstName ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:path ( schema:contactPoint foaf:firstName ) ;
+      sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput;
+    sh:group ext:contactPg .
+
+
+  ##########################################################
+  #  field: last name
+  ##########################################################
+  ext:lastNameF a form:Field ;
+    sh:order 2 ;
+    sh:name "Familienaam contactpersoon";
+    sh:path ( schema:contactPoint foaf:familyName ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:path ( schema:contactPoint foaf:familyName ) ;
+      sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group ext:contactPg .
+
+
+  ##########################################################
+  #  field: telephone
+  ##########################################################
+  ext:telephoneF a form:Field ;
+    sh:order 3 ;
+    sh:name "Telefoonnummer";
+    sh:path ( schema:contactPoint schema:telephone ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:path ( schema:contactPoint schema:telephone ) ;
+      sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidPhoneNumber ;
+      form:grouping form:MatchEvery ;
+      form:defaultCountry "BE" ;
+      sh:path ( schema:contactPoint schema:telephone ) ;
+      sh:resultMessage "Geef een geldig telefoonnummer in."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group ext:contactPg .
+
+
+  ##########################################################
+  #  field: email
+  ##########################################################
+  ext:mailF a form:Field ;
+    sh:order 4 ;
+    sh:name "Mailadres";
+    sh:path ( schema:contactPoint schema:email ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:path ( schema:contactPoint schema:email ) ;
+      sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidEmail ;
+      form:grouping form:MatchEvery ;
+      sh:path ( schema:contactPoint schema:email ) ;
+      sh:resultMessage "Geef een geldig e-mailadres op."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group ext:contactPg .
+
+  ##########################################################
+  #  field: function
+  ##########################################################
+  ext:functionF a form:Field ;
+    sh:order 5 ;
+    sh:name "Functie contactpersoon";
+    sh:path ( schema:contactPoint schema:jobTitle ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:path ( schema:contactPoint schema:jobTitle ) ;
+      sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group ext:contactPg .
+
+
+##########################################################
+#  property-group: payment
+##########################################################
+ext:paymentPg a form:PropertyGroup;
+    sh:name "Betaling" ;
+    sh:order 2 .
+
+  ##########################################################
+  #  field: iban
+  ##########################################################
+  ext:ibanF a form:Field ;
+    sh:order 1 ;
+    sh:name "Rekeningnummer uitbetaling";
+    form:help "IBAN: BE00 0000 0000 0000";
+    sh:path ( schema:bankAccount schema:identifier ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:path ( schema:bankAccount schema:identifier ) ;
+      sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidIBAN ;
+      form:grouping form:MatchEvery ;
+      sh:path ( schema:bankAccount schema:identifier ) ;
+      sh:resultMessage "Geef een geldig IBAN op."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput;
+    sh:group ext:paymentPg .
+
+
+  ##########################################################
+  #  field: confirmation letter
+  ##########################################################
+  ext:confirmationLetterF a form:Field ;
+    sh:order 2 ;
+    sh:name "Voeg een bevestingsbrief toe dat dit rekeningnummer gebruikt mag worden, ondertekend door de burgemeester en medeondertekend door de financieel directeur." ;
+    form:help "Deze brief moet enkel toegevoegd worden als dit niet het rekeningnummer is waarop het aandeel van het gemeentefonds wordt gestort." ;
+    sh:path ( schema:bankAccount dct:hasPart ) ;
+    form:displayType displayTypes:files ;
+    sh:group ext:paymentPg .
+    
+
+  ##########################################################
+  #  hidden field: confirmation letter
+    # Hidden field required for all variations of URL or FILE
+    # input field which require validation.
+    # It makes sure there is a type attached to hasPart object.
+    # This enables correct validation in both front and backend.
+  ##########################################################
+  ext:hiddenLetterF a form:Field ;
+    sh:order 3 ;
+    sh:name "Type RemoteDataObject or FileDataObject [hidden input]" ;
+    sh:path ( schema:bankAccount dct:hasPart rdf:type );
+    sh:group ext:paymentPg .    
+
+
+##########################################################
+#  property-group: request
+##########################################################
+ext:requestPg a form:PropertyGroup;
+    sh:name "Inhoudelijke aanvraag" ;
+    sh:order 3 .
+
+  ##########################################################
+  #  field: subsidy amount
+  ##########################################################
+  ext:amountF a form:Field ;
+    sh:order 1 ;
+    sh:name "Gevraagde subsidiebedrag";
+    form:help """Aan de hand van een <a href="https://assets.vlaanderen.be/image/upload/v1658218571/VR_2021_1507_BVR_uitrol_lokaal_e-inclusiebeleid_-_4_BIS_Bijlage_overzicht_maximumbedragen_ctuwpd.pdf" target="_blank">verdeelsleutel</a> werd het maximale bedrag berekend dat elke Vlaamse gemeente of stad, die in aanmerking komt, kan aanvragen.""";
+    sh:path lblodSubsidie:amount ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:path lblodSubsidie:amount ;
+      sh:resultMessage "Dit veld is verplicht."@nl
+    ],
+    [ a form:PositiveNumber ;
+      form:grouping form:MatchEvery ;
+      sh:path lblodSubsidie:amount ;
+      sh:resultMessage "Geef een positief aantal op."@nl
+    ] ;
+    form:options """{}""" ;
+    form:displayType displayTypes:numericalInput ;
+    sh:group ext:requestPg .
+
+
+  ##########################################################
+  #  field: current Action(s)
+  ##########################################################
+  ext:currentActionsF a form:Field ;
+    sh:order 2 ;
+    sh:name "Selecteer welke actie(s) rond e-inclusie uw bestuur op dit moment reeds organiseert, los van deze subsidie. U kan meerdere aanduiden.";
+    sh:path lblodSubsidie:currentEInclusionActions ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:path lblodSubsidie:currentEInclusionActions ;
+      sh:resultMessage "Dit veld is verplicht."@nl
+    ];
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/e31c7d36-6e7d-47e0-a749-5011f99d1514", "orderBy": "http://purl.org/linked-data/cube#order"}""" ;
+    form:displayType displayTypes:conceptSchemeMultiSelectCheckboxes ;
+    sh:group ext:requestPg .
+
+##########################################################
+#  property-group: primaryActionPg
+##########################################################
+ext:primaryActionPg a form:PropertyGroup;
+    sh:name """Om deze subsidie te ontvangen moet er minstens 1 actie gepland worden rond individuele toegang tot het internet op het thuisadres van kwetsbare burgers.
+    In de volgende sectie kun je nog bijkomende acties indienen.""";
+    form:options """{ "level": 2, "skin": 5 }""";
+    sh:order 4 .
+
+  ##########################################################
+  #  field: action short description
+  ##########################################################
+  ext:actionShortDescriptionF a form:Field ;
+    sh:order 1 ;
+    sh:name "Beschrijf in 1 zin de doelstelling dat het bestuur concreet met deze nieuwe actie wil bereiken.";
+    sh:path lblodSubsidie:actionShortDescription ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:path lblodSubsidie:actionShortDescription ;
+      sh:resultMessage "Dit veld is verplicht."@nl
+    ],
+    [ a form:MaxLength ;
+      form:grouping form:MatchEvery ;
+      form:max "150" ;
+      sh:path lblodSubsidie:actionShortDescription ;
+      sh:resultMessage "Max. karakters overschreden."@nl
+    ];
+    form:displayType displayTypes:textArea ;
+    sh:group ext:primaryActionPg .
+
+
+  ##########################################################
+  #  field: action full description
+  ##########################################################
+  ext:actionFullDescriptionF a form:Field ;
+    sh:order 2 ;
+    sh:name "Geef een korte beschrijving van de actie. Probeer een antwoord te formuleren op de vragen wat, waar, hoe.";
+    form:help """Laat je inspireren door de voorbeelden op onze  <a href="https://www.vlaanderen.be/samenleven/subsidies/subsidie-voor-de-uitrol-van-een-lokaal-e-inclusiebeleid" target="_blank">website</a>.""" ;
+    sh:path lblodSubsidie:actionFullDescription ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:path lblodSubsidie:actionFullDescription ;
+      sh:resultMessage "Dit veld is verplicht."@nl
+    ],
+    [ a form:MaxLength ;
+      form:grouping form:MatchEvery ;
+      form:max "700" ;
+      sh:path lblodSubsidie:actionFullDescription ;
+      sh:resultMessage "Max. karakters overschreden."@nl
+    ];
+    form:displayType displayTypes:textArea ;
+    sh:group ext:primaryActionPg .
+
+
+  ##########################################################
+  #  field: targeted Audience
+  ##########################################################
+  ext:targetedAudienceF a form:Field ;
+    sh:order 3 ;
+    sh:name "Selecteer op welke doelgroep(en) deze actie gericht is. U kan meerdere aanduiden.";
+    sh:path lblodSubsidie:targetedAudience ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:path lblodSubsidie:targetedAudience ;
+      sh:resultMessage "Dit veld is verplicht."@nl
+    ];
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/0b058b75-5953-40cf-b2b5-34e23168b370", "orderBy": "http://purl.org/linked-data/cube#order"}""" ;
+    form:displayType displayTypes:conceptSchemeMultiSelectCheckboxes ;
+    sh:group ext:primaryActionPg .
+
+
+  ##########################################################
+  #  field: targeted Audience other option
+  ##########################################################
+  ext:targetedAudienceOtherF a form:Field ;
+    sh:order 4 ;
+    sh:name "Vul hier eventuele bijkomende doelgroepen in.";
+    sh:path lblodSubsidie:targetedAudienceOther ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group ext:primaryActionPg .
+
+
+##########################################################
+#  property-group: Additional Actions
+##########################################################
+ext:additionalActionsPg a form:PropertyGroup;
+    sh:name "Bijkomende acties" ;
+    form:help """Naast minstens 1 verplichte actie rond individuele toegang tot het internet op het thuisadres van kwetsbare burgers, kunnen lokale besturen met deze subsidie ook inzetten op andere acties rond e-inclusie. 
+    Beschrijf welke bijkomende actie(s) uw lokaal bestuur plant met deze subsidie. U kan meerdere bijkomende acties (max. 15) indienen.""";
+    sh:order 5 .
+
+  ##########################################################
+  #  listing-scope: Additional Actions
+  ##########################################################
+  ext:additionalActionsS a form:Scope;
+    sh:path lblodSubsidie:hasAdditionalAction .
+
+  ##########################################################
+  #  Listing: Additional Actions
+  ##########################################################
+  ext:additionalActionsL a form:Listing;
+    form:each ext:additionalActionsSf;
+    form:scope ext:additionalActionsS;
+    form:createGenerator ext:additionalActionsG;
+    sh:group ext:additionalActionsPg;
+    form:addLabel "Voeg actie toe";
+    form:canAdd true;
+    form:canRemove true;
+    sh:maxCount 15;
+    sh:order 1 .
+
+ ##########################################################
+  #  Generator: Additional Actions
+  ##########################################################
+  ext:additionalActionsG a form:Generator;
+    form:prototype [
+      form:shape [
+        a lblodSubsidie:additonalAction ;
+        lblodSubsidie:additionalActionType "";
+        lblodSubsidie:additionalActionShortDescription "";
+        lblodSubsidie:additionalActionFullDescription "";
+        lblodSubsidie:additionalActionTargetedAudience "";
+        lblodSubsidie:additionalActionTargetedAudienceOther "";
+      ];
+    ];
+    form:dataGenerator form:addMuUuid.
+
+  ##########################################################
+  #  property-group: additionalActions-sub
+  ##########################################################
+  ext:additionalActionsPg-sub a form:PropertyGroup;
+      sh:order 1 .
+
+  ##########################################################
+  #  Subform: Additional Actions
+  ##########################################################
+  ext:additionalActionsSf a form:SubForm;
+     form:removeLabel "Verwijder actie";
+     form:includes ext:additionalActionTypeF;
+     form:includes ext:additionalActionShortDescriptionF;
+     form:includes ext:additionalActionFullDescriptionF;
+     form:includes ext:additionalActionTargetedAudienceF;
+     form:includes ext:additionalActionTargetedAudienceOtherF.
+
+    ##########################################################
+    # Field: additional action type
+    ##########################################################
+    ext:additionalActionTypeF a form:Field ;
+        sh:name "Selecteer welke soort actie jullie bestuur bijkomend wenst op te zetten met deze subsidie." ;
+        sh:order 1 ;
+        sh:path lblodSubsidie:additionalActionType ;
+        form:validations
+        [ a form:ConceptSchemeConstraint ;
+            form:grouping form:Bag ;
+            sh:path lblodSubsidie:additionalActionType ;
+            form:conceptScheme <http://lblod.data.gift/concept-schemes/2c7ca3db-f61b-4903-8497-245073800ceb> ;
+            sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+        ],
+        [ a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht."@nl;
+            sh:path lblodSubsidie:additionalActionType
+        ] ;
+        form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/2c7ca3db-f61b-4903-8497-245073800ceb", "orderBy": "http://purl.org/linked-data/cube#order"}""" ;
+        form:displayType displayTypes:conceptSchemeSelector ;
+        sh:group ext:additionalActionsPg-sub .
+
+
+    ##########################################################
+    # Field: additional action short description
+    ##########################################################
+    ext:additionalActionShortDescriptionF a form:Field ;
+        sh:name "Beschrijf in 1 zin de doelstelling dat het bestuur concreet met deze actie wil bereiken." ;
+        sh:order 2 ;
+        sh:path lblodSubsidie:additionalActionShortDescription ;
+        form:validations
+        [ a form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path lblodSubsidie:additionalActionShortDescription ;
+          sh:resultMessage "Dit veld is verplicht."@nl
+        ],
+        [ a form:MaxLength ;
+          form:grouping form:MatchEvery ;
+          form:max "150" ;
+          sh:path lblodSubsidie:additionalActionShortDescription ;
+          sh:resultMessage "Max. karakters overschreden."@nl
+        ];
+        form:displayType displayTypes:textArea ;
+        sh:group ext:additionalActionsPg-sub .
+
+    ##########################################################
+    # Field: additional action full description
+    ##########################################################
+    ext:additionalActionFullDescriptionF a form:Field ;
+        sh:name "Geef een korte beschrijving van de actie. Probeer een antwoord te formuleren op de vragen wat, waar, hoe." ;
+        form:help "Laat je inspireren door de voorbeelden op one website.";
+        sh:order 3;
+        sh:path lblodSubsidie:additionalActionFullDescription ;
+        form:validations
+        [ a form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path lblodSubsidie:additionalActionFullDescription ;
+          sh:resultMessage "Dit veld is verplicht."@nl
+        ],
+        [ a form:MaxLength ;
+          form:grouping form:MatchEvery ;
+          form:max "700" ;
+          sh:path lblodSubsidie:additionalActionFullDescription ;
+          sh:resultMessage "Max. karakters overschreden."@nl
+        ];
+        form:displayType displayTypes:textArea ;
+        sh:group ext:additionalActionsPg-sub .
+
+    ##########################################################
+    # Field: additional actions targeted audience
+    ##########################################################
+    ext:additionalActionTargetedAudienceF a form:Field ;
+        sh:order 4 ;
+        sh:name "Selecteer op welke doelgroep(en) deze actie gericht is. U kan meerdere aanduiden.";
+        sh:path lblodSubsidie:additionalActionTargetedAudience ;
+        form:validations
+        [ a form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path lblodSubsidie:additionalActionTargetedAudience ;
+          sh:resultMessage "Dit veld is verplicht."@nl
+        ];
+        form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/0b058b75-5953-40cf-b2b5-34e23168b370", "orderBy": "http://purl.org/linked-data/cube#order"}""" ;
+        form:displayType displayTypes:conceptSchemeMultiSelectCheckboxes ;
+        sh:group ext:additionalActionsPg-sub .
+
+
+    ##########################################################
+    # Field: additional actions targeted audience other
+    ##########################################################
+    ext:additionalActionTargetedAudienceOtherF a form:Field ;
+        sh:order 5 ;
+        sh:name "Vul hier eventuele bijkomende doelgroepen in.";
+        sh:path lblodSubsidie:additionalActionTargetedAudienceOther ;
+        form:displayType displayTypes:defaultInput ;
+        sh:group ext:additionalActionsPg-sub .
+  


### PR DESCRIPTION
Textual adjustments added to e-inclusion form.
**NOTE: Only works (propery) for frontend with ember-submission-form-fields with version 2.1.0**
Release 2.1.0 contains configurable propertygroups