### PR TITLE
Add missing subsidy for Deinze Municipality

### DIFF
--- a/config/migrations/2023/20230203114112-add-missing-stadsvernieuwing-subsidy-for-Deinze.sparql
+++ b/config/migrations/2023/20230203114112-add-missing-stadsvernieuwing-subsidy-for-Deinze.sparql
@@ -1,0 +1,35 @@
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX subsidie: <http://data.vlaanderen.be/ns/subsidie#>
+PREFIX gleif: <https://www.gleif.org/ontology/Base/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX cpsv: <http://purl.org/vocab/cpsv#>
+PREFIX common: <http://www.w3.org/2007/uwa/context/common.owl#>
+PREFIX xkos: <http://rdf-vocabulary.ddialliance.org/xkos#>
+PREFIX qb: <http://purl.org/linked-data/cube#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+# Insert only the specific SubsidiemaatregelAanbod and reeks into the graph
+INSERT {
+  GRAPH ?newGraph {
+    ?SubsidiemaatregelAanbod ?p ?o .
+    ?SubsidiemaatregelAanbodReeks ?p1 ?o1 .
+  }
+}
+
+WHERE {
+  BIND(<http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> as ?bestuureenheid) # Gemeente Deinze
+  
+  ?bestuureenheid mu:uuid ?uuid .
+  BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", STR(?uuid), "/LoketLB-subsidies")) as ?newGraph)
+
+  BIND(<http://lblod.data.info/id/subsidy-measure-offers/c10fc76f-effe-430e-822f-60f03f575302> as ?SubsidiemaatregelAanbod) 
+
+  BIND(<http://lblod.data.info/id/subsidy-measure-offer-series/7dab5e94-89d3-4e26-b28a-cc585652786b> as ?SubsidiemaatregelAanbodReeks)
+
+  GRAPH ?g {
+    ?SubsidiemaatregelAanbod ?p ?o .
+    ?SubsidiemaatregelAanbodReeks ?p1 ?o1 .
+  }
+}


### PR DESCRIPTION
(Addresses DL-4814) Add the "stadsvernieuwing" subsidy to "Gemeente Deinze" as it was missing from the previous subsidy migration.