### PR TITLE
Feature/representatieve organen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 1.74.2 (2022-12-06)
+### hofix
+#### IPDC
+  - To prepare the export to ipdc, we remove the publication flag.
 ## 1.74.1 (2022-11-29)
 ### hofix
 - attempt to fix load issues

--- a/config/migrations/2022/20221206170512-remove-published-flag-from-lpdc-services.sparql
+++ b/config/migrations/2022/20221206170512-remove-published-flag-from-lpdc-services.sparql
@@ -1,0 +1,16 @@
+PREFIX cpsv: <http://purl.org/vocab/cpsv#>
+PREFIX schema: <http://schema.org/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+
+DELETE {
+  GRAPH ?g {
+  ?publicService schema:publication ?publication.
+  }
+}
+WHERE {
+  GRAPH ?g {
+   ?publicService a cpsv:PublicService;
+     adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c>;
+     schema:publication ?publication.
+  }
+}

--- a/config/migrations/2022/20221207103559-representatiev-organen/20221207103558-add-new-RO-classification.graph
+++ b/config/migrations/2022/20221207103559-representatiev-organen/20221207103558-add-new-RO-classification.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2022/20221207103559-representatiev-organen/20221207103558-add-new-RO-classification.ttl
+++ b/config/migrations/2022/20221207103559-representatiev-organen/20221207103558-add-new-RO-classification.ttl
@@ -1,5 +1,5 @@
 <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>, <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>;
-          mu:uuid "36372fad-0358-499c-a4e3-f412d2eae213"
-          skos:prefLabel "Representatief orgaan"
-          skos:topConceptOf <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode>
-          skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode>, <http://lblod.data.gift/concept-schemes/10caf4a4-1ff5-4c05-917e-56489910d68b>
+          mu:uuid "36372fad-0358-499c-a4e3-f412d2eae213";
+          skos:prefLabel "Representatief orgaan";
+          skos:topConceptOf <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode>;
+          skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode>, <http://lblod.data.gift/concept-schemes/10caf4a4-1ff5-4c05-917e-56489910d68b>.

--- a/config/migrations/2022/20221207103559-representatiev-organen/20221207103558-add-new-RO-classification.ttl
+++ b/config/migrations/2022/20221207103559-representatiev-organen/20221207103558-add-new-RO-classification.ttl
@@ -1,0 +1,5 @@
+<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>, <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>;
+          mu:uuid "36372fad-0358-499c-a4e3-f412d2eae213"
+          skos:prefLabel "Representatief orgaan"
+          skos:topConceptOf <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode>
+          skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode>, <http://lblod.data.gift/concept-schemes/10caf4a4-1ff5-4c05-917e-56489910d68b>

--- a/config/migrations/2022/20221207103559-representatiev-organen/20221207103558-add-new-RO-classification.ttl
+++ b/config/migrations/2022/20221207103559-representatiev-organen/20221207103558-add-new-RO-classification.ttl
@@ -1,3 +1,6 @@
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
 <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> a <http://www.w3.org/2004/02/skos/core#Concept>, <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>, <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>;
           mu:uuid "36372fad-0358-499c-a4e3-f412d2eae213";
           skos:prefLabel "Representatief orgaan";

--- a/config/migrations/2022/20221207103559-representatiev-organen/20221207103559-add-representatieve-organen.graph
+++ b/config/migrations/2022/20221207103559-representatiev-organen/20221207103559-add-representatieve-organen.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2022/20221207103559-representatiev-organen/20221207103559-add-representatieve-organen.ttl
+++ b/config/migrations/2022/20221207103559-representatiev-organen/20221207103559-add-representatieve-organen.ttl
@@ -7,59 +7,59 @@
 <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "e224c637ba8bb0e5dfbb87da225b4652";
   skos:prefLabel "Executief van de Moslims van België";
-  ext:kbonummer "0898.987.189";
+  ext:kbonummer "0898987189";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/859ae3dff21dcfd97e70d180569ebad1> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "859ae3dff21dcfd97e70d180569ebad1";
   skos:prefLabel "Centraal Israëlitische Consistorie van België";
