### PR TITLE
Add the Hoppinpunten and Haltes external subsidies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   - Only toezichthoudende betrokkenheid should be shown (hence bump enrich-submission)
 ### Erediensten
   - flush, rerun op sync migrations to fix typeBetrokkenheid
+### Subsidies
+  - Add two new external subsidies (Hoppinpunten and Haltes)
 ### deploy instructions
 - Follow the steps to re-sync data from OP
 ## 1.81.1 (2023-05-18)

--- a/config/migrations/2023/20230524133607-add-external-subsidy-hoppinpunten.sparql
+++ b/config/migrations/2023/20230524133607-add-external-subsidy-hoppinpunten.sparql
@@ -8,7 +8,7 @@ PREFIX cpsv:          <http://purl.org/vocab/cpsv#>
 PREFIX xkos:          <http://rdf-vocabulary.ddialliance.org/xkos#>
 PREFIX qb:            <http://purl.org/linked-data/cube#>
 PREFIX xsd:           <http://www.w3.org/2001/XMLSchema#>
-PREFIX mg8:           <http://data.europa.eu/m8g/>
+PREFIX m8g:           <http://data.europa.eu/m8g/>
 PREFIX common:        <http://www.w3.org/2007/uwa/context/common.owl#>
 
 #
@@ -30,9 +30,9 @@ INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
     # Period of the series
     <http://data.lblod.info/id/periodes/f3357ba2-abd4-44b3-a66b-70e8f3f9671f>
-      a             mg8:PeriodOfTime ;
+      a             m8g:PeriodOfTime ;
       mu:uuid       "f3357ba2-abd4-44b3-a66b-70e8f3f9671f" ;
-      mg8:startTime "2023-05-29T21:59:59Z"^^xsd:dateTime .
+      m8g:startTime "2023-05-29T21:59:59Z"^^xsd:dateTime .
 
     # Step(s) of the series
     <http://data.lblod.info/id/subsidy-procedural-steps/570fb5da-4874-46f5-8adb-3467cf88f3f2>
@@ -74,6 +74,7 @@ INSERT DATA {
       dct:title                 """Subsidie voor Hoppinpunten""" ;
       skos:prefLabel            """Subsidie voor Hoppinpunten""" ;
       skos:related              <https://www.vlaanderen.be/subsidies-voor-de-aanleg-of-herinrichting-van-een-hoppinpunt> ;
+      m8g:hasCriterion          <http://data.lblod.info/id/criterions/f5ea0615-0b0a-47db-a38c-6097ff80815d> ; # Available only for "gemeenten"
       cpsv:follows              <http://data.lblod.info/id/subsidy-procedural-steps/570fb5da-4874-46f5-8adb-3467cf88f3f2> ;
       lblodSubsidie:heeftReeks  <http://lblod.data.info/id/subsidy-measure-offer-series/3bfba485-f211-445c-80b7-e340c410ce1d> .
   }

