### PR TITLE
Dasherize the `createdBy` relationship name

### DIFF
--- a/config/resources/lpdc.json
+++ b/config/resources/lpdc.json
@@ -143,7 +143,7 @@
           "predicate": "dct:source",
           "cardinality": "one"
         },
-        "createdBy": {
+        "created-by": {
           "target": "bestuurseenheid",
           "predicate": "pav:createdBy",
           "cardinality": "one"


### PR DESCRIPTION
Relationship names are used as-is in API requests so this required us to also use the camelCased name which isn't consistent with the other relationships.