-  ext:kbonummer "0413.234.648";
+  ext:kbonummer "0413234648";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/c98e270d84a8455b2f4bf16b915aeff2> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "c98e270d84a8455b2f4bf16b915aeff2";
   skos:prefLabel "Bisdom Hasselt";
-  ext:kbonummer "0409.771.253";
+  ext:kbonummer "0409771253";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/78dcd875a7f2a7d0b5767c9fd8052efa> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "78dcd875a7f2a7d0b5767c9fd8052efa";
   skos:prefLabel "Bisdom Brugge";
-  ext:kbonummer "0687.815.914";
+  ext:kbonummer "0687815914";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/2089dc85d4ba48a7f28ee4b521af2b26> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "2089dc85d4ba48a7f28ee4b521af2b26";
   skos:prefLabel "Aartsbisdom Mechelen-Brussel";
-  ext:kbonummer "0410.195.380";
+  ext:kbonummer "0410195380";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/2267e8e132b5556bd4d0b454c9383ca0> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "2267e8e132b5556bd4d0b454c9383ca0";
   skos:prefLabel "Bisdom Gent";
-  ext:kbonummer "0409.677.223";
+  ext:kbonummer "0409677223";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/bf83abb71bd810ad1ebe05ac8cb72a1c> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "bf83abb71bd810ad1ebe05ac8cb72a1c";
   skos:prefLabel "Centraal Comité van de Anglicaanse Eredienst in België";
-  ext:kbonummer "0792.962.924";
+  ext:kbonummer "0792962924";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/0ebb44c2ef14d86978ea85e74d128ad1> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "0ebb44c2ef14d86978ea85e74d128ad1";
   skos:prefLabel "Oecumenisch Patriarchaat van Konstantinopel";
-  ext:kbonummer "0655.698.422";
+  ext:kbonummer "0655698422";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/6f79a1b89678b85009484da7c4a104bc> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "6f79a1b89678b85009484da7c4a104bc";
   skos:prefLabel "Administratieve Raad van de Protestants-Evangelische Eredienst (ARPEE)";
-  ext:kbonummer "0864.330.673";
+  ext:kbonummer "0864330673";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/b4d22cde910a7b58b6e4d9c1d3b15fbb> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "b4d22cde910a7b58b6e4d9c1d3b15fbb";
   skos:prefLabel "Bisdom Antwerpen";
-  ext:kbonummer "0408.140.861";
+  ext:kbonummer "0408140861";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .

