### PR TITLE
Add support for concept archiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### Subsidies
   - Add two new external subsidies (Hoppinpunten and Haltes)
 ### LPDC
-  - add "nieuw" and "toegevoegd" labels and filters to concepts
+  - Add "nieuw" and "toegevoegd" labels and filters to concepts
+  - Add support for concept archiving
 ### deploy instructions
 - Follow the steps to re-sync data from OP
 - `drc restart migrations` and check if they ran successfully

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## Unreleased
 ### General
-  - Frontend [v0.80.0 - v0.82.0](https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0820-2023-06-08)
+  - Frontend [v0.80.0 - v0.83.0](https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0830-2023-06-14)
 ### Inzending voor toezicht
   - Only toezichthoudende betrokkenheid should be shown (hence bump enrich-submission)
 ### Erediensten

--- a/config/migrations/2023/lpdc/20230602103001-service-status-concept-scheme.graph
+++ b/config/migrations/2023/lpdc/20230602103001-service-status-concept-scheme.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2023/lpdc/20230602103001-service-status-concept-scheme.ttl
+++ b/config/migrations/2023/lpdc/20230602103001-service-status-concept-scheme.ttl
@@ -1,0 +1,23 @@
+<http://lblod.data.gift/concept-schemes/fdfeccc2-4b4a-47eb-ad9c-32fb5d1a4423> a <http://www.w3.org/2004/02/skos/core#ConceptScheme> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "(Conceptual) public service statuses"@en,
+    "Statusen van publieke producten en diensten en hun concepten"@nl .
+
+# This concept is also part of the "Submission document statuses" concept scheme
+<http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd> a <http://www.w3.org/2004/02/skos/core#Concept> ;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79a52da4-f491-4e2f-9374-89a13cde8ecd" ;
+  <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/fdfeccc2-4b4a-47eb-ad9c-32fb5d1a4423> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Concept"@nl ;
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/fdfeccc2-4b4a-47eb-ad9c-32fb5d1a4423> .
+
+# This concept is also part of the "Submission document statuses" concept scheme
+<http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> a <http://www.w3.org/2004/02/skos/core#Concept> ;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bd8d86d-bb10-4456-a84e-91e9507c374c" ;
+  <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/fdfeccc2-4b4a-47eb-ad9c-32fb5d1a4423> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Verstuurd"@nl ;
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/fdfeccc2-4b4a-47eb-ad9c-32fb5d1a4423> .
+
+<http://lblod.data.gift/concepts/3f2666df-1dae-4cc2-a8dc-e8213e713081> a <http://www.w3.org/2004/02/skos/core#Concept> ;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f2666df-1dae-4cc2-a8dc-e8213e713081" ;
+  <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/fdfeccc2-4b4a-47eb-ad9c-32fb5d1a4423> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Gearchiveerd"@nl ;
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/fdfeccc2-4b4a-47eb-ad9c-32fb5d1a4423> .

