### PR TITLE
Revert "update config mu-auth"

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -347,18 +347,7 @@ defmodule Acl.UserGroups.Config do
                     constraint: %ResourceConstraint{
                       resource_types: [
                         "http://mu.semte.ch/vocabularies/ext/Vendor"
-                      ] } },
-                  %GraphSpec{
-                    graph: "http://mu.semte.ch/graphs/public",
-                    constraint: %ResourceConstraint{
-                      resource_types: [
-                        "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
-                      ],
-                  predicates: %NoPredicates{
-                    except: [
-                     "http://mu.semte.ch/vocabularies/account/canActOnBehalfOf"
-                     ] } } }
-                  ] },
+                      ] } } ] },
 
       # // LEIDINGGEVENDEN
       %GroupSpec{


### PR DESCRIPTION
This reverts commit 6cf9656f1942531114053d3969d74734c2191bc8 that was added in #371 

That change wasn't actually needed since the underlying issue was a caching problem.