--- a/config/migrations/2022/20221207103559-representatiev-organen/20221207103559-add-representatieve-organen.ttl
+++ b/config/migrations/2022/20221207103559-representatiev-organen/20221207103559-add-representatieve-organen.ttl
@@ -1,0 +1,64 @@
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#> .
+@prefix ere: <http://data.lblod.info/vocabularies/erediensten/> .
+
+<http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "e224c637ba8bb0e5dfbb87da225b4652";
+  skos:prefLabel "Executief van de Moslims van België";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+
+<http://data.lblod.info/id/representatieveOrganen/859ae3dff21dcfd97e70d180569ebad1> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "859ae3dff21dcfd97e70d180569ebad1";
+  skos:prefLabel "Centraal Israëlitische Consistorie van België";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+
+<http://data.lblod.info/id/representatieveOrganen/c98e270d84a8455b2f4bf16b915aeff2> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "c98e270d84a8455b2f4bf16b915aeff2";
+  skos:prefLabel "Bisdom Hasselt";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+
+<http://data.lblod.info/id/representatieveOrganen/78dcd875a7f2a7d0b5767c9fd8052efa> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "78dcd875a7f2a7d0b5767c9fd8052efa";
+  skos:prefLabel "Bisdom Brugge";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+
+<http://data.lblod.info/id/representatieveOrganen/2089dc85d4ba48a7f28ee4b521af2b26> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "2089dc85d4ba48a7f28ee4b521af2b26";
+  skos:prefLabel "Aartsbisdom Mechelen-Brussel";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+
+<http://data.lblod.info/id/representatieveOrganen/2267e8e132b5556bd4d0b454c9383ca0> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "2267e8e132b5556bd4d0b454c9383ca0";
+  skos:prefLabel "Bisdom Gent";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+
+<http://data.lblod.info/id/representatieveOrganen/45a0c64b0f2ee4ac0fa8c151e6f2209c> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "45a0c64b0f2ee4ac0fa8c151e6f2209c";
+  skos:prefLabel "V.Z.W. “Centrale Raad der Niet-Confessionele Levensbeschouwelijke Gemeenschappen van België”";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+
+<http://data.lblod.info/id/representatieveOrganen/5871503aa86b44cd470f97228a2ce413> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "5871503aa86b44cd470f97228a2ce413";
+  skos:prefLabel "Boeddhistiche Unie van België";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+
+<http://data.lblod.info/id/representatieveOrganen/bf83abb71bd810ad1ebe05ac8cb72a1c> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "bf83abb71bd810ad1ebe05ac8cb72a1c";
+  skos:prefLabel "Centraal Comité van de Anglicaanse Eredienst in België";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+
+<http://data.lblod.info/id/representatieveOrganen/0ebb44c2ef14d86978ea85e74d128ad1> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "0ebb44c2ef14d86978ea85e74d128ad1";
+  skos:prefLabel "Oecumenisch Patriarchaat van Konstantinopel";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+
+<http://data.lblod.info/id/representatieveOrganen/6f79a1b89678b85009484da7c4a104bc> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "6f79a1b89678b85009484da7c4a104bc";
+  skos:prefLabel "Administratieve Raad van de Protestants-Evangelische Eredienst (ARPEE)";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+
+<http://data.lblod.info/id/representatieveOrganen/b4d22cde910a7b58b6e4d9c1d3b15fbb> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
+  mu:uuid "b4d22cde910a7b58b6e4d9c1d3b15fbb";
+  skos:prefLabel "Bisdom Antwerpen";
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .

--- a/config/migrations/2022/20221207103559-representatiev-organen/20221207103559-add-representatieve-organen.ttl
+++ b/config/migrations/2022/20221207103559-representatiev-organen/20221207103559-add-representatieve-organen.ttl
@@ -2,74 +2,64 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix besluit: <http://data.vlaanderen.be/ns/besluit#> .
 @prefix ere: <http://data.lblod.info/vocabularies/erediensten/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
 
 <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "e224c637ba8bb0e5dfbb87da225b4652";
   skos:prefLabel "Executief van de Moslims van België";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  ext:kbonummer "0898.987.189";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/859ae3dff21dcfd97e70d180569ebad1> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "859ae3dff21dcfd97e70d180569ebad1";
   skos:prefLabel "Centraal Israëlitische Consistorie van België";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  ext:kbonummer "0413.234.648";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/c98e270d84a8455b2f4bf16b915aeff2> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "c98e270d84a8455b2f4bf16b915aeff2";
   skos:prefLabel "Bisdom Hasselt";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  ext:kbonummer "0409.771.253";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/78dcd875a7f2a7d0b5767c9fd8052efa> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "78dcd875a7f2a7d0b5767c9fd8052efa";
   skos:prefLabel "Bisdom Brugge";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  ext:kbonummer "0687.815.914";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/2089dc85d4ba48a7f28ee4b521af2b26> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "2089dc85d4ba48a7f28ee4b521af2b26";
   skos:prefLabel "Aartsbisdom Mechelen-Brussel";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  ext:kbonummer "0410.195.380";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/2267e8e132b5556bd4d0b454c9383ca0> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "2267e8e132b5556bd4d0b454c9383ca0";
   skos:prefLabel "Bisdom Gent";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
