### PR TITLE
Add Climate 2.1 subsidy for a specific list of governments

### DIFF
--- a/config/migrations/2023/20230215141257-set-up-climate-2-1-subsidy-for-specific-list-of-governments.sparql
+++ b/config/migrations/2023/20230215141257-set-up-climate-2-1-subsidy-for-specific-list-of-governments.sparql
@@ -1,0 +1,333 @@
+PREFIX mobiliteit:    <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>
+PREFIX dct:           <http://purl.org/dc/terms/>
+PREFIX subsidie:      <http://data.vlaanderen.be/ns/subsidie#>
+PREFIX gleif:         <https://www.gleif.org/ontology/Base/>
+PREFIX mu:            <http://mu.semte.ch/vocabularies/core/>
+PREFIX cpsv:          <http://purl.org/vocab/cpsv#>
+PREFIX common:        <http://www.w3.org/2007/uwa/context/common.owl#>
+PREFIX xkos:          <http://rdf-vocabulary.ddialliance.org/xkos#>
+PREFIX qb:            <http://purl.org/linked-data/cube#>
+PREFIX m8g:	          <http://data.europa.eu/m8g/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+     # Period of the Series
+    <http://data.lblod.info/id/periodes/46e05ff6-08f4-4ff9-a831-8897de75f25c>
+        a             m8g:PeriodOfTime ;
+        mu:uuid       "46e05ff6-08f4-4ff9-a831-8897de75f25c" ;
+        m8g:startTime "2023-01-01T03:00:00Z"^^xsd:dateTime ;
+        m8g:endTime   "2024-12-31T22:59:00Z"^^xsd:dateTime .
+
+    # Period of step Indienen pact
+    <http://data.lblod.info/id/periodes/33f16980-1d9b-49b9-b26c-d595ecb8689f>
+        a             m8g:PeriodOfTime ;
+        mu:uuid       "33f16980-1d9b-49b9-b26c-d595ecb8689f" ;
+        m8g:startTime "2023-02-15T03:00:00Z"^^xsd:dateTime ;
+        m8g:endTime   "2023-06-05T21:59:00Z"^^xsd:dateTime .
+
+    # Period of step Opvolgmoment
+    <http://data.lblod.info/id/periodes/f8e73b21-7231-494c-93b6-8f58bf69b0bd>
+        a             m8g:PeriodOfTime ;
+        mu:uuid       "f8e73b21-7231-494c-93b6-8f58bf69b0bd" ;
+        m8g:startTime "2023-02-15T03:00:00Z"^^xsd:dateTime ;
+        m8g:endTime   "2025-04-01T22:59:00Z"^^xsd:dateTime .
+
+    # Subsidy Procedural Step (Indienen pact)
+    <http://data.lblod.info/id/subsidy-procedural-steps/a9a20ff7-a727-4b92-8d16-dac36b0c27cd>
+        a                   subsidie:Subsidieprocedurestap ;
+        mu:uuid             "a9a20ff7-a727-4b92-8d16-dac36b0c27cd" ;
+        dct:description     """Indienen pact""" ;
+        mobiliteit:periode  <http://data.lblod.info/id/periodes/33f16980-1d9b-49b9-b26c-d595ecb8689f> .
+
+    # Subsidy Procedural Step (Opvolgmoment)
+    <http://data.lblod.info/id/subsidy-procedural-steps/be1168a8-5131-4adb-a913-a4147bd8c6f5>
+        a                                   subsidie:Subsidieprocedurestap ;
+        mu:uuid                             "be1168a8-5131-4adb-a913-a4147bd8c6f5" ;
+        dct:description                     """Opvolgmoment""" ;
+        subsidie:Subsidieprocedurestap.type <http://lblod.data.gift/concepts/ee855aae-eb10-44aa-ae01-38c4f6cca0f6> ; # Mark as last procedural step
+        mobiliteit:periode                  <http://data.lblod.info/id/periodes/f8e73b21-7231-494c-93b6-8f58bf69b0bd> .
+
+    # Subsidy Active Submission Flow Step 0
+    <http://data.lblod.info/id/subsidie-application-flow-steps/d598df32-c36a-4847-ae7c-cbb0f91a9926>
+        a               lblodSubsidie:ApplicationStep ;
+        mu:uuid         "d598df32-c36a-4847-ae7c-cbb0f91a9926" ;
+        qb:order        0 ;
+        xkos:next       <http://data.lblod.info/id/subsidie-application-flow-steps/02691ee9-2eba-448a-a1b1-2416c90ad42d> ;
+        dct:references  <http://data.lblod.info/id/subsidy-procedural-steps/a9a20ff7-a727-4b92-8d16-dac36b0c27cd> ;
+        dct:isPartOf    <http://data.lblod.info/id/subsidie-application-flows/d8010cdb-d2f1-403b-8eab-d2eb7cd572ed> ;
+        dct:source      <config://forms/climate-2-1/step-submit-pact/versions/20230215141257/form.ttl> .
+
+    # Subsidy Active Submission Flow Step 1
+    <http://data.lblod.info/id/subsidie-application-flow-steps/02691ee9-2eba-448a-a1b1-2416c90ad42d>
+        a               lblodSubsidie:ApplicationStep ;
+        mu:uuid         "02691ee9-2eba-448a-a1b1-2416c90ad42d" ;
+        qb:order        1 ;
+        xkos:previous   <http://data.lblod.info/id/subsidie-application-flow-steps/d598df32-c36a-4847-ae7c-cbb0f91a9926> ;
+        dct:references  <http://data.lblod.info/id/subsidy-procedural-steps/be1168a8-5131-4adb-a913-a4147bd8c6f5> ;
+        dct:isPartOf    <http://data.lblod.info/id/subsidie-application-flows/d8010cdb-d2f1-403b-8eab-d2eb7cd572ed> ;
+        dct:source      <config://forms/climate-2-1/step-submit-opvolgmoment/versions/20230215141257/form.ttl> .
+
+    # Subsidy Active Submission Flow
+    <http://data.lblod.info/id/subsidie-application-flows/d8010cdb-d2f1-403b-8eab-d2eb7cd572ed>
+        a               lblodSubsidie:ApplicationFlow ;
+        mu:uuid         "d8010cdb-d2f1-403b-8eab-d2eb7cd572ed" ;
+        xkos:belongsTo  <http://data.lblod.info/id/subsidy-measure-offer-series/a04b604a-86c6-49c0-8b70-1910e3fdfa4c> ;
+        xkos:next       <http://data.lblod.info/id/subsidie-application-flow-steps/d598df32-c36a-4847-ae7c-cbb0f91a9926> .
+  }
+}
+
+;
+
+INSERT {
+  # Insert SubsidiemaatregelAanbod and SubsidiemaatregelAanbodReeks into the graphs
+  # of the local governments listed below, so that they can only be visible to them.
+  GRAPH ?newGraph {
+    # Create Series for subsidy call named "2023 - 2024"
+    <http://data.lblod.info/id/subsidy-measure-offer-series/a04b604a-86c6-49c0-8b70-1910e3fdfa4c>
+        a                                         lblodSubsidie:SubsidiemaatregelAanbodReeks ;
+        mu:uuid                                   "a04b604a-86c6-49c0-8b70-1910e3fdfa4c" ;
+        dct:title                                 "2023 - 2024"@nl ;
+        dct:description                           "01/01/2023 - 31/12/2024"@nl ;
+        mobiliteit:periode                        <http://data.lblod.info/id/periodes/46e05ff6-08f4-4ff9-a831-8897de75f25c> ;
+        lblodSubsidie:heeftSubsidieprocedurestap  <http://data.lblod.info/id/subsidy-procedural-steps/a9a20ff7-a727-4b92-8d16-dac36b0c27cd> ;
+        lblodSubsidie:heeftSubsidieprocedurestap  <http://data.lblod.info/id/subsidy-procedural-steps/be1168a8-5131-4adb-a913-a4147bd8c6f5> ;
+        common:active                             <http://data.lblod.info/id/subsidie-application-flows/d8010cdb-d2f1-403b-8eab-d2eb7cd572ed> .
+
+    # Subsidy Offer for Climate 2.1
+     <http://data.lblod.info/id/subsidy-measure-offers/8815fe07-e53f-4657-94be-efaa4898f03c>
+      a                         <http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelAanbod> ;
+      mu:uuid                   "8815fe07-e53f-4657-94be-efaa4898f03c" ;
+      dct:title                 """Lokaal Energie- en Klimaatpact 2.1""" ;
+      skos:prefLabel            """Lokaal Energie- en Klimaatpact 2.1""" ;
+      skos:related              <https://www.vvsg.be/kennisitem/vvsg/lokaal-energie-en-klimaatpact> ;
+      m8g:hasCriterion          <http://data.lblod.info/id/criterions/f5ea0615-0b0a-47db-a38c-6097ff80815d> ; # Available only for "gemeenten"
+      cpsv:follows              <http://data.lblod.info/id/subsidy-procedural-steps/a9a20ff7-a727-4b92-8d16-dac36b0c27cd> ;
+      cpsv:follows              <http://data.lblod.info/id/subsidy-procedural-steps/be1168a8-5131-4adb-a913-a4147bd8c6f5> ;
+      lblodSubsidie:heeftReeks  <http://data.lblod.info/id/subsidy-measure-offer-series/a04b604a-86c6-49c0-8b70-1910e3fdfa4c> .
+ }
+}
+WHERE {
+  # A list of local governments who applied for the Climate 2.0 subsidy. These governments are the only entities
+  # allowed to apply for the new Climate 2.1 subsidy. 
+  VALUES ?bestuurseenheid {
+    <http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4> # Aalst
+    <http://data.lblod.info/id/bestuurseenheden/38dc63f50a4f7ea61ef741d8944a874a59ba84b69b9ff3e73f69680da2c6ef37> # Aartselaar
+    <http://data.lblod.info/id/bestuurseenheden/8af37430f91603017873dbc1390eccf364bf82854f7358e9c9845498b184660f> # Alken
+    <http://data.lblod.info/id/bestuurseenheden/670db1d66c0de3b931962e1044033ccfa9d6e3023aa9828a5f252c3bc69bd32c> # Antwerpen
+    <http://data.lblod.info/id/bestuurseenheden/8662dc060c121e9d69101062f67daeef8370d38bfe86533752b9e54190dd0e2f> # Anzegem
+    <http://data.lblod.info/id/bestuurseenheden/0a71e2b47c58e6d13ac628f733863543b791869395afcfe5b5c82c98ff894e3d> # Arendonk
+    <http://data.lblod.info/id/bestuurseenheden/c2c19bec2f337e69a4c9838eacd88041734db523df4f7534cf407c9d380b64b8> # As
+    <http://data.lblod.info/id/bestuurseenheden/0d2e643f4635d2b4d2fc75241a1624013b274c7ffbe8f8a5f36f2bf250336863> # Asse
+    <http://data.lblod.info/id/bestuurseenheden/e971816acb021c37576835e6a96922442628956fd029d885fd849c9f07414469> # Assenede
+    <http://data.lblod.info/id/bestuurseenheden/a6fae65d377aa9e3f2575d4bc0f7cf53df2b5e80ca1823433885557ff0b18834> # Baarle-Hertog
+    <http://data.lblod.info/id/bestuurseenheden/6d323b27377e803eccb4261e8014f5198bba924b7ec3d7d7fa2d2a3a41f7e0f2> # Balen
+    <http://data.lblod.info/id/bestuurseenheden/530983bec9d00f1ab745b2eec290d35200c1011c592bd5694782680bf055092b> # Beerse
+    <http://data.lblod.info/id/bestuurseenheden/696a100b72d304a89de34ac2f10c9ebbfc82268297f201feca5d60b51c8b883a> # Beersel
+    <http://data.lblod.info/id/bestuurseenheden/780e50a94a76c850a8f88c7e01427de38b445dcc6ebe79815a6d0f44adc530bc> # Bekkevoort
+    <http://data.lblod.info/id/bestuurseenheden/1490ca18f894573f76065dc4fdfa2f9c0bcb00964a6af2e21ff8a81e9f1d1198> # Beringen
+    <http://data.lblod.info/id/bestuurseenheden/18eb574437cc9fa5af24990f495aaed7af868d33341faf60cffa2ee0e57dc914> # Berlaar
+    <http://data.lblod.info/id/bestuurseenheden/5d814bf5ab1e7ef33db393cb938315910c262743afed3a464e93c1aa25f12e20> # Berlare
+    <http://data.lblod.info/id/bestuurseenheden/4f0eb4436c88cf831c35f84e7c34ce32f9ee4e99c5139aff62990e5e531aa1e7> # Beveren
+    <http://data.lblod.info/id/bestuurseenheden/6377f53f54990033c90de6101e263f4d9e41eb7c3e4f70dec48caccefc253760> # Blankenberge
+    <http://data.lblod.info/id/bestuurseenheden/bb749fce340952ed57a7055edbec4c7a0aec9b2623ab5c41997eb4b013287997> # Bocholt
+    <http://data.lblod.info/id/bestuurseenheden/c26acb21f9fef0843d93523827562f96a6ccd939dfa43ad1dd70dcb8064c40a4> # Boechout
+    <http://data.lblod.info/id/bestuurseenheden/156dad76d5d8e30d26b501d715fd237b38cbae60e76753a09d897fd317ab914c> # Bonheiden
+    <http://data.lblod.info/id/bestuurseenheden/43d5a7c66986ee2e88090b3988ea0179ad4abf5bbfb8864fc44012aa181d0e4d> # Boom
+    <http://data.lblod.info/id/bestuurseenheden/b942231860865ab0c4108651b117f69a755a04186df97e767707e5d95955ebbd> # Boortmeerbeek
+    <http://data.lblod.info/id/bestuurseenheden/05441122597e0b20b61a8968ea1247c07f9014aad1f1f0709d0b1234e3dfbc2f> # Borgloon
+    <http://data.lblod.info/id/bestuurseenheden/f0326d3687d05c2e41ddbfaee635ce7ecb00eddc81454e58eb5fc8c66f511629> # Bornem
+    <http://data.lblod.info/id/bestuurseenheden/e41ffa04f94bb450a79793020e70d55b5fee5033a5280277998608a9d0913117> # Borsbeek
+    <http://data.lblod.info/id/bestuurseenheden/920b64f03ced3fc044fcdf5493bbb99573a4213f921dc92509581cea87d7a80f> # Boutersem
+    <http://data.lblod.info/id/bestuurseenheden/25fc615f81f2032ee7126108474e842b418c890c3755f9e1efc58ac6dc59d1fc> # Brasschaat
+    <http://data.lblod.info/id/bestuurseenheden/c73ee91f068da28ed1f16fb057f38808e7c0d29f4c5b8b9d7b2eec235ed4d5a4> # Brecht
+    <http://data.lblod.info/id/bestuurseenheden/d7187635377e73d8cdd7e2743257bf93742a82f700e6839eb12a3e3705ac36c5> # Bree
+    <http://data.lblod.info/id/bestuurseenheden/28346950e285b8b816133fece5ac9408097c3f190c7f32573cf0c640d6c34b1a> # Brugge
+    <http://data.lblod.info/id/bestuurseenheden/788f5e9af7c2e5e158bb9b72d7cababff6d4a871c5b63f346c8fcedefed33905> # Damme
+    <http://data.lblod.info/id/bestuurseenheden/e39bc997aa6dd9f240277735efd745b6a0422614d2b36cf01825c86b1b91a9ee> # De Pinte
+    <http://data.lblod.info/id/bestuurseenheden/d2d0cd89d307fb651e2d0d064a89134dbc2f26b0ffacd92d2d71e9683468a206> # Deerlijk
+    <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8>                             # Deinze
+    <http://data.lblod.info/id/bestuurseenheden/856cbc8af3fbe7390d43420e249c288596e87fbc069c601751d5c5fcd52c543b> # Denderleeuw
+    <http://data.lblod.info/id/bestuurseenheden/a605a770e69d0af2d501614a41b446c76328d2f32165be238458468fbd5f8b88> # Dendermonde
+    <http://data.lblod.info/id/bestuurseenheden/b40be11d4f04a2e0fff76e8feae92471963c063e2d65a68210dab2707ac62726> # Dessel
+    <http://data.lblod.info/id/bestuurseenheden/d8f7f1849303f3bd250d476ee5b44456d42b4d2f79f8f72b0be754484cb5fda4> # Diepenbeek
+    <http://data.lblod.info/id/bestuurseenheden/a863212dae496f3c67044c214843841e636f373fb1c97a46fef3ef82d77ac925> # Diksmuide
+    <http://data.lblod.info/id/bestuurseenheden/dcacdef6115b1c15bbaf8559ad4fbc3b694a12af37c178ac54227a630d2ead34> # Dilsen-Stokkem
+    <http://data.lblod.info/id/bestuurseenheden/c42e0bde83126aaa67ed2c4b3ff5f5b42ae5023075e707c85369345195c79a43> # Duffel
+    <http://data.lblod.info/id/bestuurseenheden/b456cda7fa9b2b176adb216e5598aeeb60ff19753a5a08ade6ffd32e9a0ead89> # Edegem
+    <http://data.lblod.info/id/bestuurseenheden/d9267014daa2764a9edd3b176678b56f57474ffe162363795690e5c684c6eab1> # Erpe-Mere
+    <http://data.lblod.info/id/bestuurseenheden/23d04e951dabc6c108803eac7e8faf08c639ba6984d1cda170f09fbd8a511855> # Evergem
+    <http://data.lblod.info/id/bestuurseenheden/764278b3ceac360476b418c108d1b022b6e0cc8fb676f3f6b6b9faf78a2375ba> # Geel
+    <http://data.lblod.info/id/bestuurseenheden/243e6582a03e891c3a30a3e5db7552c83e703a609f82e1c5db8844a7ad1c8924> # Geetbets
+    <http://data.lblod.info/id/bestuurseenheden/09f5b10fbd078fcb1e0e4910d32e47146a5eb31d8138dcbaec798309e64dd059> # Genk
+    <http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5> # Gent
+    <http://data.lblod.info/id/bestuurseenheden/71e6c6f58d20f6db457245a70394f2d63f601a32f8ccbc7e443e98f8d06b0b0e> # Geraardsbergen
+    <http://data.lblod.info/id/bestuurseenheden/1d2b18c49b345b619afdaaae22a13bf31156ef06417399fd59bbc321f15d228b> # Gingelom
+    <http://data.lblod.info/id/bestuurseenheden/5efa0b9c06f5b70b071e539047bd847dff555b9ce51c1b86b263018a610f5820> # Gistel
+    <http://data.lblod.info/id/bestuurseenheden/25c9ed309395f3dafc25ae14e5fd515a729f260eda74fa2ab8b3cb02adb85c84> # Grimbergen
+    <http://data.lblod.info/id/bestuurseenheden/f4641f7ba21f1a575993f1b523fb581af12269164006abeab121886037ac0cad> # Grobbendonk
+    <http://data.lblod.info/id/bestuurseenheden/2ad0d123f4a81787572342c394a1917b81752f42d802d1e013941f56b53bdd2a> # Haacht
+    <http://data.lblod.info/id/bestuurseenheden/a4509bc9057f893f626626a7eadd0c713eea564c9c948efdafdfae9a1c153771> # Haaltert
+    <http://data.lblod.info/id/bestuurseenheden/e84ba36959d82fc95bb17b25d2e70c135d8805737ba27bab572af670a2768338> # Halle
+    <http://data.lblod.info/id/bestuurseenheden/05099fa1f6524b8b994d86f61549455d2c00b2a956d5308683ac2d1f810fc729> # Ham
+    <http://data.lblod.info/id/bestuurseenheden/290c4b53b407dcb12457bd32c9c33e521f9a43e8743a64b02294c72d114ec6b7> # Hamme
+    <http://data.lblod.info/id/bestuurseenheden/bcf3f79bcb96133312dbdc63dd157caabd3329358ed4440a03ce6d6fc6af09d2> # Hamont-Achel
+    <http://data.lblod.info/id/bestuurseenheden/6463c55877def582f642cb5b3b4a7eab60d8d8dd9779fc45d87e4c8aa5d9a07e> # Harelbeke
+    <http://data.lblod.info/id/bestuurseenheden/9db1b46874a57fe63c08fb5f16b117e6f61fdd98e7f64f745d0fceb9d3731169> # Hasselt
+    <http://data.lblod.info/id/bestuurseenheden/9574bd4a68b1f9243f10b6e5e5c973f4e957c96cd15f57057d2966036fb1a7fd> # Hechtel-Eksel
+    <http://data.lblod.info/id/bestuurseenheden/c5b139c66d86282381b3eb0ae4da68252d6eaf974e310fa5d200601b7cb69070> # Heers
+    <http://data.lblod.info/id/bestuurseenheden/763adc09114dd8d54a1c8bfabeaec5e5ce543d858c3dff057a1c39f9103249a0> # Heist-op-den-Berg
+    <http://data.lblod.info/id/bestuurseenheden/56423901b281897688074e6ce6811a6a33eec4070da7e22c4fae65050d7b712f> # Herent
+    <http://data.lblod.info/id/bestuurseenheden/70b79f6678036bf05e970aa3885d1779f143d4eab63ecf339ea6263e7e76ad1d> # Herentals
+    <http://data.lblod.info/id/bestuurseenheden/8620c62b9e51d2275c98cb724ce4b6784b432db8e1e0376ac70cbda098ea0d0a> # Herenthout
+    <http://data.lblod.info/id/bestuurseenheden/a9e63c13a602de3cc5463cc81eee0b8d80d14a1846d1deb82b3a2d4e7efc96af> # Herk-de-Stad
+    <http://data.lblod.info/id/bestuurseenheden/1b983548dc44e39bc920a7a8ec1901b692a664865d5fee5133ae96e7281eca6f> # Herselt
+    <http://data.lblod.info/id/bestuurseenheden/19a90656ebde5754d524ca8a17d06b857a6392b0b3db57dd24f899a1b71eda7d> # Herzele
+    <http://data.lblod.info/id/bestuurseenheden/2fb596ee22eb20999478e63cfb8f270ab00e4336e34442c031471293ca6f92e8> # Heusden-Zolder
+    <http://data.lblod.info/id/bestuurseenheden/42887f141929197c227828071ec7dec4cb5435794fedfc7fcf901648e0ea4742> # Hoegaarden
+    <http://data.lblod.info/id/bestuurseenheden/3f2f378a666a52e74cb283fa75718e27d7f3adbf16ffcab02dac203a9f756721> # Hoeilaart
+    <http://data.lblod.info/id/bestuurseenheden/0c2d775df43f87d2048eb26c322d1bc9423e0a3f0ee7ceefd2011cdb077f12df> # Holsbeek
+    <http://data.lblod.info/id/bestuurseenheden/d168033a9bac278fa744c425e078eeabd304397f953feaaf5327b4e039aecacb> # Hooglede
+    <http://data.lblod.info/id/bestuurseenheden/69af2347b1d0a9a39dbcf0ea4d94b9eaa15edb0c7d2dba56bbd9c39ab1c80e9f> # Horebeke
+    <http://data.lblod.info/id/bestuurseenheden/d760812063231cc45ced3fa65a7cd54920329178c8df7e891aa12db442e6606a> # Houthalen-Helchteren
+    <http://data.lblod.info/id/bestuurseenheden/003e84121111866af60611a59e13d4c478718f60472655936edec1e352a34c5f> # Huldenberg
+    <http://data.lblod.info/id/bestuurseenheden/6adc5e4321b234c5e026c9b785435c791733fe13655cb3dad402af6b73534516> # Ichtegem
+    <http://data.lblod.info/id/bestuurseenheden/3b6163727a5930106e631885999aa8e1dbd24eaf1931367b7f38123a89f14f10> # Ieper
+    <http://data.lblod.info/id/bestuurseenheden/6a56d8c050b6c2a76912c5f6ec3859b939de6d990815f35403e5be41a7703a44> # Izegem
+    <http://data.lblod.info/id/bestuurseenheden/53eb88088ce2822bcef97df5f71154045e113b750c6b97b29793a29c4f0ac7b4> # Jabbeke
+    <http://data.lblod.info/id/bestuurseenheden/c7ff21a1a6c315ca5aec2b136ffcf0d9d285dd37a1d5b10d8d134bb714e8d774> # Kalmthout
+    <http://data.lblod.info/id/bestuurseenheden/5679c9292547a19a6186dfccb4047045f8a9c4d24435a6daf45226b3d675558f> # Kampenhout
+    <http://data.lblod.info/id/bestuurseenheden/7d457bc3985fbb70ba748c121043c89d498a3926e8c59ffdf9438c2896791248> # Kapellen
+    <http://data.lblod.info/id/bestuurseenheden/2d6f7aa09c55d347a56da51c583f762843fca5da4acd824ee2dede879a197a7a> # Kasterlee
+    <http://data.lblod.info/id/bestuurseenheden/44c5d81bf86b888159e3c2ee2cf3fd39e4afd58c73edc27245111c8a32bf5fa0> # Keerbergen
+    <http://data.lblod.info/id/bestuurseenheden/5ee75cb5b6f031391189ad0f6ce6fefbc35f7fbfe1e50b7ab57dcab25ccfa139> # Kinrooi
+    <http://data.lblod.info/id/bestuurseenheden/92fd2a12bdcc24f8e6ef34de765d54b3d7a0412b69c0877836cbe3098a5caf57> # Kluisbergen
+    <http://data.lblod.info/id/bestuurseenheden/6cec176758a515b339ebca3b863b8f2b7caf7da58d329ebceee830ab6518bd86> # Knokke-Heist
+    <http://data.lblod.info/id/bestuurseenheden/c1c28cd9e31c25100374482b71b951d5be9b849454b1bd7e1a5158a589bda5de> # Kortenaken
+    <http://data.lblod.info/id/bestuurseenheden/e580b3ee33ff28d93f803e7f70cdb1d99bf6ae9d56b0f630fd7b6837adf8cd4c> # Kortenberg
+    <http://data.lblod.info/id/bestuurseenheden/f6b131de5e40a0dfd4fc93fedf3b95c9bf156ece718b87fe00469dea2564b3fb> # Kortessem
+    <http://data.lblod.info/id/bestuurseenheden/8fd5ea9aeb61c45ec79986650bee55142b2f8a599d5d611dd578114216a58430> # Kortrijk
+    <http://data.lblod.info/id/bestuurseenheden/3f1ec7f1afc4cc466bb3a7fe5bc43199bf600963ec3231e1480a23d103a438a7> # Kuurne
+    <http://data.lblod.info/id/bestuurseenheden/4e6d15d5c7fd95c996087bb13cdee985f0b550256be745024d5facd1485df284> # Laakdal
+    <http://data.lblod.info/id/bestuurseenheden/32ff6774dcd0547c842f7b065f7b1f9441fba0ea2b2586700a0426795787b2f5> # Laarne
+    <http://data.lblod.info/id/bestuurseenheden/bd2cfcb37561afe84b4f8b1894bf7e0f204b21931b6f9ae1d5dbbafcb6681c9b> # Lanaken
+    <http://data.lblod.info/id/bestuurseenheden/08e1b1e460bc9a9dfbd6570ab96a6b4813fbd4d9df2294dad86b11d9e4093d32> # Langemark-Poelkapelle
+    <http://data.lblod.info/id/bestuurseenheden/a277d61f41cf0025df3e51df800c9551a27c80e2515c32aabbbbbc2c818852eb> # Lebbeke
+    <http://data.lblod.info/id/bestuurseenheden/955a75560dd7c57fb9b882b0e92826ab06d77f1a4fc2722b4421389d47a247f3> # Ledegem
+    <http://data.lblod.info/id/bestuurseenheden/d82b46992186c404b09e13b47502a8ab420c8f72316f1819847b1be44ba6314e> # Lendelede
+    <http://data.lblod.info/id/bestuurseenheden/931a2bf4f5c461d8c3636b446fa642693d4535d865d3af068e87d25ddc93374e> # Lennik
+    <http://data.lblod.info/id/bestuurseenheden/72f67d3444ab98d389f85fa57939aad373269bfe15dd47aa6c1a9a24ce1a746b> # Leopoldsburg
+    <http://data.lblod.info/id/bestuurseenheden/c648ea5d12626ee3364a02debb223908a71e68f53d69a7a7136585b58a083e77> # Leuven
+    <http://data.lblod.info/id/bestuurseenheden/319016d52cb54b416721b0c5fc74f211fdd4dd576d13a34aa9210759401dc7f2> # Lier
+    <http://data.lblod.info/id/bestuurseenheden/02c739446ed9f2585fd96cb4c25743106462a589aa6d6f3e5feb088f025e6851> # Lierde
+    <http://data.lblod.info/id/bestuurseenheden/57b1646f-bf4c-4dc4-8bc9-6ec8a6486018>                             # Lievegem
+    <http://data.lblod.info/id/bestuurseenheden/5db8cd4f01b90c3dfc31f5d2b5e931cfdd9116a779790ee55cb71cd314c5a4bb> # Lille
+    <http://data.lblod.info/id/bestuurseenheden/a71e8220eac329de3fca638aa1b8236309730ef15de41e7f84820d50b582a5ca> # Linter
+    <http://data.lblod.info/id/bestuurseenheden/2ac1bb2a7d7bbd98e2e7a24be2c67e42171788a71c2436a33060626593bb2f78> # Lochristi
+    <http://data.lblod.info/id/bestuurseenheden/cb2a6e0a490ee881ddd0d9ded7f2b3d1dc2df7e57a19d014caac054bfa355f5a> # Lokeren
+    <http://data.lblod.info/id/bestuurseenheden/d8247b68bb62c768c36308fbd7203c58038e249b8363da29d223aa6cd97cf242> # Lommel
+    <http://data.lblod.info/id/bestuurseenheden/169b6bfa2d8ee340f266af26d1a6055182214082dca720b8817d3893692f3068> # Londerzeel
+    <http://data.lblod.info/id/bestuurseenheden/1086df7c6c150e427fc56e2239eed2b7e2d9d4a97abb24c00e951ec89f9bcbec> # Lo-Reninge
+    <http://data.lblod.info/id/bestuurseenheden/bfdf2304f758f547ffb7c7afd4e6358290778642104f73910eadb0fb103152fe> # Lummen
+    <http://data.lblod.info/id/bestuurseenheden/7aa957d6377d45bf9e2a1dbaf7524d01b1999cf0cc5bc8c4f4a2380e13ef096e> # Maaseik
+    <http://data.lblod.info/id/bestuurseenheden/a10d7dc2599e3ab6854fc83d1023224eda8cfbc62017d4a1a82bedef7a03b8e4> # Maasmechelen
+    <http://data.lblod.info/id/bestuurseenheden/4adb22348ac4f9e8aa3872c9366df56df12fcb49a854eac06b4c6ab3625bb75f> # Machelen
+    <http://data.lblod.info/id/bestuurseenheden/71d2d00fdfc37c325895247f203ff4e4ed04cdb756413f5837d64854cc91f7c6> # Maldegem
+    <http://data.lblod.info/id/bestuurseenheden/be278471a2a318edba32e7ac4294c0eafbe4c8077a34dcbb9c2e43211d4a78a6> # Mechelen
+    <http://data.lblod.info/id/bestuurseenheden/514bd3d6ba551d4b2a7e866c7dafd65e371acd75240dc92610590c5804c641df> # Meerhout
+    <http://data.lblod.info/id/bestuurseenheden/c0b6b5cf198cd939251dff8ed052177cfff245074c6b8d43394c8c97f7b6e945> # Melle
+    <http://data.lblod.info/id/bestuurseenheden/c94741a612946db4bffa00439a515a831c7d4de0d09d79538af2a1dd781500ca> # Menen
+    <http://data.lblod.info/id/bestuurseenheden/484b4d65dee04db442889741026527199e484ad1249a9a96401b45718d6d497b> # Merchtem
+    <http://data.lblod.info/id/bestuurseenheden/a510e5ebd5798668f45080e36762539bd3bc5d5b5f05c5e1e7ecaf27e481ad31> # Merksplas
+    <http://data.lblod.info/id/bestuurseenheden/5a4b2b4f1de1f3b91b0348a7eb6d6aa0ef9420b8ec31374970c9ffe933a79515> # Meulebeke
+    <http://data.lblod.info/id/bestuurseenheden/55155a78bd145df7bfa3caaa17ba491fb4dd238f4f4d2c5485bff1be96ca3036> # Mol
+    <http://data.lblod.info/id/bestuurseenheden/95e51e4c874a9db9ab6fef81453b1d64531c4c5daaff47b24d266e3ac032d759> # Moorslede
+    <http://data.lblod.info/id/bestuurseenheden/0327a51548f73607f8a5ec11b36711a3c96703686ad93a3d632718c135c295db> # Nazareth
+    <http://data.lblod.info/id/bestuurseenheden/0efaaec80a4ad0328aebadee1ad36a787adff5e31490795ea411fb3644be7f60> # Niel
+    <http://data.lblod.info/id/bestuurseenheden/1f1e0b8819cb311774b62e85f5d701fcd0a50410894da331687b66b4ce3e96c5> # Nieuwerkerken
+    <http://data.lblod.info/id/bestuurseenheden/f4a187c72e551b9d7745e3b8602b11f12ce0fd5399c7f8aebbd4f8f42dc9c028> # Nieuwpoort
+    <http://data.lblod.info/id/bestuurseenheden/fb4ab93def093fcefdcbafe1055941c02bb109290fffb9cd9012d549aed480b8> # Nijlen
+    <http://data.lblod.info/id/bestuurseenheden/9a187d228c5c22e402cb2186f731a5b7cce9549d3fac1e667ce59a3cb80b76c0> # Ninove
+    <http://data.lblod.info/id/bestuurseenheden/80c5a6a8789862c171c8d33ae28cb0649b4a0186114eb49ed36dc28ea515604b> # Olen
+    <http://data.lblod.info/id/bestuurseenheden/764a0c6bbc866153ae70cf75d745b9477fa010567246cfe6683b7bb8aec541b4> # Oostende
+    <http://data.lblod.info/id/bestuurseenheden/8df96cc548c53410332620ec1adae4591bd5340127b1332c4b902c5c3afe260d> # Oosterzele
+    <http://data.lblod.info/id/bestuurseenheden/ce5950d88624248728b62bb587d934da5aee55f5fd5a9d3f569b3a1310390395> # Oostkamp
+    <http://data.lblod.info/id/bestuurseenheden/929c049597e4961ea84051927af6be67062da4fc8ed9b755fc33b1597b8cdc7c> # Opwijk
+    <http://data.lblod.info/id/bestuurseenheden/d9f7c0ab4920fdecf3f9a60b92e921b5ca07248fcb0eac2113eb97392ddd6c6c> # Oudenaarde
+    <http://data.lblod.info/id/bestuurseenheden/cf8131ac6fcc41224b895fde6e18def464a16012f05d3c078da2637e0f1674ee> # Oudenburg
+    <http://data.lblod.info/id/bestuurseenheden/48fc71248bff17e9a5ca8f2c5c95d38ea551084b82e944cf7121749555ea00c9> # Oud-Turnhout
+    <http://data.lblod.info/id/bestuurseenheden/476ddecbaf169d4c9af3ca8ed6725f4efebdfdb9647fe82ec4406496c6e930d9> # Overijse
+    <http://data.lblod.info/id/bestuurseenheden/87548df6451c56b75e1064613f01fa92bb0c1d9b1e0d9019336fabd39e54ace0> # Peer
+    <http://data.lblod.info/id/bestuurseenheden/8d7de878-db13-4fe1-8d74-bb8c9a690d90>                             # Pelt
+    <http://data.lblod.info/id/bestuurseenheden/73840d393bd94828f0903e8357c7f328d4bf4b8fbd63adbfa443e784f056a589> # Pepingen
+    <http://data.lblod.info/id/bestuurseenheden/bf2ed8893d2ec4689b4c60b0b236edf11f381e247c535f0b12d132fc80ca1ad0> # Poperinge
+    <http://data.lblod.info/id/bestuurseenheden/d408e63f6ebbdfb20dbc63f8f8a4f91f2fe4eb23fa2496f9ca102ec583e9e022> # Putte
+    <http://data.lblod.info/id/bestuurseenheden/c8f33e80-6f19-4ba1-a758-9d85f42d28d4>                             # Puurs-Sint-Amands
+    <http://data.lblod.info/id/bestuurseenheden/8fb90f367f105c14f37a7062d6732696dc2efc292f87fd5045548a0da407dbe4> # Ranst
+    <http://data.lblod.info/id/bestuurseenheden/36f1c660b51e5809170f17ce6bf420a9ad7bf596f049d0d2f2c638f107e8c509> # Ravels
+    <http://data.lblod.info/id/bestuurseenheden/1ed8e751e664569fe2792f523f234e66bdc42d9c01736d850ae59e1b2177d70b> # Retie
+    <http://data.lblod.info/id/bestuurseenheden/0a3ba641d653b436b14fde37bb6eab4f1054aa0586eb98021b723d58f6ce82fb> # Rijkevorsel
+    <http://data.lblod.info/id/bestuurseenheden/3e58880a542424b73f85c9ffba8837b0da40d8c43e936c92603cde2015f5cdae> # Roeselare
+    <http://data.lblod.info/id/bestuurseenheden/59eaecae469f80eccaf6d36a165927eb8ee8749b9866ab1730e6b1ba45dfaaa7> # Ronse
+    <http://data.lblod.info/id/bestuurseenheden/f08dca136aca8cfd86913c6e452ca3b763d618b52aec02f8864443942c50277a> # Roosdaal
+    <http://data.lblod.info/id/bestuurseenheden/4fd07fa6c794ef12a12c17976570c2bae5fe62dcc373a09032276397ae153f04> # Rotselaar
+    <http://data.lblod.info/id/bestuurseenheden/78ea1cc22fb4b7760f81755a9a6b0de8daf21268c91ff44bdbec308d514cb88c> # Schelle
+    <http://data.lblod.info/id/bestuurseenheden/7c51e88f8a89d42e054368a7c5da3c16ecce3b86ea63918a0d7e1d46fbdde2b9> # Schilde
+    <http://data.lblod.info/id/bestuurseenheden/f881bb13d3a1ae27056d085fc041792beb3b4b3d1adf1ee3399a7184b71f6863> # Schoten
+    <http://data.lblod.info/id/bestuurseenheden/665f6a3b8e4ad7766a1be93578b5d8b6312afa8600c1301388225880fe4eca53> # Sint-Gillis-Waas
+    <http://data.lblod.info/id/bestuurseenheden/1cb4914d7d6a57869d4d9cf68abe20151334b30694e6a7546c155c5beaa6ac8a> # Sint-Katelijne-Waver
+    <http://data.lblod.info/id/bestuurseenheden/7004c5cca97f47f3ea5fd5d011983bed0257432c4dd317c4ebdf1f1d7035890a> # Sint-Lievens-Houtem
+    <http://data.lblod.info/id/bestuurseenheden/71f6925a4b895c2a91dce039c87d227809edcda82963714814141b1e41631b08> # Sint-Niklaas
+    <http://data.lblod.info/id/bestuurseenheden/1b17382556917a15828249872bc4f913a24f7656cd5722be270f0e31b9ff0c06> # Sint-Pieters-Leeuw
+    <http://data.lblod.info/id/bestuurseenheden/416aada66520f1b6f4eb79177cefa7c5815bfb85fd455431c1ef91fd333769fd> # Sint-Truiden
+    <http://data.lblod.info/id/bestuurseenheden/d2ddbbea9b30242eedb334f9729dc9f9b31c9c0496009a474b407393b383ef53> # Spiere-Helkijn
+    <http://data.lblod.info/id/bestuurseenheden/69e815e62d4698903b7db1df39f372317439cb28a8c4ca62aa6bfd1acaa62266> # Stabroek
+    <http://data.lblod.info/id/bestuurseenheden/6025a5d1ca2262a784f002edd8ce9ca9073ae3d5ebc6b6b5531f05a29e9250af> # Stekene
+    <http://data.lblod.info/id/bestuurseenheden/4411539b345d3b7ffa3f9ac54fce0fc381e579b999c46cb11c7d9af03aa04a79> # Temse
+    <http://data.lblod.info/id/bestuurseenheden/26e9007dd8e6316c45488b1c4d5ceff1707d25e67b892f82c166ee889c0c2e41> # Ternat
+    <http://data.lblod.info/id/bestuurseenheden/01f5df79d1c889c5fb42592a72d7aa50bcfc77a8d04c7f2015df993b0e479835> # Tervuren
+    <http://data.lblod.info/id/bestuurseenheden/af8969752f6b28c66b6bc402d7987fa38774901ac72b95c5cb7976570487c3c9> # Tessenderlo
+    <http://data.lblod.info/id/bestuurseenheden/b36da606fba6dd4dc99ae1ef5f4a52bba3268d33f4bc2cd1e65b87f01f35101a> # Tielt
+    <http://data.lblod.info/id/bestuurseenheden/3499c07d07336622b8880bd8fd9bd49667f88d6998755cb1dc31f58012248b43> # Tielt-Winge
+    <http://data.lblod.info/id/bestuurseenheden/da17a1c564c4f0aecbe800efaedcee7428e80c127b4a1bc829519b375ad20707> # Tienen
+    <http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625> # Tongeren
+    <http://data.lblod.info/id/bestuurseenheden/842737db3afe0bad6a72bbbdeee376fe49abe721975d549d81bb22c70bc7002d> # Torhout
+    <http://data.lblod.info/id/bestuurseenheden/d03795d069b5de6a386ad04bdb0970ef079eaac1be473414bcb63a6c9eaed4d0> # Tremelo
+    <http://data.lblod.info/id/bestuurseenheden/800ce18716ba451af47c2e05c2a7bdd29ab9305eaa61068629c1ea2ae6c08f4c> # Turnhout
+    <http://data.lblod.info/id/bestuurseenheden/a1f8ddebe40f6a09270fbe460e71ebb7adda7b1ac2e5c4ccb3fd6e9dda2162b6> # Veurne
+    <http://data.lblod.info/id/bestuurseenheden/8fd72c4cd5f095c508af05e3406aa63114279e8bde54e9f5b83a59c7794dac72> # Vilvoorde
+    <http://data.lblod.info/id/bestuurseenheden/f39eb137cb5c9195f92928522bbbf0d104fb54be6eb0c9c62a24d16b88b44272> # Voeren
+    <http://data.lblod.info/id/bestuurseenheden/3be4b70020a4e13d92d67de7e0624d365cf0909ca69eeedf6f95b0690c96f076> # Vorselaar
+    <http://data.lblod.info/id/bestuurseenheden/7d47cc2df885086cee43dc51b76668d566a324dc7e021180ec80788bfb76124c> # Vosselaar
+    <http://data.lblod.info/id/bestuurseenheden/1313d4a58f9ecf52cc7e274e3549a759b35e731973cc9f5e07562e5650f594dd> # Wachtebeke
+    <http://data.lblod.info/id/bestuurseenheden/5a8f9c6bde6c6b01bee07d9dbed16a8b685851865d5083edbf617a4dbd2e51ce> # Waregem
+    <http://data.lblod.info/id/bestuurseenheden/23bb41cfe7b4cb3af101ef96bf9ef0466d19997c0e100123722371d369d580b1> # Wellen
+    <http://data.lblod.info/id/bestuurseenheden/4fb8eb24aa9d5561f3cd7b502715fc758f41b71aafa13b872ee8aeb1d027dbe9> # Wemmel
+    <http://data.lblod.info/id/bestuurseenheden/f923867abb64ec787e987ad25b3bae8bcf38dce127e3a664ad18b30e18d70986> # Wervik
+    <http://data.lblod.info/id/bestuurseenheden/03ff483dadbae6e23f785f5b428248911bec4f5b3ce2559e960d0d8f32f15619> # Westerlo
+    <http://data.lblod.info/id/bestuurseenheden/bc1d9bf8b47dad5cc29db38c5510f1c91399302b27e928719ac1286637406f25> # Wetteren
+    <http://data.lblod.info/id/bestuurseenheden/0bb11f642e87a81479446ebe4938947cbc35da5f7516a3d5a9667b67d5024574> # Wevelgem
+    <http://data.lblod.info/id/bestuurseenheden/b47cda1a1458dc4935e118b6fffbdfbc55eba2659fc9321c61be0de63b5a27e3> # Wichelen
+    <http://data.lblod.info/id/bestuurseenheden/0f8e458aac514d1966ff7594b23fe784dba93ccff5d63fdfa279879eb007233a> # Wijnegem
+    <http://data.lblod.info/id/bestuurseenheden/479540ea9de26a669c2c7e6cf5c98a2102c1771c48f63808e0e9b41db24dd575> # Willebroek
+    <http://data.lblod.info/id/bestuurseenheden/6093f33e8eacb798481b1f826416eaf310552e9568e74804f59c69dada2187e4> # Wommelgem
+    <http://data.lblod.info/id/bestuurseenheden/4b93b99b2a80c6ce4e64850589a8c0163fc055b074b061a64add3e1af303f1fe> # Wortegem-Petegem
+    <http://data.lblod.info/id/bestuurseenheden/6e7e9f3e54866ceeafcbee973e2799e4d1cc8c3970f92af29fd2d66d475c2b3b> # Wuustwezel
+    <http://data.lblod.info/id/bestuurseenheden/93bf61e0c1a48a58c1f6af804e087221de46fc492b30e3a7194b0b098356ab82> # Zandhoven
+    <http://data.lblod.info/id/bestuurseenheden/e40c7c891fb462d2128235f88fede078846d942da5688e4f9cdfb5bb04844d84> # Zaventem
+    <http://data.lblod.info/id/bestuurseenheden/26721daac0558a8a9efee4fc9d1141733844b3a6eb0813401546eb805a978182> # Zele
+    <http://data.lblod.info/id/bestuurseenheden/51689560fe677738ed03e8a14dc01723d0f865c488f5f47c388622f332241e2d> # Zelzate
+    <http://data.lblod.info/id/bestuurseenheden/a0393ba99ecc1a0e05d93966aaad42b07980efa5dc90f72106f3fb5954215e18> # Zemst
+    <http://data.lblod.info/id/bestuurseenheden/d59bf99ac29e71796ad7bdfe68cf74709c63721691d9680e0ea7636070f7513c> # Zoersel
+    <http://data.lblod.info/id/bestuurseenheden/3e3d8146912fb57b6f7c4c665051351b6dd1a92730f363a17bddabe58bcdeb51> # Zottegem
+    <http://data.lblod.info/id/bestuurseenheden/8da71bf3f06102d4c2e45daa597622ffd1c13ca150ddd12f6258e02855cdaeb5> # Zoutleeuw
+    <http://data.lblod.info/id/bestuurseenheden/0584f1096c6eb744a680d13e4974ff85744ec9aa163e31833acaa694c8c9c6c8> # Zulte
+    <http://data.lblod.info/id/bestuurseenheden/dbf74e8b71e474626b7a7566e6b74db3a73790e8b991a385d404e2267378635e> # Zutendaal
+    <http://data.lblod.info/id/bestuurseenheden/f8ad83ae8d0d96983b5bddb3c2cb768323b4f5103d95c111f6143c9109034aab> # Zwalm
+    <http://data.lblod.info/id/bestuurseenheden/7269d3607a761c9ce0e226e0b7ea5687324230b65a568d48c81a7acba53998fd> # Zwevegem
+    <http://data.lblod.info/id/bestuurseenheden/dac6ed961e62f29e2706c8213c6c5ee28d07bb719e564bcd47157499561e613b> # Zonhoven
+ }
+
+ ?bestuurseenheid mu:uuid ?uuid .
+ BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", STR(?uuid), "/LoketLB-subsidies")) as ?newGraph)
+}

