### PR TITLE
Fix multiple labels on worship organen

### DIFF
--- a/config/migrations/2022/20220829135928-erediesten-data/20221004180654-refresh-worship-organen-labels.sparql
+++ b/config/migrations/2022/20220829135928-erediesten-data/20221004180654-refresh-worship-organen-labels.sparql
@@ -12,7 +12,7 @@ PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
 DELETE {
   GRAPH <http://mu.semte.ch/graphs/public> {
-    ?bestuursorgaan skos:prefLabel ?oldBestuursogaanLabel.
+    ?bestuursorgaan skos:prefLabel ?oldBestuursorgaanLabel.
   }
 }
 INSERT {
@@ -31,7 +31,7 @@ WHERE {
       skos:prefLabel ?bestuurseenheidLabel.
 
     ?bestuursorgaan besluit:bestuurt ?bestuurseenheid ;
-      skos:prefLabel ?oldBestuursogaanLabel ;
+      skos:prefLabel ?oldBestuursorgaanLabel ;
       besluit:classificatie ?classificationBestuursorgaan .
 
     ?classificationBestuursorgaan skos:prefLabel ?classificationBestuursorgaanLabel.

--- a/config/migrations/2022/20220829135928-erediesten-data/20221004180654-refresh-worship-organen-labels.sparql
+++ b/config/migrations/2022/20220829135928-erediesten-data/20221004180654-refresh-worship-organen-labels.sparql
@@ -1,0 +1,41 @@
+PREFIX erediensten: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX lblodOrg: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuursorgaan skos:prefLabel ?oldBestuursogaanLabel.
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuursorgaan skos:prefLabel ?newBestuursorgaanLabel.
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    VALUES ?type {
+      erediensten:BestuurVanDeEredienst
+      erediensten:CentraalBestuurVanDeEredienst
+    }
+
+    ?bestuurseenheid a ?type;
+      skos:prefLabel ?bestuurseenheidLabel.
+
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid ;
+      skos:prefLabel ?oldBestuursogaanLabel ;
+      besluit:classificatie ?classificationBestuursorgaan .
+
+    ?classificationBestuursorgaan skos:prefLabel ?classificationBestuursorgaanLabel.
+
+    BIND(CONCAT(?classificationBestuursorgaanLabel, " ", ?bestuurseenheidLabel) as ?newBestuursorgaanLabel)
+  }
+}


### PR DESCRIPTION
Thanks to a user testing bug, we found out that the previous migration adding labels to the organen was wrong (the triple linking the organen and the classifications was missing and it's quite essential to have only the relevant label(s) :sweat_smile: )

So to keep it simple, I flushed the labels and re-add them, adding the missing line to the previous migration.