-
-<http://data.lblod.info/id/representatieveOrganen/45a0c64b0f2ee4ac0fa8c151e6f2209c> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
-  mu:uuid "45a0c64b0f2ee4ac0fa8c151e6f2209c";
-  skos:prefLabel "V.Z.W. “Centrale Raad der Niet-Confessionele Levensbeschouwelijke Gemeenschappen van België”";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
-
-<http://data.lblod.info/id/representatieveOrganen/5871503aa86b44cd470f97228a2ce413> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
-  mu:uuid "5871503aa86b44cd470f97228a2ce413";
-  skos:prefLabel "Boeddhistiche Unie van België";
+  ext:kbonummer "0409.677.223";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/bf83abb71bd810ad1ebe05ac8cb72a1c> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "bf83abb71bd810ad1ebe05ac8cb72a1c";
   skos:prefLabel "Centraal Comité van de Anglicaanse Eredienst in België";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  ext:kbonummer "0792.962.924";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/0ebb44c2ef14d86978ea85e74d128ad1> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "0ebb44c2ef14d86978ea85e74d128ad1";
   skos:prefLabel "Oecumenisch Patriarchaat van Konstantinopel";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  ext:kbonummer "0655.698.422";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/6f79a1b89678b85009484da7c4a104bc> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "6f79a1b89678b85009484da7c4a104bc";
   skos:prefLabel "Administratieve Raad van de Protestants-Evangelische Eredienst (ARPEE)";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  ext:kbonummer "0864.330.673";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/b4d22cde910a7b58b6e4d9c1d3b15fbb> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "b4d22cde910a7b58b6e4d9c1d3b15fbb";
   skos:prefLabel "Bisdom Antwerpen";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  ext:kbonummer "0408.140.861";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .

--- a/config/migrations/2022/20221207103559-representatiev-organen/20221207103559-add-representatieve-organen.ttl
+++ b/config/migrations/2022/20221207103559-representatiev-organen/20221207103559-add-representatieve-organen.ttl
@@ -7,58 +7,69 @@
   mu:uuid "e224c637ba8bb0e5dfbb87da225b4652";
   skos:prefLabel "Executief van de Moslims van België";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/859ae3dff21dcfd97e70d180569ebad1> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "859ae3dff21dcfd97e70d180569ebad1";
   skos:prefLabel "Centraal Israëlitische Consistorie van België";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/c98e270d84a8455b2f4bf16b915aeff2> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "c98e270d84a8455b2f4bf16b915aeff2";
   skos:prefLabel "Bisdom Hasselt";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/78dcd875a7f2a7d0b5767c9fd8052efa> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "78dcd875a7f2a7d0b5767c9fd8052efa";
   skos:prefLabel "Bisdom Brugge";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/2089dc85d4ba48a7f28ee4b521af2b26> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "2089dc85d4ba48a7f28ee4b521af2b26";
   skos:prefLabel "Aartsbisdom Mechelen-Brussel";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/2267e8e132b5556bd4d0b454c9383ca0> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "2267e8e132b5556bd4d0b454c9383ca0";
   skos:prefLabel "Bisdom Gent";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/45a0c64b0f2ee4ac0fa8c151e6f2209c> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "45a0c64b0f2ee4ac0fa8c151e6f2209c";
   skos:prefLabel "V.Z.W. “Centrale Raad der Niet-Confessionele Levensbeschouwelijke Gemeenschappen van België”";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/5871503aa86b44cd470f97228a2ce413> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "5871503aa86b44cd470f97228a2ce413";
   skos:prefLabel "Boeddhistiche Unie van België";
-  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/bf83abb71bd810ad1ebe05ac8cb72a1c> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "bf83abb71bd810ad1ebe05ac8cb72a1c";
   skos:prefLabel "Centraal Comité van de Anglicaanse Eredienst in België";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/0ebb44c2ef14d86978ea85e74d128ad1> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "0ebb44c2ef14d86978ea85e74d128ad1";
   skos:prefLabel "Oecumenisch Patriarchaat van Konstantinopel";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/6f79a1b89678b85009484da7c4a104bc> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "6f79a1b89678b85009484da7c4a104bc";
   skos:prefLabel "Administratieve Raad van de Protestants-Evangelische Eredienst (ARPEE)";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
 
 <http://data.lblod.info/id/representatieveOrganen/b4d22cde910a7b58b6e4d9c1d3b15fbb> a ere:RepresentatiefOrgaan, besluit:Bestuurseenheid;
   mu:uuid "b4d22cde910a7b58b6e4d9c1d3b15fbb";
   skos:prefLabel "Bisdom Antwerpen";
   besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+  besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .

