### PR TITLE
Remove the buggy table of a bicycle subsidy on production

### DIFF
--- a/config/migrations/2022/20221128090000-fix-bicycle-subsidy-bug-production/20221128090000-remove-buggy-bicycle-subsidy-table.sparql
+++ b/config/migrations/2022/20221128090000-fix-bicycle-subsidy-bug-production/20221128090000-remove-buggy-bicycle-subsidy-table.sparql
@@ -1,0 +1,14 @@
+DELETE { GRAPH ?g {
+    ?form <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveTable> ?table.
+    ?table ?tablePreds ?tableObjects.
+    ?entry ?entryPreds ?entryObjects.
+  }
+}
+WHERE { GRAPH ?g {
+    ?form ?mu "61B8C816E4465300080003FD";
+      <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveTable> ?table.
+    ?table ?tablePreds ?tableObjects.
+    ?table <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveEntry> ?entry.
+    ?entry ?entryPreds ?entryObjects.
+  }
+}


### PR DESCRIPTION
Can be tested on production database, Gemeente Harelbeke - bicycle subsidy with project name Harelbeke_Stasegemsesteenweg_GeneraalDeprezstraat.

Can also be tested on another database by creating a bicycle-subsidy and in step 2, fill in the estimated cost table (bottom), save as concept and run the added migration file but changing the mu parameter to the last one in the URL of the subsidy.