--- a/config/subsidy-application-management/forms/climate-2-1/step-submit-opvolgmoment/tailored/source/extractors/contact-info-extractor.js
+++ b/config/subsidy-application-management/forms/climate-2-1/step-submit-opvolgmoment/tailored/source/extractors/contact-info-extractor.js
@@ -1,0 +1,84 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate-subsidy/submit-aanvraag/contact-info-extractor',
+  execute: async (store, graphs, lib, target, source) => {
+
+    if (!source)
+      source = target;
+
+    const {$rdf, mu, sudo} = lib;
+
+    const SCHEMA = new $rdf.Namespace('http://schema.org/');
+    const FOAF = new $rdf.Namespace('http://xmlns.com/foaf/0.1/');
+
+    const contactPoint = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+    store.add(
+        $rdf.sym(target.uri),
+        SCHEMA('contactPoint'),
+        $rdf.sym(contactPoint),
+        graphs.additions);
+
+    const {firstName, familyName, email, telephone} =
+        await getGenericInfo(source.uri, mu, sudo);
+
+    if (familyName)
+      store.add(
+          $rdf.sym(contactPoint),
+          FOAF('familyName'),
+          familyName.value,
+          graphs.additions);
+    if (firstName)
+      store.add(
+          $rdf.sym(contactPoint),
+          FOAF('firstName'),
+          firstName.value,
+          graphs.additions);
+    if (email)
+      store.add(
+          $rdf.sym(contactPoint),
+          SCHEMA('email'),
+          email.value,
+          graphs.additions);
+    if (telephone)
+      store.add(
+          $rdf.sym(contactPoint),
+          SCHEMA('telephone'),
+          telephone.value,
+          graphs.additions);
+  }
+};
+
+async function getGenericInfo(uri, mu, sudo) {
+  const { results } = await sudo.querySudo(`
+    PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>
+    PREFIX schema: <http://schema.org/>
+    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    SELECT DISTINCT ?firstName ?familyName ?email ?telephone
+    WHERE {
+      GRAPH ?g {
+        ${mu.sparqlEscapeUri(uri)}
+          schema:contactPoint ?contactPoint.
+        OPTIONAL {
+            ?contactPoint foaf:familyName ?familyName.
+        }
+        OPTIONAL {
+            ?contactPoint foaf:firstName ?firstName.
+        }
+        OPTIONAL {
+            ?contactPoint schema:email ?email.
+        }
+        OPTIONAL {
+            ?contactPoint schema:telephone ?telephone.
+        }
+      }
+    }`
+  );
+
+  if (results.bindings.length) {
+    return results.bindings[0];
+  }
+  return null;
+}

