### PR TITLE
Fix/skip optional climate subsidie step

### DIFF
--- a/config/migrations/2022/20221130090000-skip-optional-climate-step-callup2021-production.sparql
+++ b/config/migrations/2022/20221130090000-skip-optional-climate-step-callup2021-production.sparql
@@ -1,0 +1,33 @@
+PREFIX subsidie: <http://data.vlaanderen.be/ns/subsidie#>
+PREFIX transactie: <http://data.vlaanderen.be/ns/transactie#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+
+DELETE { GRAPH ?g {
+
+    ?subsidie <http://www.w3.org/2007/uwa/context/common.owl#active> ?o .
+    ?form adms:status ?status .
+  }
+}
+INSERT { GRAPH ?g {
+    ?subsidie <http://www.w3.org/2007/uwa/context/common.owl#active> <http://lblod.data.info/id/subsidie-application-flow-steps/6977011a-a29c-11eb-b62a-7fee2a9561b8> .
+    ?form adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> .
+  }
+}
+WHERE  {
+ ?foo dct:references  <http://data.lblod.info/id/subsidy-procedural-steps/233f0b64-d261-469e-9ef3-e0e2d64d42de> .
+ GRAPH ?g {
+  
+    ?subsidie a subsidie:SubsidiemaatregelConsumptie ;
+      transactie:isInstantieVan <http://lblod.data.info/id/subsidy-measure-offers/64d40351-8128-464f-990f-41066154583e> ;
+      dct:source ?form ;
+      <http://www.w3.org/2007/uwa/context/common.owl#active> ?o .
+
+    ?form dct:isPartOf ?foo ;
+      adms:status ?status.
+    VALUES ?status {
+      <http://lblod.data.gift/concepts/6b7ae118-4653-48f2-9d9a-4712f8c30da9>
+      <http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd>
+    }
+  }
+}

--- a/config/migrations/2022/20221130090000-skip-optional-climate-step-callup2021-production.sparql
+++ b/config/migrations/2022/20221130090000-skip-optional-climate-step-callup2021-production.sparql
@@ -5,7 +5,7 @@ PREFIX adms: <http://www.w3.org/ns/adms#>
 
 DELETE { GRAPH ?g {
 
-    ?subsidie <http://www.w3.org/2007/uwa/context/common.owl#active> ?o .
+    ?subsidie <http://www.w3.org/2007/uwa/context/common.owl#active> <http://lblod.data.info/id/subsidie-application-flow-steps/c50d7726-4880-43e2-b098-c356722a3096> .
     ?form adms:status ?status .
   }
 }
@@ -21,7 +21,7 @@ WHERE  {
     ?subsidie a subsidie:SubsidiemaatregelConsumptie ;
       transactie:isInstantieVan <http://lblod.data.info/id/subsidy-measure-offers/64d40351-8128-464f-990f-41066154583e> ;
       dct:source ?form ;
-      <http://www.w3.org/2007/uwa/context/common.owl#active> ?o .
+      <http://www.w3.org/2007/uwa/context/common.owl#active> <http://lblod.data.info/id/subsidie-application-flow-steps/c50d7726-4880-43e2-b098-c356722a3096> .
 
     ?form dct:isPartOf ?foo ;
       adms:status ?status.


### PR DESCRIPTION
This migration will change all climate subsidies 1 callup 2021 in step 2 to step 3, because this step is optional and after deadline it should be updated.

Before testing this branch, you should query:

```
PREFIX subsidie: <http://data.vlaanderen.be/ns/subsidie#>
PREFIX transactie: <http://data.vlaanderen.be/ns/transactie#>
PREFIX dct: <http://purl.org/dc/terms/>
PREFIX adms: <http://www.w3.org/ns/adms#>

SELECT ?subsidie
WHERE  {
 ?foo dct:references  <http://data.lblod.info/id/subsidy-procedural-steps/233f0b64-d261-469e-9ef3-e0e2d64d42de> .
 GRAPH ?g {
  
    ?subsidie a subsidie:SubsidiemaatregelConsumptie ;
      transactie:isInstantieVan <http://lblod.data.info/id/subsidy-measure-offers/64d40351-8128-464f-990f-41066154583e> ;
      dct:source ?form ;
      <http://www.w3.org/2007/uwa/context/common.owl#active> <http://lblod.data.info/id/subsidie-application-flow-steps/c50d7726-4880-43e2-b098-c356722a3096> .

    ?form dct:isPartOf ?foo ;
      adms:status ?status.
    VALUES ?status {
      <http://lblod.data.gift/concepts/6b7ae118-4653-48f2-9d9a-4712f8c30da9>
      <http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd>
    }
  }
}
```

If this query is empty, you should create a climate subsidy callup 2021 (testMode=true is required) and send the first step, then the second step will render and just close the subsidy so it has status 'Actief - indienen voorstel'. 

Run above command and it should return 1 subsidy. 
After running the branch, the above command should not return anything and if you check in frontend, you will see that the status of those subsidies has been changed to 'Actief - Opvolgmoment'

