### PR TITLE
Change opvolgment deadline for LEKP 1.0

### DIFF
--- a/config/migrations/2023/20230224122141-update-opvolgmoment-deadline-for-LEKP-1-0.sparql
+++ b/config/migrations/2023/20230224122141-update-opvolgmoment-deadline-for-LEKP-1-0.sparql
@@ -1,0 +1,27 @@
+PREFIX m8g: <http://data.europa.eu/m8g/>
+
+#
+# Update opvolgmoment deadline for the LEKP 1.0 subsidy from 01 March, 2023 to
+# 01 April, 2023.
+#
+
+DELETE {
+  GRAPH ?g {
+    ?period m8g:endTime ?endTime .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    # Time is set to 21:59:00 because Belgium time is UTC+2 instead of 
+    # UTC+1 in April.
+    ?period m8g:endTime "2023-05-01T21:59:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  }
+}
+WHERE {
+  # URI for LEKP 1.0 subsidy end date
+  BIND(<http://data.lblod.info/id/periodes/c251381e-300f-43e0-a83c-b1ffdfd06b48> as ?period)
+
+  GRAPH ?g {
+    ?period m8g:endTime ?endTime .
+  }
+}

--- a/config/migrations/2023/20230224122141-update-opvolgmoment-deadline-for-LEKP-1-0.sparql
+++ b/config/migrations/2023/20230224122141-update-opvolgmoment-deadline-for-LEKP-1-0.sparql
@@ -2,7 +2,7 @@ PREFIX m8g: <http://data.europa.eu/m8g/>
 
 #
 # Update opvolgmoment deadline for the LEKP 1.0 subsidy from 01 March, 2023 to
-# 01 April, 2023.
+# 01 May, 2023.
 #
 
 DELETE {
@@ -13,7 +13,7 @@ DELETE {
 INSERT {
   GRAPH ?g {
     # Time is set to 21:59:00 because Belgium time is UTC+2 instead of 
-    # UTC+1 in April.
+    # UTC+1 in May.
     ?period m8g:endTime "2023-05-01T21:59:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   }
 }


### PR DESCRIPTION
(Addresses DL-4797) Update opvolgment deadline for the LEKP 1.0 subsidy from 01 March 2023 to 01 May 2023.