### PR TITLE
Hotfix/fietssubsidies deadlines

### DIFF
--- a/config/migrations/2022/20221014090000-fietssubsidie-deadlines/20221014093000-update-deadline.sparql
+++ b/config/migrations/2022/20221014090000-fietssubsidie-deadlines/20221014093000-update-deadline.sparql
@@ -1,0 +1,14 @@
+PREFIX mg8: <http://data.europa.eu/m8g/>
+
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Period of step Proposal
+     <http://data.lblod.info/id/periodes/ce0ad95a-baba-42df-9d94-28f0d83e0ed7> mg8:endTime "2022-10-15T21:59:00Z"^^xsd:dateTime .
+  }
+}
+;
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+   <http://data.lblod.info/id/periodes/ce0ad95a-baba-42df-9d94-28f0d83e0ed7> mg8:endTime "2022-11-15T21:59:00Z"^^xsd:dateTime.
+  }
+}

--- a/config/migrations/2022/20221014090000-fietssubsidie-deadlines/20221014100000-remove-gemeenten-from-criteria.sparql
+++ b/config/migrations/2022/20221014090000-fietssubsidie-deadlines/20221014100000-remove-gemeenten-from-criteria.sparql
@@ -1,0 +1,8 @@
+DELETE DATA {
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+      
+    <http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2> <http://data.europa.eu/m8g/hasCriterion>
+      <http://data.lblod.info/id/criterions/f5ea0615-0b0a-47db-a38c-6097ff80815d>. # gemeente
+  }
+}

--- a/config/reports/fietsSubsidieProposalsDeadlineGemeentenReports.js
+++ b/config/reports/fietsSubsidieProposalsDeadlineGemeentenReports.js
@@ -1,0 +1,62 @@
+import { generateReportFromData } from '../helpers.js';
+import { querySudo as query } from '@lblod/mu-auth-sudo';
+import { getSafeValue } from './util/report-helpers';
+
+export default {
+  cronPattern: '0 0 1 * * *',
+  name: 'fietsSubsidieProposalsDeadlineGemeentenReport',
+  execute: async () => {
+    const reportData = {
+      title: 'List of proposals of fiets subsidies for checking deadline gemeenten',
+      description: 'All proposals for bike subsidies of Gemeenten with submission date information',
+      filePrefix: 'fietsSubsidieProposalsDeadlineGemeentenReport'
+    };
+    console.log('Generate Fiets Subsidie Proposals Deadline Gemeenten Report');
+    const queryString = `
+    PREFIX subsidie: <http://data.vlaanderen.be/ns/subsidie#>
+    PREFIX transactie: <http://data.vlaanderen.be/ns/transactie#>
+    PREFIX m8g: <http://data.europa.eu/m8g/>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX adms: <http://www.w3.org/ns/adms#>
+
+    SELECT DISTINCT ?subsidie ?bestuurseenheid ?subsidieStatus ?formStatus ?dossierNummer ?modifiedStep
+    WHERE {
+        ?subsidie a subsidie:SubsidiemaatregelConsumptie ;
+        transactie:isInstantieVan <http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2> ;
+            dct:source ?form .
+
+        ?form dct:isPartOf/dct:references <http://data.lblod.info/id/subsidieprocedurestappen/002f93ed-bdb0-4e3a-af13-ef6c00e89651> .
+        ?form adms:status/skos:prefLabel ?formStatus ;
+            dct:modified ?modifiedStep.
+        FILTER (?modifiedStep > "2022-10-15T21:59:00Z"^^xsd:dateTime)
+        ?subsidie adms:status/skos:prefLabel ?subsidieStatus ;
+            m8g:hasParticipation ?participation .
+        ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>;
+            m8g:playsRole ?participation ;
+            skos:prefLabel ?bestuurseenheid .
+        OPTIONAL { ?form <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#identifier> ?dossierNummer. }
+    }
+    ORDER BY DESC(?modifiedStep)
+    `;
+    const queryResponse = await query(queryString);
+    const data = queryResponse.results.bindings.map((subsidie) => {
+      return {
+        subsidie: getSafeValue(subsidie, 'subsidie'),
+        bestuurseenheid: getSafeValue(subsidie, 'bestuurseenheid'),
+        modified: getSafeValue(subsidie, 'modifiedStep'),
+        subsidieStatus: getSafeValue(subsidie, 'subsidieStatus'),
+        formStatus: getSafeValue(subsidie, 'formStatus'),
+        dossierNummer: getSafeValue(subsidie, 'dossierNummer'),
+      };
+    });
+
+    await generateReportFromData(data, [
+      'subsidie',
+      'bestuurseenheid',
+      'modified',
+      'subsidieStatus',
+      'formStatus',
+      'dossierNummer'
+    ], reportData);
+  }
+};

--- a/config/reports/index.js
+++ b/config/reports/index.js
@@ -37,6 +37,7 @@ import toezichtTaxRegulationSubmissionReport from './toezicht-tax-regulation-sub
 import planSubsidieProposalsReport from './planSubsidieProposalsReport';
 import ukraineSubsidyOproepOneReport from './ukraineSubsidyOproep1Report';
 import eInclusionRequestReport from './eInclusionRequestReport';
+import fietsSubsidieProposalsDeadlineGemeentenReports from './fietsSubsidieProposalsDeadlineGemeentenReports';
 
 export default [
   BestuurseenhedenReport,
@@ -79,5 +80,6 @@ export default [
   toezichtTaxRegulationSubmissionReport,
   planSubsidieProposalsReport,
   ukraineSubsidyOproepOneReport,
-  eInclusionRequestReport
+  eInclusionRequestReport,
+  fietsSubsidieProposalsDeadlineGemeentenReports
 ];


### PR DESCRIPTION
Modified deadline and criteria for fietssubsidies:
- New deadline is 15/11/2022
- Gemeenten can no longer create new fietssubsidies

Added report to check any forms  (step 1) of gemeenten have been adjusted after deadline
`drc exec report-generation /bin/bash`
`wget -O- --header='Content-Type:application/json' --post-data='{"data":{"attributes":{"reportName":"fietsSubsidieProposalsDeadlineGemeentenReport"}}}' 'http://localhost/reports'`