### PR TITLE
[Toezicht] Hotfix cronPattern to send submission reports daily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+# 1.76.2 (2023-02-02)
+### Toezicht
+#### backend
+  - hotfix cronPattern for toezicht, submission reports are now daily at 22:30
 ## 1.76.1 (2022-01-26)
 ### Toezicht
 #### frontend

--- a/config/reports/toezicht-submissions-report.js
+++ b/config/reports/toezicht-submissions-report.js
@@ -6,7 +6,7 @@ const metadata = {
 };
 
 export default {
-  cronPattern: '0 0 22 * * 6',
+  cronPattern: '30 22 * * *',
   name: 'toezicht-submissions',
   execute: async () => {
     const startTime = new Date();


### PR DESCRIPTION
DL-4812

Cronjob is now updated to 22:30 daily.
Updating changelog.
Adding a new tag v1.76.2.