### PR TITLE
Propagate first and last names in all the graphs they belong to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.68.6 (2022-09-27)
+- propgate persons first or last names to all the graphs it belongs to
 ## 1.68.5 (2022-09-27)
 - update bicycle subsidy deadline
 ## 1.68.4 (2022-09-26)

--- a/config/migrations/2022/20220927132654-propagate-missing-names-across-graphs.sparql
+++ b/config/migrations/2022/20220927132654-propagate-missing-names-across-graphs.sparql
@@ -1,0 +1,39 @@
+# Propagate last names
+
+INSERT {
+  GRAPH ?g {
+    ?s <http://xmlns.com/foaf/0.1/familyName> ?lastName .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s a <http://www.w3.org/ns/person#Person> ;
+      <http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam> ?firstName .
+
+    FILTER NOT EXISTS {
+      ?s <http://xmlns.com/foaf/0.1/familyName> ?unexistingLastName .
+    }
+  }
+
+  ?s <http://xmlns.com/foaf/0.1/familyName> ?lastName .
+}
+
+;
+
+# Propagate first names
+
+INSERT {
+  GRAPH ?g {
+    ?s <http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam> ?firstName .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s a <http://www.w3.org/ns/person#Person> ;
+    <http://xmlns.com/foaf/0.1/familyName> ?lastName .
+
+    FILTER NOT EXISTS {
+      ?s <http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam> ?unexistingFirstName .
+    }
+  }
+
+  ?s <http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam> ?firstName .
+}


### PR DESCRIPTION
Something wrong probably happened with the persons reconciliation, causing first or last names missing in some graphs but not in all the graphs the persons belongs to.
Here we make sure that the first and last name reside in all the needed graphs.

Branch starting from tag v1.68.5