--- a/config/subsidy-application-management/forms/climate-2-1/step-submit-opvolgmoment/versions/20230215141257/form.json
+++ b/config/subsidy-application-management/forms/climate-2-1/step-submit-opvolgmoment/versions/20230215141257/form.json
@@ -1,0 +1,56 @@
+{
+    "source": {
+      "prefixes": [
+        "PREFIX mu: <http://mu.semte.ch/vocabularies/core/>",
+        "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
+        "PREFIX dct: <http://purl.org/dc/terms/>",
+        "PREFIX skos: <http://www.w3.org/2004/02/skos/core#>",
+        "PREFIX subsidie: <http://data.vlaanderen.be/ns/subsidie#>",
+        "PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>",
+        "PREFIX pav: <http://purl.org/pav/>",
+        "PREFIX schema: <http://schema.org/>",
+        "PREFIX foaf: <http://xmlns.com/foaf/0.1/>",
+        "PREFIX gleif: <https://www.gleif.org/ontology/Base/>",
+        "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>",
+        "PREFIX adms: <http://www.w3.org/ns/adms#>",
+        "PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>"
+      ],
+      "properties": [
+        {
+          "s-prefix": "schema:contactPoint",
+          "properties": [
+            "foaf:firstName",
+            "foaf:familyName",
+            "schema:telephone",
+            "schema:email"
+          ]
+        },
+        {
+          "s-prefix": "lblodSubsidie:attachment",
+          "properties": [
+            {
+              "s-prefix": "dct:hasPart",
+              "properties": [
+                "rdf:type"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "meta": {
+      "schemes": [
+        "http://lblod.data.gift/concept-schemes/33e233eb-6a9b-4141-b607-2ff72fe2ded2",
+        "http://lblod.data.gift/concepts/1df4b56a-3ccd-450d-93dc-317fda1ada38",
+        "http://lblod.data.gift/concepts/2697fbe1-4226-4325-807b-5dfa58e40a95",
+        "http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2",
+        "http://lblod.data.gift/concepts/5e52660c-9067-4d6f-b82c-c73ffd043401",
+        "http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2",
+        "http://lblod.data.gift/concept-schemes/dcfb437e-1219-4d1e-891d-057f262da9d6",
+        "http://lblod.data.gift/concept-schemes/dd44f316-7a30-45ab-b0f3-5dd642e0b6c7",
+        "http://lblod.data.gift/concept-schemes/2c0ec673-a430-4cd3-861d-8666991b790f",
+        "http://lblod.data.gift/concept-schemes/9a3f018b-6528-4abb-82d5-b7920d05a3da"
+      ]
+    }
+  }
+  

--- a/config/subsidy-application-management/forms/climate-2-1/step-submit-opvolgmoment/versions/20230215141257/form.ttl
+++ b/config/subsidy-application-management/forms/climate-2-1/step-submit-opvolgmoment/versions/20230215141257/form.ttl
@@ -1,0 +1,184 @@
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix fieldGroups: <http://data.lblod.info/field-groups/> .
+@prefix fields: <http://data.lblod.info/fields/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix schema: <http://schema.org/>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/>.
+
+
+##########################################################
+# Property groups
+##########################################################
+
+fields:2524865a-d463-4e0b-9528-924b8439e9e6 a form:PropertyGroup;
+    mu:uuid "2524865a-d463-4e0b-9528-924b8439e9e6";
+    sh:description "parent property-group, used to group fields and property-groups together";
+    sh:order 1 .
+
+
+fields:66d4d042-ac7f-4793-b70a-c611b48ac0a1 a form:PropertyGroup;
+    mu:uuid "66d4d042-ac7f-4793-b70a-c611b48ac0a1";
+    sh:description "contact person information";
+    sh:order 2;
+    sh:name "Contactgegevens contactpersoon" ;
+    form:help "Dit is de persoon die gecontacteerd wordt bij de opvolging van dit dossier." ;
+    sh:group fields:2524865a-d463-4e0b-9528-924b8439e9e6 .
+
+fields:70f45080-8a18-473f-bb3f-abf6ce9c678e a form:PropertyGroup;
+    mu:uuid "70f45080-8a18-473f-bb3f-abf6ce9c678e";
+    sh:description "submit follow-up moment";
+    sh:order 3;
+    sh:name "Indienen Opvolgmoment" ;
+    form:help "Het voltooien van deze stap laat zien dat de voortgang van het Lokaal Energie en Klimaat Pact op de gemeenteraad werd besproken." ;
+    sh:group fields:2524865a-d463-4e0b-9528-924b8439e9e6 .
+
+##########################################################
+# Hidden input to trigger property groups
+##########################################################
+
+fields:d0a69063-5eb5-41a6-84a4-5fd2934b71b3 a form:Field ;
+    mu:uuid "d0a69063-5eb5-41a6-84a4-5fd2934b71b3";
+    sh:order 20 ;
+    sh:path ext:stubPformPath ;
+    form:options """{}""" ;
+    sh:group fields:91fda733-791e-48ea-9f48-5ee7a284de37 .
+
+##########################################################
+# Contact info
+##########################################################
+
+fields:0d945c25-54aa-4a87-a849-c844b2c62f30 a form:Field ;
+    mu:uuid "0d945c25-54aa-4a87-a849-c844b2c62f30";
+    sh:name "Voornaam contactpersoon" ;
+    sh:order 30 ;
+    sh:path ( schema:contactPoint foaf:firstName ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint foaf:firstName ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:66d4d042-ac7f-4793-b70a-c611b48ac0a1 .
+
+fields:fc6454c7-3540-4078-bfb8-0c5b1766f482 a form:Field ;
+    mu:uuid "fc6454c7-3540-4078-bfb8-0c5b1766f482";
+    sh:name "Familienaam contactpersoon" ;
+    sh:order 31 ;
+    sh:path ( schema:contactPoint foaf:familyName ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint foaf:familyName ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:66d4d042-ac7f-4793-b70a-c611b48ac0a1 .
+
+fields:9d44b4bc-46fe-459b-aca1-f5a81b1e0acb a form:Field ;
+    mu:uuid "9d44b4bc-46fe-459b-aca1-f5a81b1e0acb";
+    sh:name "Telefoonnummer" ;
+    sh:order 32 ;
+    sh:path ( schema:contactPoint schema:telephone ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint schema:telephone ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidPhoneNumber ;
+        form:grouping form:MatchEvery ;
+        form:defaultCountry "BE" ;
+        sh:path ( schema:contactPoint schema:telephone ) ;
+        sh:resultMessage "Geef een geldig telefoonnummer in."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:66d4d042-ac7f-4793-b70a-c611b48ac0a1 .
+
+fields:910b83b8-2ebc-4e59-9303-1f57a6c68d7d a form:Field ;
+    mu:uuid "910b83b8-2ebc-4e59-9303-1f57a6c68d7d";
+    sh:name "Mailadres" ;
+    sh:order 33 ;
+    sh:path ( schema:contactPoint schema:email ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint schema:email ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidEmail ;
+        form:grouping form:MatchEvery ;
+        sh:path ( schema:contactPoint schema:email ) ;
+        sh:resultMessage "Geef een geldig e-mailadres op."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:66d4d042-ac7f-4793-b70a-c611b48ac0a1 .
+
+##########################################################
+# Attachment
+##########################################################
+fields:f6f972c0-e796-42e8-87c1-c689dab0a690 a form:Field ;
+    mu:uuid "f6f972c0-e796-42e8-87c1-c689dab0a690" ;
+    sh:name "Laad hier het gemeenteraadsbesluit op" ;
+    sh:order 40 ;
+    sh:path ( lblodSubsidie:attachment dct:hasPart ) ;
+    form:validations
+        [ a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht."@nl ;
+            sh:path lblodSubsidie:attachment
+        ] ;
+    form:displayType displayTypes:files ;
+    sh:group fields:70f45080-8a18-473f-bb3f-abf6ce9c678e .
+
+##########################################################
+# Hidden field required for all variations of URL or FILE
+# input field which require validation.
+# It makes sure there is a type attached to hasPart object.
+# This enables correct validation in both front and backend.
+##########################################################
+
+fields:08ebe38b-9b5f-43be-9b61-e1ee58da1168 a form:Field ;
+    mu:uuid "08ebe38b-9b5f-43be-9b61-e1ee58da1168" ;
+    sh:name "Type RemoteDataObject or FileDataObject [hidden input]" ;
+    sh:order 41 ;
+    sh:path ( lblodSubsidie:attachment dct:hasPart rdf:type );
+    sh:group fields:70f45080-8a18-473f-bb3f-abf6ce9c678e .
+
+##########################################################
+# Linking fields to form
+##########################################################
+
+fieldGroups:main a form:FieldGroup ;
+    mu:uuid "1f3cf92c-aa5f-4708-85c6-77aabbc8989f" ;
+    form:hasField
+
+        ### First name contact person
+        fields:0d945c25-54aa-4a87-a849-c844b2c62f30 ,
+
+        ### First name contact person
+        fields:fc6454c7-3540-4078-bfb8-0c5b1766f482 ,
+
+        ### Phone
+        fields:9d44b4bc-46fe-459b-aca1-f5a81b1e0acb ,
+
+        ### Email
+        fields:910b83b8-2ebc-4e59-9303-1f57a6c68d7d ,
+
+        ### Attachment
+        fields:f6f972c0-e796-42e8-87c1-c689dab0a690 ,
+
+        ### Attachment [hidden]
+        fields:08ebe38b-9b5f-43be-9b61-e1ee58da1168 .
+
+form:3ff36255-f108-4527-990c-6d7896f4b989 a form:Form ;
+    mu:uuid "3ff36255-f108-4527-990c-6d7896f4b989" ;
+    form:hasFieldGroup fieldGroups:main .

--- a/config/subsidy-application-management/forms/climate-2-1/step-submit-pact/versions/20230215141257/form.json
+++ b/config/subsidy-application-management/forms/climate-2-1/step-submit-pact/versions/20230215141257/form.json
@@ -1,0 +1,56 @@
+{
+    "source": {
+      "prefixes": [
+        "PREFIX mu:             <http://mu.semte.ch/vocabularies/core/>",
+        "PREFIX rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
+        "PREFIX dct:            <http://purl.org/dc/terms/>",
+        "PREFIX skos:           <http://www.w3.org/2004/02/skos/core#>",
+        "PREFIX subsidie:       <http://data.vlaanderen.be/ns/subsidie#>",
+        "PREFIX lblodSubsidie:  <http://lblod.data.gift/vocabularies/subsidie/>",
+        "PREFIX pav:            <http://purl.org/pav/>",
+        "PREFIX schema:         <http://schema.org/>",
+        "PREFIX foaf:           <http://xmlns.com/foaf/0.1/>",
+        "PREFIX gleif:          <https://www.gleif.org/ontology/Base/>",
+        "PREFIX ext:            <http://mu.semte.ch/vocabularies/ext/>",
+        "PREFIX adms:           <http://www.w3.org/ns/adms#>",
+        "PREFIX nie:            <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>"
+      ],
+      "properties": [
+        {
+          "s-prefix": "lblodSubsidie:signedPact",
+          "properties": [
+            {
+              "s-prefix": "dct:hasPart",
+              "properties": [
+                "rdf:type"
+              ]
+            }
+          ]
+        },
+        {
+          "s-prefix": "schema:contactPoint",
+          "properties": [
+            "foaf:firstName",
+            "foaf:familyName",
+            "schema:telephone",
+            "schema:email"
+          ]
+        }
+      ]
+    },
+    "meta": {
+      "schemes": [
+        "http://lblod.data.gift/concept-schemes/33e233eb-6a9b-4141-b607-2ff72fe2ded2",
+        "http://lblod.data.gift/concepts/1df4b56a-3ccd-450d-93dc-317fda1ada38",
+        "http://lblod.data.gift/concepts/2697fbe1-4226-4325-807b-5dfa58e40a95",
+        "http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2",
+        "http://lblod.data.gift/concepts/5e52660c-9067-4d6f-b82c-c73ffd043401",
+        "http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2",
+        "http://lblod.data.gift/concept-schemes/dcfb437e-1219-4d1e-891d-057f262da9d6",
+        "http://lblod.data.gift/concept-schemes/dd44f316-7a30-45ab-b0f3-5dd642e0b6c7",
+        "http://lblod.data.gift/concept-schemes/2c0ec673-a430-4cd3-861d-8666991b790f",
+        "http://lblod.data.gift/concept-schemes/9a3f018b-6528-4abb-82d5-b7920d05a3da"
+      ]
+    }
+  }
+  

--- a/config/subsidy-application-management/forms/climate-2-1/step-submit-pact/versions/20230215141257/form.ttl
+++ b/config/subsidy-application-management/forms/climate-2-1/step-submit-pact/versions/20230215141257/form.ttl
@@ -1,0 +1,165 @@
+@prefix form:           <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh:             <http://www.w3.org/ns/shacl#>.
+@prefix mu:             <http://mu.semte.ch/vocabularies/core/> .
+@prefix fieldGroups:    <http://data.lblod.info/field-groups/> .
+@prefix fields:         <http://data.lblod.info/fields/> .
+@prefix displayTypes:   <http://lblod.data.gift/display-types/> .
+@prefix skos:           <http://www.w3.org/2004/02/skos/core#>.
+@prefix schema:         <http://schema.org/>.
+@prefix foaf:           <http://xmlns.com/foaf/0.1/>.
+@prefix lblodSubsidie:  <http://lblod.data.gift/vocabularies/subsidie/>.
+@prefix dct:            <http://purl.org/dc/terms/>.
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix nie:            <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+
+
+##########################################################
+# Form definition
+##########################################################
+
+form:6b70a6f0-cce2-4afe-81f5-5911f45b0b27 a form:Form ;
+    mu:uuid "6b70a6f0-cce2-4afe-81f5-5911f45b0b27" ;
+    form:hasFieldGroup fieldGroups:fa339dfb-da67-469f-add5-edf282b32d5e .
+
+fieldGroups:fa339dfb-da67-469f-add5-edf282b32d5e a form:FieldGroup ;
+    mu:uuid "fa339dfb-da67-469f-add5-edf282b32d5e" .
+
+##########################################################
+# Property groups
+##########################################################
+
+fields:4dea4bc9-6d65-4642-ba34-10c668a5e72d a form:PropertyGroup;
+    mu:uuid "4dea4bc9-6d65-4642-ba34-10c668a5e72d";
+    sh:description "parent property-group, used to group fields and property-groups together";
+    sh:order 1 .
+
+fields:08b0c3fe-6275-4a1f-81c9-4bad9ddaf730 a form:PropertyGroup;
+    mu:uuid "08b0c3fe-6275-4a1f-81c9-4bad9ddaf730";
+    sh:description "contact person information";
+    sh:order 2;
+    sh:name "Contactgegevens contactpersoon" ;
+    form:help "Dit is de persoon die gecontacteerd wordt bij de opvolging van dit dossier." ;
+    sh:group fields:4dea4bc9-6d65-4642-ba34-10c668a5e72d .
+
+fields:07372422-b306-4157-9970-60fdd79ac57f a form:PropertyGroup;
+    mu:uuid "07372422-b306-4157-9970-60fdd79ac57f";
+    sh:description "Ondertekend pact";
+    sh:order 3 ;
+    sh:name "Ondertekend pact" ;
+    form:help """Het voltooien van deze stap geldt als aanvraag van het trekkingsrecht voor de subsidieerbare klimaatacties.
+    Een <a href="https://www.vvsg.be/Leden/Netwerk Klimaat/LEKP/20220713_Gemeenteraadsbeslissing_LEKP2.0.docx" target="_blank">voorbeeldsjabloon</a> is terug te vinden op de website van het <a href="https://www.vvsg.be/kennisitem/vvsg/lokaal-energie-en-klimaatpact" target="_blank">Netwerk Klimaat</a>""" ;
+    sh:group fields:4dea4bc9-6d65-4642-ba34-10c668a5e72d .
+
+##########################################################
+# Contact person info
+##########################################################
+
+fields:e19e245a-c24b-4fb5-84b8-a7e2744ce9a0 a form:Field ;
+    mu:uuid "e19e245a-c24b-4fb5-84b8-a7e2744ce9a0";
+    sh:name "Voornaam contactpersoon" ;
+    sh:order 30 ;
+    sh:path ( schema:contactPoint foaf:firstName ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint foaf:firstName ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:08b0c3fe-6275-4a1f-81c9-4bad9ddaf730 .
+
+fields:82258a58-6c67-4b0a-a26d-0676b88886ad a form:Field ;
+    mu:uuid "82258a58-6c67-4b0a-a26d-0676b88886ad";
+    sh:name "Familienaam contactpersoon" ;
+    sh:order 31 ;
+    sh:path ( schema:contactPoint foaf:familyName ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint foaf:familyName ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:08b0c3fe-6275-4a1f-81c9-4bad9ddaf730 .
+
+fields:6285341d-a0ad-4933-bb5f-c49016b0f935 a form:Field ;
+    mu:uuid "6285341d-a0ad-4933-bb5f-c49016b0f935";
+    sh:name "Telefoonnummer" ;
+    sh:order 32 ;
+    sh:path ( schema:contactPoint schema:telephone ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint schema:telephone ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidPhoneNumber ;
+        form:grouping form:MatchEvery ;
+        form:defaultCountry "BE" ;
+        sh:path ( schema:contactPoint schema:telephone ) ;
+        sh:resultMessage "Geef een geldig telefoonnummer in."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:08b0c3fe-6275-4a1f-81c9-4bad9ddaf730 .
+
+fields:31c743c7-b243-4ca7-a6c1-dc5f03cb5afb a form:Field ;
+    mu:uuid "31c743c7-b243-4ca7-a6c1-dc5f03cb5afb";
+    sh:name "Mailadres" ;
+    sh:order 33 ;
+    sh:path ( schema:contactPoint schema:email ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint schema:email ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidEmail ;
+        form:grouping form:MatchEvery ;
+        sh:path ( schema:contactPoint schema:email ) ;
+        sh:resultMessage "Geef een geldig e-mailadres op."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:08b0c3fe-6275-4a1f-81c9-4bad9ddaf730 .
+
+##########################################################
+# Climate: signed pact
+##########################################################
+
+fields:fbd15091-9155-4c73-a12a-0df4e4eda7b9 a form:Field ;
+    mu:uuid "fbd15091-9155-4c73-a12a-0df4e4eda7b9";
+    sh:name "Voeg het gemeenteraadsbesluit (ondertekend pact) toe" ;
+    sh:order 20 ;
+    sh:path ( lblodSubsidie:signedPact dct:hasPart );
+    form:options """{}""" ;
+    form:displayType displayTypes:files ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path lblodSubsidie:signedPact ] ;
+    sh:group fields:07372422-b306-4157-9970-60fdd79ac57f .
+
+##########################################################
+# Hidden field required for all variations of URL or FILE
+# input field which require validation.
+# It makes sure there is a type attached to hasPart object.
+# This enables correct validation in both front and backend.
+##########################################################
+
+fields:ccb94821-be31-43fa-87df-ef64e3c4ce45 a form:Field ;
+    mu:uuid "ccb94821-be31-43fa-87df-ef64e3c4ce45" ;
+    sh:name "Type RemoteDataObject or FileDataObject [hidden input]" ;
+    sh:order 43 ;
+    sh:path ( lblodSubsidie:signedPact dct:hasPart rdf:type );
+    sh:group fields:07372422-b306-4157-9970-60fdd79ac57f .
+
+
+##########################################################
+# Linking fields to form
+##########################################################
+fieldGroups:fa339dfb-da67-469f-add5-edf282b32d5e form:hasField fields:e19e245a-c24b-4fb5-84b8-a7e2744ce9a0 .
+fieldGroups:fa339dfb-da67-469f-add5-edf282b32d5e form:hasField fields:82258a58-6c67-4b0a-a26d-0676b88886ad .
+fieldGroups:fa339dfb-da67-469f-add5-edf282b32d5e form:hasField fields:6285341d-a0ad-4933-bb5f-c49016b0f935 .
+fieldGroups:fa339dfb-da67-469f-add5-edf282b32d5e form:hasField fields:31c743c7-b243-4ca7-a6c1-dc5f03cb5afb .
+fieldGroups:fa339dfb-da67-469f-add5-edf282b32d5e form:hasField fields:fbd15091-9155-4c73-a12a-0df4e4eda7b9 .
+fieldGroups:fa339dfb-da67-469f-add5-edf282b32d5e form:hasField fields:ccb94821-be31-43fa-87df-ef64e3c4ce45 .


### PR DESCRIPTION
(Addresses DL-4792) Adds the Climate (LEKP) 2.1 subsidy which is restricted for only a specific list of governments that had previously applied for the Climate (LEKP) 2.0 subsidy.