### PR TITLE
poc elasticsearch config generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  project-scripts:
+    image: semtech/mu-scripts:1.0.0
+    volumes:
+      - ./scripts/project:/app/scripts/
+    restart: "no"
   dashboard:
     image: lblod/frontend-dashboard:1.3.0
     links:

--- a/scripts/project/build-elasticsearch-config/build.sh
+++ b/scripts/project/build-elasticsearch-config/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+{
+bundle config set path /tmp/gems
+gem install stringio:3.0.2
+gem install psych:4.0.6
+rm out.json
+
+}&> /dev/null
+rm /data/app/config/search/config.json
+mkdir -p /data/app/config/search
+ruby ./script.rb  >> /data/app/config/search/config.json

--- a/scripts/project/build-elasticsearch-config/script.rb
+++ b/scripts/project/build-elasticsearch-config/script.rb
@@ -1,0 +1,90 @@
+require 'bundler/inline'
+$stdout.sync = true
+gemfile do
+  source 'https://rubygems.org'
+  gem 'stringio'
+  gem 'linkeddata'
+end
+
+ROLE = "LoketLB-toezichtGebruiker";
+SPEC_NAME = "o-toez-rwf";
+SPARQL_CLIENT = "http://virtuoso:8890/sparql"
+DEFAULT_SETTINGS = %|
+                        {
+                            "analysis": {
+                                "normalizer": {
+                                "custom_sort_normalizer": {
+                                    "type": "custom",
+                                    "char_filter": [],
+                                    "filter": ["lowercase", "trim", "asciifolding"]
+                                }
+                                }
+                            }
+                        }
+                    |
+
+                     
+def client
+    @client ||= SPARQL::Client.new(SPARQL_CLIENT)
+end
+
+def query(role) 
+    q = %|
+            PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+            PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+            SELECT DISTINCT ?session_group  WHERE {
+            ?sessionId ext:sessionGroup/mu:uuid ?session_group;
+                        ext:sessionRole ?session_role.
+            FILTER( ?session_role = "#{role}" )
+            }
+        |   
+    return  client.query(q)
+end
+
+def get_eager_index_groups() 
+    data = query(ROLE);
+    search_conf = []
+    session_group = data.map { |b| b.session_group.value };
+
+    session_group.each do |sg|
+        json = %|
+            [
+                {
+                "variables": [],
+                "name": "clean"
+                },
+                {
+                "variables": [],
+                "name": "public"
+                },
+                {
+                "name": "#{SPEC_NAME}",
+                "variables": ["#{sg}", "#{ROLE}"]
+                }
+            ]
+
+        |
+        search_conf << json
+      
+   end
+    return search_conf.join(',');
+end
+
+
+def make_config() 
+    groups = get_eager_index_groups();
+
+    config = %| 
+        {
+        "automatic_index_updates": true,
+        "persist_indexes": true,
+        "eager_indexing_groups": [#{groups}],
+        "default_settings": #{DEFAULT_SETTINGS},
+        "types": []
+        }
+    |
+  
+    puts config
+end
+
+make_config()

--- a/scripts/project/build-elasticsearch-config/script.rb
+++ b/scripts/project/build-elasticsearch-config/script.rb
@@ -2,7 +2,6 @@ require 'bundler/inline'
 $stdout.sync = true
 gemfile do
   source 'https://rubygems.org'
-  gem 'stringio'
   gem 'linkeddata'
 end
 


### PR DESCRIPTION
this pull request is not intended to be merged.

Its intent is to show how we could generate the elasticsearch config for a specific role (DL-4280), in this case

```
ROLE = "LoketLB-toezichtGebruiker";
SPEC_NAME = "o-toez-rwf";
```

# How to:

- `docker-compose up -d virtuoso` (make sure you have data in the virtuoso db)
- `mu script project-scripts build-elasticsearch-config` (make sure you have mu-cli installed)
- you should see the config generated in `config/search/config.json`
 