### PR TITLE
bump multiple automatic submission services for correct exposure of vendor-data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,7 +267,7 @@ services:
     restart: always
     logging: *default-logging
   import-submission:
-    image: lblod/import-submission-service:1.1.0
+    image: lblod/import-submission-service:1.2.0
     volumes:
       - ./data/files:/share
     labels:
@@ -275,7 +275,7 @@ services:
     restart: always
     logging: *default-logging
   enrich-submission:
-    image: lblod/enrich-submission-service:1.4.0
+    image: lblod/enrich-submission-service:1.5.0
     environment:
       ACTIVE_FORM_FILE: "share://semantic-forms/20230126155111-forms.ttl"
     volumes:
@@ -286,7 +286,7 @@ services:
     restart: always
     logging: *default-logging
   validate-submission:
-    image: lblod/validate-submission-service:1.1.0
+    image: lblod/validate-submission-service:1.2.0
     environment:
       MAX_BODY_SIZE: "10000kb"
     volumes:
@@ -297,7 +297,7 @@ services:
     restart: always
     logging: *default-logging
   toezicht-flattened-form-data-generator:
-    image: lblod/toezicht-flattened-form-data-generator:1.1.0
+    image: lblod/toezicht-flattened-form-data-generator:1.2.0
     volumes:
       - ./data/files/submissions:/share/submissions
     labels:


### PR DESCRIPTION
In the submission flow, all sudo calls should calculate the correct graph to insert data into
The data distribution services exposes potentially too much data. 
There is currently no more elegant way then to calculate ?g correctly.