--- a/config/migrations/2023/lpdc/20230607180010-add-archived-status-to-deleted-concepts.sparql
+++ b/config/migrations/2023/lpdc/20230607180010-add-archived-status-to-deleted-concepts.sparql
@@ -1,0 +1,27 @@
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX lpdcExt: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?concept adms:status <http://lblod.data.gift/concepts/3f2666df-1dae-4cc2-a8dc-e8213e713081> . # Archived
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/lpdc/ldes-data> {
+    ?snapshot a lpdcExt:ConceptualPublicService ;
+      dct:isVersionOf ?concept ;
+      lpdcExt:snapshotType ?snapshotType .
+    
+    FILTER(?snapshotType = <https://productencatalogus.data.vlaanderen.be/id/concept/SnapshotType/Delete>)
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?concept a lpdcExt:ConceptualPublicService .
+
+    FILTER NOT EXISTS {
+      ?concept adms:status ?status .
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -375,7 +375,7 @@ services:
     restart: always
     logging: *default-logging
   lpdc-management:
-    image: lblod/lpdc-management-service:0.23.0
+    image: lblod/lpdc-management-service:0.24.0
     volumes:
       - ./config/lpdc-management:/config
       - ./data/files/lpdc:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   loket:
-    image: lblod/frontend-loket:0.82.0
+    image: lblod/frontend-loket:0.83.0
     links:
       - identifier:backend
     labels:


### PR DESCRIPTION
This creates a new concept scheme to house all the concepts related to (conceptual) public service statuses.

We were already using the "Concept" and "Verstuurd" concepts from the "submission document statuses" concept scheme, but we want to add extras.

Depends on:
- https://github.com/lblod/frontend-loket/pull/311/
- https://github.com/lblod/lpdc-management-service/pull/37

<details>
<summary><b>To test the concept archiving flow:</b></summary>

- add the following config to your docker-compose.overrides.yml file:
```yml
  lpdc-ldes-consumer:
    environment:
      # I recommend using a completely new test path. I had issues when I reused the one from the labels feature.
      LDES_STREAM: "https://dev.ldes-endpoint.abb-bfg.s.redpencil.io/your-unique-test-path"
      LDES_ENDPOINT_VIEW: "https://dev.ldes-endpoint.abb-bfg.s.redpencil.io/your-unique-test-path/1" # first page of the stream
      CRON_PATTERN: "* * * * *"
```

- Create a new concept by sending a POST request to the endpoint:
<details>
  <summary>POST <code>https://dev.ldes-endpoint.abb-bfg.s.redpencil.io/your-unique-test-path?resource=https://ipdc.vlaanderen.be/id/concept/unique-id</code></summary>
  
  ### Example body
  ```ttl
@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix rdfs:	<http://www.w3.org/2000/01/rdf-schema#> .

<https://ipdc.vlaanderen.be/id/concept/unique-id>
	<https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#snapshotType> <https://productencatalogus.data.vlaanderen.be/id/concept/SnapshotType/Create> ;
  rdf:type	<https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#ConceptualPublicService> ;
   <http://mu.semte.ch/vocabularies/core/uuid>	"289041b4-cd29-4878-a0eb-f28ddb0d04c8" ;
  <http://schema.org/productID> "112233" ;
  <http://purl.org/dc/terms/title>	"concept name"@nl ;
  <http://purl.org/dc/terms/description>	"beschrijving"@nl .
  ```
</details>

- Wait until concept is available in the frontend (filtering by new concepts should help here)
- create a new instance of this concept
- Delete the concept again by sending a very similar POST request to the endpoint:
<details>
  <summary>POST <code>https://dev.ldes-endpoint.abb-bfg.s.redpencil.io/your-unique-test-path?resource=https://ipdc.vlaanderen.be/id/concept/unique-id</code></summary>
  
  ### Example body
  ```ttl
@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix rdfs:	<http://www.w3.org/2000/01/rdf-schema#> .

<https://ipdc.vlaanderen.be/id/concept/unique-id>
	<https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#snapshotType> <https://productencatalogus.data.vlaanderen.be/id/concept/SnapshotType/Delete> ;
  rdf:type	<https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#ConceptualPublicService> ;
   <http://mu.semte.ch/vocabularies/core/uuid>	"289041b4-cd29-4878-a0eb-f28ddb0d04c8" ;
  <http://schema.org/productID> "112233" ;
  <http://purl.org/dc/terms/title>	"concept name"@nl ;
  <http://purl.org/dc/terms/description>	"beschrijving"@nl .
  ```

The only change is the snapshotType predicate which has now a 'Delete' value.
</details>

- wait for the changes to propagate again
- verify that the instance displays the "concept was archived" message
- verify that the concept details page displays a message that it is archived
- verify that the concept is no longer visible when creating new instances
- verify that the concept is no longer visible when linking a concept
- more information about this test setup can be found here: https://github.com/lblod/app-ldes-endpoint 
</details>

TODOS:
- [x] Add a migration that adds the "gearchiveerd" status to concepts that were deleted in the past
- [x] merge and release the frontend and micro service work and bump the versions in this PR once reviewed

DL-5154