### PR TITLE
Allow changes to bestuurseenheid for vendor access management

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -346,7 +346,8 @@ defmodule Acl.UserGroups.Config do
                     graph: "http://mu.semte.ch/graphs/automatic-submission",
                     constraint: %ResourceConstraint{
                       resource_types: [
-                        "http://mu.semte.ch/vocabularies/ext/Vendor"
+                        "http://mu.semte.ch/vocabularies/ext/Vendor",
+                        "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid"
                       ] } } ] },
 
       # // LEIDINGGEVENDEN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -850,7 +850,7 @@ services:
       - "logging=true"
     logging: *default-logging
   op-public-consumer:
-    image: lblod/delta-consumer:0.0.17-rc.6
+    image: lblod/delta-consumer:0.0.17-rc.7
     environment:
       DCR_SERVICE_NAME: "op-public-consumer"
       DCR_SYNC_BASE_URL: "https://organisaties.abb.lblod.info" # replace with link to OP API


### PR DESCRIPTION
DL-5012

Needed for https://github.com/lblod/frontend-vendor-access-management/pull/10.

Vendor access management needs to be able to set view-only-modules to the bestuurseenheid.