### PR TITLE
Automatically create the row for the eigen aandeel table in the financiele analyse section

### DIFF
--- a/config/subsidy-application-management/forms/urban-renewal/application-phase2/versions/20221218090000/form.ttl
+++ b/config/subsidy-application-management/forms/urban-renewal/application-phase2/versions/20221218090000/form.ttl
@@ -638,6 +638,9 @@ ext:projectOnderdeelPg a form:PropertyGroup;
     form:prototype [
       form:shape [
         a lblodSubsidie:projectOnderdeelUnit ;
+        lblodSubsidie:projectOnderdeelStadUnit [
+          a lblodSubsidie:projectOnderdeelStadUnit
+        ]
       ];
     ];
     form:dataGenerator form:addMuUuid.


### PR DESCRIPTION
It seems that it is possible to generate nested listing items using the generators.