--- a/config/migrations/2023/20230524133607-add-external-subsidy-hoppinpunten.sparql
+++ b/config/migrations/2023/20230524133607-add-external-subsidy-hoppinpunten.sparql
@@ -32,7 +32,8 @@ INSERT DATA {
     <http://data.lblod.info/id/periodes/f3357ba2-abd4-44b3-a66b-70e8f3f9671f>
       a             m8g:PeriodOfTime ;
       mu:uuid       "f3357ba2-abd4-44b3-a66b-70e8f3f9671f" ;
-      m8g:startTime "2023-05-29T21:59:59Z"^^xsd:dateTime .
+      m8g:startTime "2023-05-29T21:59:59Z"^^xsd:dateTime ;
+      m8g:endTime   "3000-05-29T21:59:59Z"^^xsd:dateTime .
 
     # Step(s) of the series
     <http://data.lblod.info/id/subsidy-procedural-steps/570fb5da-4874-46f5-8adb-3467cf88f3f2>

--- a/config/migrations/2023/20230524133607-add-external-subsidy-hoppinpunten.sparql
+++ b/config/migrations/2023/20230524133607-add-external-subsidy-hoppinpunten.sparql
@@ -1,0 +1,80 @@
+PREFIX mobiliteit:    <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>
+PREFIX dct:           <http://purl.org/dc/terms/>
+PREFIX subsidie:      <http://data.vlaanderen.be/ns/subsidie#>
+PREFIX gleif:         <https://www.gleif.org/ontology/Base/>
+PREFIX mu:            <http://mu.semte.ch/vocabularies/core/>
+PREFIX cpsv:          <http://purl.org/vocab/cpsv#>
+PREFIX xkos:          <http://rdf-vocabulary.ddialliance.org/xkos#>
+PREFIX qb:            <http://purl.org/linked-data/cube#>
+PREFIX xsd:           <http://www.w3.org/2001/XMLSchema#>
+PREFIX mg8:           <http://data.europa.eu/m8g/>
+PREFIX common:        <http://www.w3.org/2007/uwa/context/common.owl#>
+
+#
+# Create subsidy procedure step type for external processing
+#
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.gift/concepts/3ded9eab-ff5b-4a20-a095-0825de486f42>
+      a               skos:Concept, rdfs:Class ;
+      mu:uuid         "3ded9eab-ff5b-4a20-a095-0825de486f42" ;
+      skos:prefLabel  "Externe verwerking"@nl ;
+      skos:inScheme   <http://lblod.data.gift/concept-schemes/77604806-1006-459b-9228-583d279c7a1c> .
+  }
+}
+
+;
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Period of the series
+    <http://data.lblod.info/id/periodes/f3357ba2-abd4-44b3-a66b-70e8f3f9671f>
+      a             mg8:PeriodOfTime ;
+      mu:uuid       "f3357ba2-abd4-44b3-a66b-70e8f3f9671f" ;
+      mg8:startTime "2023-05-29T21:59:59Z"^^xsd:dateTime .
+
+    # Step(s) of the series
+    <http://data.lblod.info/id/subsidy-procedural-steps/570fb5da-4874-46f5-8adb-3467cf88f3f2>
+      a                                   subsidie:Subsidieprocedurestap ;
+      mu:uuid                             "570fb5da-4874-46f5-8adb-3467cf88f3f2" ;
+      dct:description                     """Externe verwerking""" ;
+      subsidie:Subsidieprocedurestap.type <http://lblod.data.gift/concepts/3ded9eab-ff5b-4a20-a095-0825de486f42> ; # External processing
+      mobiliteit:periode                  <http://data.lblod.info/id/periodes/f3357ba2-abd4-44b3-a66b-70e8f3f9671f> .
+
+    # Step(s) of the active submission flow
+    <http://lblod.data.info/id/subsidie-application-flow-steps/0a1bfaab-a3aa-478c-a843-9ad1444ad192>
+      a                 lblodSubsidie:ApplicationStep ;
+      mu:uuid           "0a1bfaab-a3aa-478c-a843-9ad1444ad192" ;
+      qb:order          0 ;
+      dct:references    <http://data.lblod.info/id/subsidy-procedural-steps/570fb5da-4874-46f5-8adb-3467cf88f3f2> ;
+      dct:isPartOf      <http://lblod.data.info/id/subsidie-application-flows/394add49-28c4-48a4-bc67-c34db51502e3> ;
+      dct:isReplacedBy  <https://subsidiesmobiliteitsbeleid.vlaanderen.be/> .
+
+    # Active submission flow for latest hoppinpunten subsidy series
+    <http://lblod.data.info/id/subsidie-application-flows/394add49-28c4-48a4-bc67-c34db51502e3>
+      a               lblodSubsidie:ApplicationFlow ;
+      mu:uuid         "394add49-28c4-48a4-bc67-c34db51502e3" ;
+      xkos:belongsTo  <http://lblod.data.info/id/subsidy-measure-offer-series/3bfba485-f211-445c-80b7-e340c410ce1d> ;
+      xkos:next       <http://lblod.data.info/id/subsidie-application-flow-steps/0a1bfaab-a3aa-478c-a843-9ad1444ad192> .
+
+    # Create Series for subsidy call named "Oproep"
+    <http://lblod.data.info/id/subsidy-measure-offer-series/3bfba485-f211-445c-80b7-e340c410ce1d>
+      a                   lblodSubsidie:SubsidiemaatregelAanbodReeks ;
+      mu:uuid             "3bfba485-f211-445c-80b7-e340c410ce1d" ;
+      dct:title           "Oproep"@nl ;
+      dct:description     "29/05/2023 — nvt"@nl ;
+      mobiliteit:periode  <http://data.lblod.info/id/periodes/f3357ba2-abd4-44b3-a66b-70e8f3f9671f> ;
+      common:active       <http://lblod.data.info/id/subsidie-application-flows/394add49-28c4-48a4-bc67-c34db51502e3> .
+
+    # Subsidy offer for "hoppinpunten"
+    <http://lblod.data.info/id/subsidy-measure-offers/b6e5ccd5-ddaf-4b74-b023-a712886f3814>
+      a                         subsidie:SubsidiemaatregelAanbod ;
+      mu:uuid                   "b6e5ccd5-ddaf-4b74-b023-a712886f3814" ;
+      dct:title                 """Subsidie voor Hoppinpunten""" ;
+      skos:prefLabel            """Subsidie voor Hoppinpunten""" ;
+      skos:related              <https://www.vlaanderen.be/subsidies-voor-de-aanleg-of-herinrichting-van-een-hoppinpunt> ;
+      cpsv:follows              <http://data.lblod.info/id/subsidy-procedural-steps/570fb5da-4874-46f5-8adb-3467cf88f3f2> ;
+      lblodSubsidie:heeftReeks  <http://lblod.data.info/id/subsidy-measure-offer-series/3bfba485-f211-445c-80b7-e340c410ce1d> .
+  }
+}

