### PR TITLE
Remove person reconciliation service

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -65,8 +65,6 @@ services:
     restart: "no"
   adressenregister:
     restart: "no"
-  person-reconciliation:
-    restart: "no"
   report-generation:
     restart: "no"
   automatic-submission:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,12 +239,6 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  person-reconciliation:
-    image: lblod/person-reconciliation-service:0.3.0
-    labels:
-      - "logging=true"
-    restart: "no"
-    logging: *default-logging
   report-generation:
     image: lblod/loket-report-generation-service:0.5.0
     links:


### PR DESCRIPTION
This service adds confusion and cahos. It has consequences on consumers getting confused about what's going on. We have to rethink to a better solution.

FYI @cecemel 