### PR TITLE
Clear out organen before 2023

### DIFF
--- a/config/migrations/2022/20220829135928-erediesten-data/20220928092536-clear-erediensten-governing-bodies-before-2023.sparql
+++ b/config/migrations/2022/20220829135928-erediesten-data/20220928092536-clear-erediensten-governing-bodies-before-2023.sparql
@@ -1,0 +1,49 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX lblodOrg: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX schema: <http://schema.org/>
+PREFIX locn: <http://www.w3.org/ns/locn>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuursorgaanInTime ?pbestuursorgaanInTime ?obestuursorgaanInTime .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    VALUES ?type {
+      ere:BestuurVanDeEredienst
+      ere:CentraalBestuurVanDeEredienst
+    }
+  
+    ?bestuurseenheid a ?type .
+  
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+  
+    ?bestuursorgaanInTime mandaat:isTijdspecialisatieVan ?bestuursorgaan ;
+      mandaat:bindingStart ?start ;
+      ?pbestuursorgaanInTime ?obestuursorgaanInTime .
+
+    # We just keep the ones we created for time periods 2023-2026 and 2026-2029
+    FILTER( ?start < "2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> )
+  }
+}
+
+;
+
+# This one has no start date so the filter doesn't get it
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/eredienstbestuursorganen/cd030163720a7be3ca7934dd87d3b50f> ?p ?o .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/eredienstbestuursorganen/cd030163720a7be3ca7934dd87d3b50f> ?p ?o .
+  }
+}


### PR DESCRIPTION
I noticed on prod that we already have worship organen in time for the periods before 2023, which is not supposed to be the case. Not sure how they got here, but it might conflict with a future data import.

We are going to import those organen back later on but with different start and end dates, so I suggest we clear them out to start from a clean sheet.