--- a/config/migrations/2023/20230524174121-add-external-subsidy-haltes.sparql
+++ b/config/migrations/2023/20230524174121-add-external-subsidy-haltes.sparql
@@ -1,0 +1,65 @@
+PREFIX mobiliteit:    <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>
+PREFIX dct:           <http://purl.org/dc/terms/>
+PREFIX subsidie:      <http://data.vlaanderen.be/ns/subsidie#>
+PREFIX gleif:         <https://www.gleif.org/ontology/Base/>
+PREFIX mu:            <http://mu.semte.ch/vocabularies/core/>
+PREFIX cpsv:          <http://purl.org/vocab/cpsv#>
+PREFIX xkos:          <http://rdf-vocabulary.ddialliance.org/xkos#>
+PREFIX qb:            <http://purl.org/linked-data/cube#>
+PREFIX xsd:           <http://www.w3.org/2001/XMLSchema#>
+PREFIX mg8:           <http://data.europa.eu/m8g/>
+PREFIX common:        <http://www.w3.org/2007/uwa/context/common.owl#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Period of the series
+    <http://data.lblod.info/id/periodes/9afd5470-93e1-4ff8-8722-6ad648aa1d1e>
+      a             mg8:PeriodOfTime ;
+      mu:uuid       "9afd5470-93e1-4ff8-8722-6ad648aa1d1e" ;
+      mg8:startTime "2023-05-29T21:59:59Z"^^xsd:dateTime .
+
+    # Step(s) of the series
+    <http://data.lblod.info/id/subsidy-procedural-steps/58a5b63c-f653-422c-87f2-94e1fc3779fd>
+      a                                   subsidie:Subsidieprocedurestap ;
+      mu:uuid                             "58a5b63c-f653-422c-87f2-94e1fc3779fd" ;
+      dct:description                     """Externe verwerking""" ;
+      subsidie:Subsidieprocedurestap.type <http://lblod.data.gift/concepts/3ded9eab-ff5b-4a20-a095-0825de486f42> ; # External processing
+      mobiliteit:periode                  <http://data.lblod.info/id/periodes/9afd5470-93e1-4ff8-8722-6ad648aa1d1e> .
+
+    # Step(s) of the active submission flow
+    <http://lblod.data.info/id/subsidie-application-flow-steps/0dacd9e0-b454-4c4a-a836-09684cebcfe3>
+      a                 lblodSubsidie:ApplicationStep ;
+      mu:uuid           "0dacd9e0-b454-4c4a-a836-09684cebcfe3" ;
+      qb:order          0 ;
+      dct:references    <http://data.lblod.info/id/subsidy-procedural-steps/58a5b63c-f653-422c-87f2-94e1fc3779fd> ;
+      dct:isPartOf      <http://lblod.data.info/id/subsidie-application-flows/46409542-df7a-4cc1-9457-816b46736fdd> ;
+      dct:isReplacedBy  <https://subsidiesmobiliteitsbeleid.vlaanderen.be/> .
+
+    # Active submission flow for latest hoppinpunten subsidy series
+    <http://lblod.data.info/id/subsidie-application-flows/46409542-df7a-4cc1-9457-816b46736fdd>
+      a               lblodSubsidie:ApplicationFlow ;
+      mu:uuid         "46409542-df7a-4cc1-9457-816b46736fdd" ;
+      xkos:belongsTo  <http://lblod.data.info/id/subsidy-measure-offer-series/edb2c04c-99a6-4f88-9418-1d928dfd8447> ;
+      xkos:next       <http://lblod.data.info/id/subsidie-application-flow-steps/0dacd9e0-b454-4c4a-a836-09684cebcfe3> .
+
+    # Create Series for subsidy call named "Oproep"
+    <http://lblod.data.info/id/subsidy-measure-offer-series/edb2c04c-99a6-4f88-9418-1d928dfd8447>
+      a                   lblodSubsidie:SubsidiemaatregelAanbodReeks ;
+      mu:uuid             "edb2c04c-99a6-4f88-9418-1d928dfd8447" ;
+      dct:title           "Oproep"@nl ;
+      dct:description     "29/05/2023 — nvt"@nl ;
+      mobiliteit:periode  <http://data.lblod.info/id/periodes/9afd5470-93e1-4ff8-8722-6ad648aa1d1e> ;
+      common:active       <http://lblod.data.info/id/subsidie-application-flows/46409542-df7a-4cc1-9457-816b46736fdd> .
+
+    # Subsidy offer for "hoppinpunten"
+    <http://lblod.data.info/id/subsidy-measure-offers/60ea4171-e795-4138-998d-5888d29bdd21>
+      a                         subsidie:SubsidiemaatregelAanbod ;
+      mu:uuid                   "60ea4171-e795-4138-998d-5888d29bdd21" ;
+      dct:title                 """Subsidie voor het toegankelijk aanleggen of herinrichten van haltes en de uitrusting van haltes""" ;
+      skos:prefLabel            """Subsidie voor het toegankelijk aanleggen of herinrichten van haltes en de uitrusting van haltes""" ;
+      skos:related              <https://www.vlaanderen.be/subsidies-voor-het-toegankelijk-aanleggen-of-herinrichten-van-haltes-en-de-uitrusting-van-haltes> ;
+      cpsv:follows              <http://data.lblod.info/id/subsidy-procedural-steps/58a5b63c-f653-422c-87f2-94e1fc3779fd> ;
+      lblodSubsidie:heeftReeks  <http://lblod.data.info/id/subsidy-measure-offer-series/edb2c04c-99a6-4f88-9418-1d928dfd8447> .
+  }
+}

