### PR TITLE
[DL-4974] Fix vendor access management for worship services

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -347,7 +347,18 @@ defmodule Acl.UserGroups.Config do
                     constraint: %ResourceConstraint{
                       resource_types: [
                         "http://mu.semte.ch/vocabularies/ext/Vendor"
-                      ] } } ] },
+                      ] } },
+                  %GraphSpec{
+                    graph: "http://mu.semte.ch/graphs/public",
+                    constraint: %ResourceConstraint{
+                      resource_types: [
+                        "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
+                      ],
+                  predicates: %NoPredicates{
+                    except: [
+                     "http://mu.semte.ch/vocabularies/account/canActOnBehalfOf"
+                     ] } } }
+                  ] },
 
       # // LEIDINGGEVENDEN
       %GroupSpec{

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -642,7 +642,7 @@ defmodule Dispatcher do
   end
 
   match "/worship-services/*path" do
-    forward conn, path, "http://resource/worship-services/"
+    forward conn, path, "http://cache/worship-services/"
   end
 
   match "/recognized-worship-types/*path" do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     restart: always
     logging: *default-logging
   vendor-management:
-    image: lblod/frontend-vendor-access-management:0.6.0
+    image: lblod/frontend-vendor-access-management:0.7.0
     links:
       - identifier:backend
     labels:


### PR DESCRIPTION
This allows the user to manage vendors for worship related administrative units. I'm not sure if this is the correct fix but it seems the user also had all other roles already.

It's possible that this should be hotfixed.