### PR TITLE
Remove codelist values for gemeente and provincie in module toezicht

### DIFF
--- a/config/migrations/2023/20230322150947-remove-codelist-values-for-gemeente-and-provincie-in-module-toezicht.sparql
+++ b/config/migrations/2023/20230322150947-remove-codelist-values-for-gemeente-and-provincie-in-module-toezicht.sparql
@@ -1,0 +1,12 @@
+PREFIX besluit: <http://lblod.data.gift/vocabularies/besluit/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Delete Advies samenvoeging for Gemeente
+    <https://data.vlaanderen.be/id/concept/BesluitType/4efa4632-efc6-40d5-815a-dec785fbceac> besluit:decidableBy <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> . # Gemeente
+
+    # Delete Verslag lokale betrokkenheid for Gemeente and Provincie
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/e274f1b1-7e84-457d-befe-070afec6b752> besluit:decidableBy <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> . # Provincie
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/e274f1b1-7e84-457d-befe-070afec6b752> besluit:decidableBy <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> . # Gemeente
+  }
+}


### PR DESCRIPTION
(Addresses DL-4964) Remove "Advies samenvoeging eredienstbesturen" code list for Gemeente and "Verslag lokale betrokkenheid eredienstbesturen" code list for Gemeente and Provincie.

Testing on development data is limited to "Gemeente" since there is no "Provincie" in the development mock data. To test:
1. Log in as any Gemeente
2. Go to the "Toezicht" module
3. Click on "Maak nieuwe melding"
4. "Advies samenvoeging eredienstbesturen" and "Verslag lokale betrokkenheid eredienstbesturen" will not show up when you search for them.