### PR TITLE
Add local administration and flemish goverment to doelgroep codelist

### DIFF
--- a/config/migrations/2023/20230308161239-add-new-values-to-doelgroep-codelist/20230308161239-add-new-values-to-doelgroep-codelist.graph
+++ b/config/migrations/2023/20230308161239-add-new-values-to-doelgroep-codelist/20230308161239-add-new-values-to-doelgroep-codelist.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2023/20230308161239-add-new-values-to-doelgroep-codelist/20230308161239-add-new-values-to-doelgroep-codelist.ttl
+++ b/config/migrations/2023/20230308161239-add-new-values-to-doelgroep-codelist/20230308161239-add-new-values-to-doelgroep-codelist.ttl
@@ -1,0 +1,307 @@
+@prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dvcs:      <https://productencatalogus.data.vlaanderen.be/id/conceptscheme/> .
+@prefix dvc:       <https://productencatalogus.data.vlaanderen.be/id/concept/Doelgroep/> .
+@prefix mu:        <http://mu.semte.ch/vocabularies/core/>.
+
+dvcs:Doelgroep
+    a                   skos:ConceptScheme ;
+    mu:uuid             "f2a7c095-184c-4956-a2a8-feabb7ef4741" ;
+    skos:prefLabel      "Doelgroep"@nl ;
+    skos:prefLabel      "TargetAudience"@en ;
+    skos:definition     "Doelgroep waarop een publieke dienstverlening gericht is"@nl ;
+    skos:definition     "Target audience of a public service"@en ;
+    skos:hasTopConcept  dvc:Burger ;
+    skos:hasTopConcept  dvc:Onderneming ;
+    skos:hasTopConcept  dvc:Organisatie ;
+    skos:hasTopConcept  dvc:Vereniging .
+
+dvc:Burger
+    a                 skos:Concept ;
+    mu:uuid           "243480bf-c2f2-4200-8d76-58b779e39904" ;
+    skos:prefLabel    "Burger"@nl ;
+    skos:prefLabel    "Citizen"@en ;
+    skos:definition   "Doelgroep burgers"@nl ;
+    skos:definition   "Target audience citizens"@en ;
+    skos:inScheme     dvcs:Doelgroep ;
+    skos:topConceptOf dvcs:Doelgroep .
+
+dvc:Onderneming
+    a                 skos:Concept ;
+    mu:uuid           "bcad861a-f971-4363-adc3-3811bf327f95" ;
+    skos:prefLabel    "Onderneming"@nl ;
+    skos:prefLabel    "Company"@en ;
+    skos:definition   "Doelgroep onderemingen"@nl ;
+    skos:definition   "Target audience companies"@en ;
+    skos:inScheme     dvcs:Doelgroep ;
+    skos:topConceptOf dvcs:Doelgroep ;
+    skos:narrower     dvc:OndernemingLandbouwBosbouwVisserij ;
+    skos:narrower     dvc:OndernemingDelfstoffen ;
+    skos:narrower     dvc:OndernemingIndustrie ;
+    skos:narrower     dvc:OndernemingElektriciteitGas ;
+    skos:narrower     dvc:OndernemingWater ;
+    skos:narrower     dvc:OndernemingBouwnijverheid ;
+    skos:narrower     dvc:OndernemingHandelVoertuigen ;
+    skos:narrower     dvc:OndernemingVervoerOpslag ;
+    skos:narrower     dvc:OndernemingAccommodatieMaaltijden ;
+    skos:narrower     dvc:OndernemingInformatieCommunicatie ;
+    skos:narrower     dvc:OndernemingFinancienVerzekeringen ;
+    skos:narrower     dvc:OndernemingOnroerendGoed ;
+    skos:narrower     dvc:OndernemingVrijeBeroepenWetenschappelijk ;
+    skos:narrower     dvc:OndernemingAdministratie ;
+    skos:narrower     dvc:OndernemingOpenbaarBestuurDefensie ;
+    skos:narrower     dvc:OndernemingOnderwijs ;
+    skos:narrower     dvc:OndernemingGezondheidszorg ;
+    skos:narrower     dvc:OndernemingKunstAmusementRecreatie ;
+    skos:narrower     dvc:OndernemingOverige ;
+    skos:narrower     dvc:OndernemingHuishoudens ;
+    skos:narrower     dvc:OndernemingExtraterritoriaal .
+
+dvc:OndernemingLandbouwBosbouwVisserij
+    a               skos:Concept ;
+    mu:uuid         "5799e99f-7a1b-45f7-8126-01078a77584d" ;
+    skos:prefLabel  "Landbouw, bosbouw en visserij"@nl ;
+    skos:prefLabel  "Agriculture, forestry and fishing"@en ;
+    skos:definition "Landbouw, bosbouw en visserij"@nl ;
+    skos:definition "Agriculture, forestry and fishing"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingDelfstoffen
+    a               skos:Concept ;
+    mu:uuid         "68976819-9300-4c1c-8880-aefb98a6ddc6" ;
+    skos:prefLabel  "Winning van delfstoffen"@nl ;
+    skos:prefLabel  "Mining of minerals"@en ;
+    skos:definition "Winning van delfstoffen"@nl ;
+    skos:definition "Mining of minerals"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingIndustrie
+    a               skos:Concept ;
+    mu:uuid         "79d68dad-92c1-41d5-9481-a3705dad6b7b" ;
+    skos:prefLabel  "Industrie"@nl ;
+    skos:prefLabel  "Industry"@en ;
+    skos:definition "Industrie"@nl ;
+    skos:definition "Industry"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingElektriciteitGas
+    a               skos:Concept ;
+    mu:uuid         "f222ae51-2c28-40b2-9840-fa266caab013" ;
+    skos:prefLabel  "Productie en distributie van elektriciteit, gas, stoom en gekoelde lucht"@nl ;
+    skos:prefLabel  "Production and distribution of electricity, gas, steam and cooled air"@en ;
+    skos:definition "Productie en distributie van elektriciteit, gas, stoom en gekoelde lucht"@nl ;
+    skos:definition "Production and distribution of electricity, gas, steam and cooled air"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingWater
+    a               skos:Concept ;
+    mu:uuid         "5d0f6a47-2cd6-4bba-9dca-500a395c47f8" ;
+    skos:prefLabel  "Distributie van water; afval- en afvalwaterbeheer en sanering"@nl ;
+    skos:prefLabel  "Distribution of water; waste and wastewater management and remediation"@en ;
+    skos:definition "Distributie van water; afval- en afvalwaterbeheer en sanering"@nl ;
+    skos:definition "Distribution of water; waste and wastewater management and remediation"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingBouwnijverheid
+    a               skos:Concept ;
+    mu:uuid         "90c36eba-dae7-442d-81af-e31590747b75" ;
+    skos:prefLabel  "Bouwnijverheid"@nl ;
+    skos:prefLabel  "Construction industry"@en ;
+    skos:definition "Bouwnijverheid"@nl ;
+    skos:definition "Construction industry"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingHandelVoertuigen
+    a               skos:Concept ;
+    mu:uuid         "8c843a32-deb1-49da-a73f-435b3b86a39d" ;
+    skos:prefLabel  "Groot- en detailhandel; reparatie van auto's en motorfietsen"@nl ;
+    skos:prefLabel  "Wholesale and retail trade; repair of cars and motorcycles"@en ;
+    skos:definition "Groot- en detailhandel; reparatie van auto's en motorfietsen (Handel)"@nl ;
+    skos:definition "Wholesale and retail trade; repair of cars and motorcycles (Trade)"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingVervoerOpslag
+    a               skos:Concept ;
+    mu:uuid         "891e1d74-7c1e-4a60-8355-93a632466d83" ;
+    skos:prefLabel  "Vervoer en opslag"@nl ;
+    skos:prefLabel  "Transport and storage"@en ;
+    skos:definition "Vervoer en opslag"@nl ;
+    skos:definition "Transport and storage"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingAccommodatieMaaltijden
+    a               skos:Concept ;
+    mu:uuid         "d454d32d-1419-4e86-9b92-89a6d1241c57" ;
+    skos:prefLabel  "Verschaffen van accommodatie en maaltijden"@nl ;
+    skos:prefLabel  "Provision of accommodation and meals"@en ;
+    skos:definition "Verschaffen van accommodatie en maaltijden (Horeca en toerisme)"@nl ;
+    skos:definition "Provision of accommodation and meals (Catering and tourism)"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingInformatieCommunicatie
+    a               skos:Concept ;
+    mu:uuid         "88e2003c-8289-4ba2-81d6-590df8f55d2b" ;
+    skos:prefLabel  "Informatie en communicatie"@nl ;
+    skos:prefLabel  "Information and communication"@en ;
+    skos:definition "Informatie en communicatie"@nl ;
+    skos:definition "Information and communication"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingFinancienVerzekeringen
+    a               skos:Concept ;
+    mu:uuid         "b1360cec-857d-4ae2-8e07-a5c5a9721067" ;
+    skos:prefLabel  "Financiële activiteiten en verzekeringen"@nl ;
+    skos:prefLabel  "Financial activities and insurances"@en ;
+    skos:definition "Financiële activiteiten en verzekeringen"@nl ;
+    skos:definition "Financial activities and insurances"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingOnroerendGoed
+    a               skos:Concept ;
+    mu:uuid         "ce845deb-2e1a-40fa-a139-b35a4358a42b" ;
+    skos:prefLabel  "Exploitatie van en handel in onroerend goed"@nl ;
+    skos:prefLabel  "Real estate operation and trade"@en ;
+    skos:definition "Exploitatie van en handel in onroerend goed"@nl ;
+    skos:definition "Real estate operation and trade"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingVrijeBeroepenWetenschappelijk
+    a               skos:Concept ;
+    mu:uuid         "03071c28-8207-4a0e-a242-651c449ca1dd" ;
+    skos:prefLabel  "Vrije beroepen en wetenschappelijke en technische activiteiten"@nl ;
+    skos:prefLabel  "Liberal professions and scientific and technical activities"@en ;
+    skos:definition "Vrije beroepen en wetenschappelijke en technische activiteiten"@nl ;
+    skos:definition "Liberal professions and scientific and technical activities"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingAdministratie
+    a               skos:Concept ;
+    mu:uuid         "1a70188e-a1c1-45b8-a33d-9b2d57251e08" ;
+    skos:prefLabel  "Administratieve en ondersteunende diensten"@nl ;
+    skos:prefLabel  "Administrative and support services"@en ;
+    skos:definition "Administratieve en ondersteunende diensten"@nl ;
+    skos:definition "Administrative and support services"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingOpenbaarBestuurDefensie
+    a               skos:Concept ;
+    mu:uuid         "dd657be6-ca90-4fbc-aaab-988dcacb6d8d" ;
+    skos:prefLabel  "Openbaar bestuur en defensie; verplichte sociale verzekeringen"@nl ;
+    skos:prefLabel  "Public administration and defense; compulsory social insurances"@en ;
+    skos:definition "Openbaar bestuur en defensie; verplichte sociale verzekeringen"@nl ;
+    skos:definition "Public administration and defense; compulsory social insurances"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingOnderwijs
+    a               skos:Concept ;
+    mu:uuid         "44340fa2-6800-450c-9715-559de25a8d3d" ;
+    skos:prefLabel  "Onderwijs"@nl ;
+    skos:prefLabel  "Education"@en ;
+    skos:definition "Onderwijs"@nl ;
+    skos:definition "Education"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingGezondheidszorg
+    a               skos:Concept ;
+    mu:uuid         "6267db40-e539-4670-92ac-fbb375158940" ;
+    skos:prefLabel  "Menselijke gezondheidszorg en maatschappelijke dienstverlening"@nl ;
+    skos:prefLabel  "Human health and social services"@en ;
+    skos:definition "Menselijke gezondheidszorg en maatschappelijke dienstverlening"@nl ;
+    skos:definition "Human health and social services"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingKunstAmusementRecreatie
+    a               skos:Concept ;
+    mu:uuid         "e18bf732-8ee2-4336-9c4f-7888d659d189" ;
+    skos:prefLabel  "Kunst, amusement en recreatie"@nl ;
+    skos:prefLabel  "Arts, entertainment and recreation"@en ;
+    skos:definition "Kunst, amusement en recreatie (Culturele en creatieve sector)"@nl ;
+    skos:definition "Arts, entertainment and recreation (Cultural and creative sector)"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingOverige
+    a               skos:Concept ;
+    mu:uuid         "06ccdc62-bfd9-4af9-a1aa-4e56147b38e3" ;
+    skos:prefLabel  "Overige diensten"@nl ;
+    skos:prefLabel  "Other services"@en ;
+    skos:definition "Overige diensten"@nl ;
+    skos:definition "Other services"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingHuishoudens
+    a               skos:Concept ;
+    mu:uuid         "a77f5c1b-9546-4073-96a4-a75278173e37" ;
+    skos:prefLabel  "Huishoudens als werkgever"@nl ;
+    skos:prefLabel  "Households as employers"@en ;
+    skos:definition "Huishoudens als werkgever; niet-gedifferentieerde productie van goederen en diensten door huishoudens voor eigen gebruik"@nl ;
+    skos:definition "Households as employers"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:OndernemingExtraterritoriaal
+    a               skos:Concept ;
+    mu:uuid         "8e2883a8-0975-4843-80e5-8e66de44f37a" ;
+    skos:prefLabel  "Extraterritoriale organisaties en lichamen"@nl ;
+    skos:prefLabel  "Extraterritorial organizations and bodies"@en ;
+    skos:definition "Extraterritoriale organisaties en lichamen"@nl ;
+    skos:definition "Extraterritorial organizations and bodies"@en ;
+    skos:inScheme   dvcs:Doelgroep ;
+    skos:broader    dvc:Onderneming .
+
+dvc:Organisatie
+    a                 skos:Concept ;
+    mu:uuid           "98183fca-45dd-4141-a191-9a2cbdba85cb" ;
+    skos:prefLabel    "Organisatie"@nl ;
+    skos:prefLabel    "Organisation"@en ;
+    skos:definition   "Doelgroep organisaties"@nl ;
+    skos:definition   "Target audience organisation"@en ;
+    skos:inScheme     dvcs:Doelgroep ;
+    skos:topConceptOf dvcs:Doelgroep .
+
+dvc:Vereniging
+    a                 skos:Concept ;
+    mu:uuid           "bd1e7ba5-4b12-4cb5-a303-687277897ace" ;
+    skos:prefLabel    "Vereniging"@nl ;
+    skos:prefLabel    "Association"@en ;
+    skos:definition   "Doelgroep verenigingen"@nl ;
+    skos:definition   "Target audience association"@en ;
+    skos:inScheme     dvcs:Doelgroep ;
+    skos:topConceptOf dvcs:Doelgroep .
+
+dvc:LokaalBestuur
+    a                 skos:Concept ;
+    mu:uuid           "01f7b215-3eb6-4997-8bb7-4c2b2ffcb138" ;
+    skos:prefLabel    "Lokaal bestuur"@nl ;
+    skos:prefLabel    "Local administration"@en ;
+    skos:definition   "Doelgroep lokaal bestuur"@nl ;
+    skos:definition   "Target audience local administration"@en ;
+    skos:inScheme     dvcs:Doelgroep ;
+    skos:topConceptOf dvcs:Doelgroep .
+
+dvc:VlaamseOverheid
+    a                 skos:Concept ;
+    mu:uuid           "093fd217-10db-4985-9fba-699a6b587d32" ;
+    skos:prefLabel    "Vlaamse Overheid"@nl ;
+    skos:prefLabel    "Flemish government"@en ;
+    skos:definition   "Doelgroep vlaamse overheid"@nl ;
+    skos:definition   "Target flemish government"@en ;
+    skos:inScheme     dvcs:Doelgroep ;
+    skos:topConceptOf dvcs:Doelgroep .


### PR DESCRIPTION
(Addresses DL-4643) Add local administration and flemish goverment to doelgroep codelist.

To test:
- Create a completely new public service/product.
- Go to the "Eigenschappen" tab, and to the "doelgroep" input box specifically.
- "Local administration/lokaal bestuur" and "Flemish government/Vlaamse overheid" should show up in the "doelgroep" box.