--- a/config/migrations/2022/20221207103559-representatiev-organen/20221207103560-add-mock-users.sparql
+++ b/config/migrations/2022/20221207103559-representatiev-organen/20221207103560-add-mock-users.sparql
@@ -1,0 +1,62 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?persoon a foaf:Person;
+           mu:uuid ?uuidPersoon;
+           foaf:firstName ?classificatie;
+           foaf:familyName ?naam;
+           foaf:member ?bestuurseenheid;
+           foaf:account ?account.
+  ?account a foaf:OnlineAccount;
+           mu:uuid ?uuidAccount;
+           foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+           ext:sessionRole "LoketLB-toezichtGebruiker", "LoketLB-bbcdrGebruiker". 
+           }
+  GRAPH ?g {
+  ?persoon a foaf:Person;
+           mu:uuid ?uuidPersoon;
+           foaf:firstName ?classificatie;
+           foaf:familyName ?naam;
+           foaf:member ?bestuurseenheid;
+           foaf:account ?account.
+  ?account a foaf:OnlineAccount;
+           mu:uuid ?uuidAccount;
+           foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+           ext:sessionRole "LoketLB-toezichtGebruiker", "LoketLB-bbcdrGebruiker".
+          }
+}
+WHERE {
+     ?bestuurseenheid a besluit:Bestuurseenheid;
+     mu:uuid ?uuid;
+     skos:prefLabel ?naam;
+     besluit:classificatie/skos:prefLabel ?classificatie.
+
+     BIND(CONCAT(?classificatie, " ", ?naam) as ?volledigeNaam)
+     BIND(MD5(?volledigeNaam) as ?uuidPersoon)
+     BIND(MD5(CONCAT(?volledigeNaam,"ACCOUNT")) as ?uuidAccount)
+     BIND(IRI(CONCAT("http://data.lblod.info/id/persoon/", ?uuidPersoon)) AS ?persoon)
+     BIND(IRI(CONCAT("http://data.lblod.info/id/account/", ?uuidAccount)) AS ?account)
+     BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/",?uuid)) AS ?g )
+
+     VALUES ?bestuurseenheid  {
+      <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> 
+      <http://data.lblod.info/id/representatieveOrganen/859ae3dff21dcfd97e70d180569ebad1>
+      <http://data.lblod.info/id/representatieveOrganen/c98e270d84a8455b2f4bf16b915aeff2>
+      <http://data.lblod.info/id/representatieveOrganen/78dcd875a7f2a7d0b5767c9fd8052efa>
+      <http://data.lblod.info/id/representatieveOrganen/2089dc85d4ba48a7f28ee4b521af2b26>
+      <http://data.lblod.info/id/representatieveOrganen/2267e8e132b5556bd4d0b454c9383ca0>
+      <http://data.lblod.info/id/representatieveOrganen/45a0c64b0f2ee4ac0fa8c151e6f2209c>
+      <http://data.lblod.info/id/representatieveOrganen/5871503aa86b44cd470f97228a2ce413>
+      <http://data.lblod.info/id/representatieveOrganen/bf83abb71bd810ad1ebe05ac8cb72a1c>
+      <http://data.lblod.info/id/representatieveOrganen/0ebb44c2ef14d86978ea85e74d128ad1>
+      <http://data.lblod.info/id/representatieveOrganen/6f79a1b89678b85009484da7c4a104bc>
+      <http://data.lblod.info/id/representatieveOrganen/b4d22cde910a7b58b6e4d9c1d3b15fbb>
+     }
+}


### PR DESCRIPTION
- adds list of representatieve organen
- adds mock login accounts for those representatieve organen

IMPORTANT/:
- I am assuming the classificatie for those RO are "Centraal bestuur van de eredienst" http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86
- I am assuming the RO's have both the types ere:RepresentatiefOrgaan & besluit:Bestuurseenheid
 
please check that this is actually correct