--- a/config/migrations/2023/20230524174121-add-external-subsidy-haltes.sparql
+++ b/config/migrations/2023/20230524174121-add-external-subsidy-haltes.sparql
@@ -17,7 +17,8 @@ INSERT DATA {
     <http://data.lblod.info/id/periodes/9afd5470-93e1-4ff8-8722-6ad648aa1d1e>
       a             m8g:PeriodOfTime ;
       mu:uuid       "9afd5470-93e1-4ff8-8722-6ad648aa1d1e" ;
-      m8g:startTime "2023-05-29T21:59:59Z"^^xsd:dateTime .
+      m8g:startTime "2023-05-29T21:59:59Z"^^xsd:dateTime ;
+      m8g:endTime   "3000-05-29T21:59:59Z"^^xsd:dateTime .
 
     # Step(s) of the series
     <http://data.lblod.info/id/subsidy-procedural-steps/58a5b63c-f653-422c-87f2-94e1fc3779fd>

--- a/config/migrations/2023/20230524174121-add-external-subsidy-haltes.sparql
+++ b/config/migrations/2023/20230524174121-add-external-subsidy-haltes.sparql
@@ -8,16 +8,16 @@ PREFIX cpsv:          <http://purl.org/vocab/cpsv#>
 PREFIX xkos:          <http://rdf-vocabulary.ddialliance.org/xkos#>
 PREFIX qb:            <http://purl.org/linked-data/cube#>
 PREFIX xsd:           <http://www.w3.org/2001/XMLSchema#>
-PREFIX mg8:           <http://data.europa.eu/m8g/>
+PREFIX m8g:           <http://data.europa.eu/m8g/>
 PREFIX common:        <http://www.w3.org/2007/uwa/context/common.owl#>
 
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
     # Period of the series
     <http://data.lblod.info/id/periodes/9afd5470-93e1-4ff8-8722-6ad648aa1d1e>
-      a             mg8:PeriodOfTime ;
+      a             m8g:PeriodOfTime ;
       mu:uuid       "9afd5470-93e1-4ff8-8722-6ad648aa1d1e" ;
-      mg8:startTime "2023-05-29T21:59:59Z"^^xsd:dateTime .
+      m8g:startTime "2023-05-29T21:59:59Z"^^xsd:dateTime .
 
     # Step(s) of the series
     <http://data.lblod.info/id/subsidy-procedural-steps/58a5b63c-f653-422c-87f2-94e1fc3779fd>
@@ -59,6 +59,7 @@ INSERT DATA {
       dct:title                 """Subsidie voor het toegankelijk aanleggen of herinrichten van haltes en de uitrusting van haltes""" ;
       skos:prefLabel            """Subsidie voor het toegankelijk aanleggen of herinrichten van haltes en de uitrusting van haltes""" ;
       skos:related              <https://www.vlaanderen.be/subsidies-voor-het-toegankelijk-aanleggen-of-herinrichten-van-haltes-en-de-uitrusting-van-haltes> ;
+      m8g:hasCriterion          <http://data.lblod.info/id/criterions/f5ea0615-0b0a-47db-a38c-6097ff80815d> ; # Available only for "gemeenten"
       cpsv:follows              <http://data.lblod.info/id/subsidy-procedural-steps/58a5b63c-f653-422c-87f2-94e1fc3779fd> ;
       lblodSubsidie:heeftReeks  <http://lblod.data.info/id/subsidy-measure-offer-series/edb2c04c-99a6-4f88-9418-1d928dfd8447> .
   }

--- a/config/resources/master-subsidies-domain.lisp
+++ b/config/resources/master-subsidies-domain.lisp
@@ -100,7 +100,8 @@
 
 (define-resource subsidy-application-flow-step ()
   :class (s-prefix "lblodSubsidie:ApplicationStep")
-  :properties `((:order :integer ,(s-prefix "qb:order")))
+  :properties `((:order :integer ,(s-prefix "qb:order"))
+                (:is-replaced-by :uri, (s-prefix "dct:isReplacedBy")))
   :has-one `((file :via ,(s-prefix "dct:source")
                    :as "form-specification")
              (subsidy-procedural-step :via ,(s-prefix "dct:references")

--- a/config/resources/master-subsidies-domain.lisp
+++ b/config/resources/master-subsidies-domain.lisp
@@ -101,7 +101,7 @@
 (define-resource subsidy-application-flow-step ()
   :class (s-prefix "lblodSubsidie:ApplicationStep")
   :properties `((:order :integer ,(s-prefix "qb:order"))
-                (:is-replaced-by :uri, (s-prefix "dct:isReplacedBy")))
+                (:external-process-link :uri, (s-prefix "dct:isReplacedBy")))
   :has-one `((file :via ,(s-prefix "dct:source")
                    :as "form-specification")
              (subsidy-procedural-step :via ,(s-prefix "dct:references")


### PR DESCRIPTION
(Addresses DL-4930 and DL-5120) Adds two external subsidies: Hoppinpunten and Haltes.

This PR should be used in conjuction with the following frontend PR (https://github.com/lblod/frontend-loket/pull/310), which adds support for handling external subsidies.

To test:
* Log in as any gemeente
* Go to the subsidies and add a new subsidy
* In case testing before 29 May, add `?testMode=true` to the URL to display the subsidies

Once done with the above steps:
* Two new subsidies should show up: `Subsidie voor Hoppinpunten` and `Subsidie voor het toegankelijk aanleggen of herinrichten van haltes en de uitrusting van haltes`
* Both should have `Oproep` in `Periode`, with the secondary `29 mei - N.V.T` text below.
* `Aanvragen tot` should be empty.
* Clicking on `Start aanvraag` should take you to `https://subsidiesmobiliteitsbeleid.vlaanderen.be/#/` which then re-directs to `https://authenticatie.vlaanderen.be/stb/html/ssologin`.

Given that the subsidies don't have a specific start date (tickets says any date as soon as possible), we can change the dates and merge the PR the day we want to deploy a new loket version.