### PR TITLE
Remove the `required` validation from the executing authority field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+### LPDC
+  - make the "uitvoerende overheid" an optional field
 ## 1.78.3 (2023-03-30)
 ### General
   - added report links accross organisations

--- a/config/lpdc-management/characteristics/form.ttl
+++ b/config/lpdc-management/characteristics/form.ttl
@@ -199,12 +199,6 @@ ext:authorityPg a form:PropertyGroup;
       form:help "Meerdere overheden kunnen worden toegewezen";
       sh:order 30 ;
       sh:path lpdcExt:hasExecutingAuthority ;
-      form:validations [
-        a form:RequiredConstraint ;
-        form:grouping form:Bag ;
-        sh:resultMessage "Dit veld is verplicht." ;
-        sh:path lpdcExt:hasExecutingAuthority
-      ];
       form:options  """
                      {
                        "conceptScheme":"https://productencatalogus.data.vlaanderen.be/id/conceptscheme/IPDCOrganisaties/tailored"


### PR DESCRIPTION
It should only be required in some cases, but we can't cover that with conditional fields yet so we disable the requirement altogether.

[DL-4568]