### PR TITLE
update lekp-2.1 subsidie link

### DIFF
--- a/config/migrations/2023/20230307112318-update-lekp-2.1-link.sparql
+++ b/config/migrations/2023/20230307112318-update-lekp-2.1-link.sparql
@@ -1,0 +1,19 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH ?g {
+    ?subsidy skos:related ?link .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?subsidy skos:related """https://lokaalbestuur.vlaanderen.be/nieuws/lekp-21-versterking-lekp-om-energie-armoede-te-voorkomen""" .
+  }
+}
+WHERE {
+  BIND(<http://data.lblod.info/id/subsidy-measure-offers/8815fe07-e53f-4657-94be-efaa4898f03c> as ?subsidy)
+
+  GRAPH ?g {
+    ?subsidy skos:related ?link .
+  }
+}


### PR DESCRIPTION
To test:
- run migration
- login to app
- go to new subsidie list
- check if "informatie submaatregel" field for LEKP 2.1 subside changed to `https://lokaalbestuur.vlaanderen.be/nieuws/lekp-21-versterking-lekp-om-energie-armoede-te-voorkomen`