### PR TITLE
Update the link for the LEKP 2.1 subsidy

### DIFF
--- a/config/migrations/2023/subsidies/20230605163000-update-lekp-2.1-link.sparql
+++ b/config/migrations/2023/subsidies/20230605163000-update-lekp-2.1-link.sparql
@@ -1,0 +1,19 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH ?g {
+    ?subsidy skos:related ?oldLink .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?subsidy skos:related """https://www.vlaanderen.be/lokaal-bestuur/beleid-in-ontwikkeling-2019-2024/relanceprojecten/lokaal-energie-en-klimaatpact""" .
+  }
+}
+WHERE {
+  BIND(<http://data.lblod.info/id/subsidy-measure-offers/8815fe07-e53f-4657-94be-efaa4898f03c> as ?subsidy)
+
+  GRAPH ?g {
+    ?subsidy skos:related ?oldLink .
+  }
+}


### PR DESCRIPTION
The link to the old website no longer works, so we replace it with the new version.