### PR TITLE
Added migration to flush for OP - sync v1

### DIFF
--- a/config/migrations/2023/20230310062435-sync-op/20230309162437-flush-erediensten-before-sync-with-op.sparql
+++ b/config/migrations/2023/20230310062435-sync-op/20230309162437-flush-erediensten-before-sync-with-op.sparql
@@ -1,0 +1,162 @@
+# removes GestructureerdeIdentificator
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?typeOfInterest {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <https://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+      ?p ?o.
+
+    ?id <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ?s;
+      a <http://www.w3.org/ns/adms#Identifier>.
+
+    ?bestuurseenheid <http://www.w3.org/ns/adms#identifier> ?id;
+      a ?typeOfInterest.
+  }
+}
+
+;
+
+# removes identifiers of interest
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?typeOfInterest {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <https://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+
+    ?s a <http://www.w3.org/ns/adms#Identifier>;
+      ?p ?o.
+
+    ?bestuurseenheid <http://www.w3.org/ns/adms#identifier> ?s;
+      a ?typeOfInterest.
+  }
+}
+
+;
+
+# remove mandates
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?typeOfInterest {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <https://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+
+    ?s a <http://data.vlaanderen.be/ns/mandaat#Mandaat>;
+      ?p ?o.
+
+    ?bot a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+      <http://www.w3.org/ns/org#hasPost> ?s;
+      <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan.
+
+    ?orgaan a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+      <http://data.vlaanderen.be/ns/besluit#bestuurt> ?eenheid.
+    ?eenheid a ?typeOfInterest.
+  }
+}
+
+;
+
+# bestuursorganen in tijd
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?typeOfInterest {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <https://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+      ?p ?o;
+      <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan.
+    ?orgaan a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+      <http://data.vlaanderen.be/ns/besluit#bestuurt> ?eenheid.
+    ?eenheid a ?typeOfInterest.
+  }
+}
+
+;
+
+# bestuursorganen
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?typeOfInterest {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <https://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+      ?p ?o;
+      <http://data.vlaanderen.be/ns/besluit#bestuurt> ?eenheid.
+    ?eenheid a ?typeOfInterest.
+  }
+}
+
+;
+
+# remaining
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?type {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <https://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+    <https://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>
+    <http://data.lblod.info/vocabularies/erediensten/PositieBedienaar>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a ?type;
+      ?p ?o.
+  }
+}
+
+;
+
+# betrokken lokaal bestuur
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?o.
+  }
+}
+WHERE {
+  VALUES ?type {
+    <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a ?type;
+      <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?o.
+  }
+}


### PR DESCRIPTION
@bdevloed this migration flushes the data that will be managed in the first version of OP sync. It targets `feature/op-public-consumer`. You can just merge.