### PR TITLE
Fix duplicate label in YourEuropeCategory code-list

### DIFF
--- a/config/migrations/2023/20230321151511-fix-duplicate-in-YourEuropeCategory-codelist.sparql
+++ b/config/migrations/2023/20230321151511-fix-duplicate-in-YourEuropeCategory-codelist.sparql
@@ -1,0 +1,13 @@
+PREFIX dvc:   <https://productencatalogus.data.vlaanderen.be/id/concept/YourEuropeCategorie/>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    dvc:ProcedureStartenExploiterenSluitenBedrijf skos:prefLabel "Starten, exploiteren en sluiten van een bedrijf"@nl .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    dvc:ProcedureStartenExploiterenSluitenBedrijf skos:prefLabel "Procedures voor starten, exploiteren en sluiten van een bedrijf"@nl .
+  }
+}


### PR DESCRIPTION
(Addresses DL-4960) Remove a duplicate label in YourEuropeCategory that was shared between "dvc:Bedrijf" and "dvc:ProcedureStartenExploiterenSluitenBedrijf ".

To test:
1. Log in as any gemeente.
2. Go to the "Producten- en dienstencatalogus" module.
3. Edit an existing product or create a completely new one.
4. Go to the "Eigenschappen" tab and scroll down to the "Categorieën Your Europe" field.
5. Search for "starten" and two results should show up:
    a. "Starten, exploiteren en sluiten van een bedrijf"
    b. "Procedures voor starten, exploiteren en sluiten van een bedrijf"