### PR TITLE
Change date title for subsidie opknapwerken slaapplekken oekraine

### DIFF
--- a/config/migrations/2023/20230405215914-change-date-title-for-subsidie-opknapwerken-slaapplekken-Oekraine.sparql
+++ b/config/migrations/2023/20230405215914-change-date-title-for-subsidie-opknapwerken-slaapplekken-Oekraine.sparql
@@ -1,0 +1,30 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX m8g: <http://data.europa.eu/m8g/>
+
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # SubsidiemaatregelAanbodReeks for the Opknapwerken slaapplekken Oekraïne subsidy
+    # Title to be deleted is "Oproep 1"
+    <http://lblod.data.info/id/subsidy-measure-offer-series/fecdeba8-cabb-43b0-a0a1-3ab7a1d4a773> dct:title ?title .
+
+    # End time for the Aanvraag step to be deleted is "30 September, 2023"
+    <http://data.lblod.info/id/periodes/cbc00fd0-0d0e-4c99-8dfc-691db7dde72d> m8g:endTime ?endTime1 .
+
+    # End time for the SubsidiemaatregelAanbod to be deleted is "30 September, 2023"
+    <http://data.lblod.info/id/periodes/9e11f337-8575-4c8f-a9e5-34d7d91988da> m8g:endTime ?endTime2 .
+  }
+}
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # SubsidiemaatregelAanbodReeks for the Opknapwerken slaapplekken Oekraïne subsidy
+    # Title to be added is "Oproep"
+    <http://lblod.data.info/id/subsidy-measure-offer-series/fecdeba8-cabb-43b0-a0a1-3ab7a1d4a773> dct:title "Oproep"@nl .
+
+    # End time for the Aanvraag step to be added is "31 March, 2024"
+    <http://data.lblod.info/id/periodes/cbc00fd0-0d0e-4c99-8dfc-691db7dde72d> m8g:endTime "2024-03-31T21:59:59Z"^^xsd:dateTime .
+
+    # End time for the SubsidiemaatregelAanbod to be added is "31 March, 2024"
+    <http://data.lblod.info/id/periodes/9e11f337-8575-4c8f-a9e5-34d7d91988da> m8g:endTime "2024-03-31T21:59:59Z"^^xsd:dateTime .
+  }
+}


### PR DESCRIPTION
(Addresses DL-5009) Change date title for subsidie opknapwerken slaapplekken oekraïne from 30 September, 2023 to 31 March, 2024.

To test:
* Log in as any gemeente
* Go to the subsidy module and search for the "Opknapwerken Slaapplekken Oekraïne" subsidy
* The "Periode" column should have "Oproep" as title with a duration of "14 maart 2022 – 31 maart 2024"
* The "Aanvragen tot" column should have a value of "31 maart 2024".
* Open the subsidy and save it as a Concept.
* The "Indienen tot" column should have a value of "31 maart 2024".