### PR TITLE
migration moving the thematische subsidie from public to org graphs

### DIFF
--- a/config/migrations/2023/20230426112611-thematische-subsidie/20230607112547-update-thematische-subsidie-graph.sparql
+++ b/config/migrations/2023/20230426112611-thematische-subsidie/20230607112547-update-thematische-subsidie-graph.sparql
@@ -1,0 +1,94 @@
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX subsidie: <http://data.vlaanderen.be/ns/subsidie#>
+PREFIX gleif: <https://www.gleif.org/ontology/Base/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX cpsv: <http://purl.org/vocab/cpsv#>
+PREFIX common: <http://www.w3.org/2007/uwa/context/common.owl#>
+PREFIX xkos: <http://rdf-vocabulary.ddialliance.org/xkos#>
+PREFIX qb: <http://purl.org/linked-data/cube#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.info/id/subsidy-measure-offers/80737eb2-4f1b-4a0b-b8c7-3f69d296b6a3>
+      a <http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelAanbod>;
+      mu:uuid "80737eb2-4f1b-4a0b-b8c7-3f69d296b6a3";
+      dct:title """Stadsvernieuwing - thematische subsidie""";
+      skos:prefLabel """Stadsvernieuwing - thematische subsidie""";
+      skos:related <https://www.vlaanderen.be/stedenbeleid/stadsvernieuwing-in-vlaanderen>;
+      <http://data.europa.eu/m8g/hasCriterion> <http://data.lblod.info/id/criterions/f5ea0615-0b0a-47db-a38c-6097ff80815d>;
+      cpsv:follows <http://data.lblod.info/id/subsidy-procedural-steps/903a4cf5-1b57-44ed-8c00-a0c71a0d3970> ;
+      lblodSubsidie:heeftReeks <http://lblod.data.info/id/subsidy-measure-offer-series/b460cfa7-915b-4c06-990c-605aa6cbc682> .
+
+    <http://lblod.data.info/id/subsidy-measure-offer-series/b460cfa7-915b-4c06-990c-605aa6cbc682> a lblodSubsidie:SubsidiemaatregelAanbodReeks;
+      mu:uuid "b460cfa7-915b-4c06-990c-605aa6cbc682";
+      dct:title "Oproep 2023"@nl;
+      dct:description ""@nl ; 
+      common:active <http://lblod.data.info/id/subsidie-application-flows/0c7e217b-fec9-4a56-9024-35c6db006fa3> ;
+      lblodSubsidie:heeftSubsidieprocedurestap <http://data.lblod.info/id/subsidy-procedural-steps/903a4cf5-1b57-44ed-8c00-a0c71a0d3970>. 
+  }
+}
+
+INSERT {
+  GRAPH ?newGraph {
+    <http://lblod.data.info/id/subsidy-measure-offers/80737eb2-4f1b-4a0b-b8c7-3f69d296b6a3>
+      a <http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelAanbod>;
+      mu:uuid "80737eb2-4f1b-4a0b-b8c7-3f69d296b6a3";
+      dct:title """Stadsvernieuwing - thematische subsidie""";
+      skos:prefLabel """Stadsvernieuwing - thematische subsidie""";
+      skos:related <https://www.vlaanderen.be/stedenbeleid/stadsvernieuwing-in-vlaanderen>;
+      <http://data.europa.eu/m8g/hasCriterion> <http://data.lblod.info/id/criterions/f5ea0615-0b0a-47db-a38c-6097ff80815d>;
+      cpsv:follows <http://data.lblod.info/id/subsidy-procedural-steps/903a4cf5-1b57-44ed-8c00-a0c71a0d3970> ;
+      lblodSubsidie:heeftReeks <http://lblod.data.info/id/subsidy-measure-offer-series/b460cfa7-915b-4c06-990c-605aa6cbc682> .
+
+    <http://lblod.data.info/id/subsidy-measure-offer-series/b460cfa7-915b-4c06-990c-605aa6cbc682> a lblodSubsidie:SubsidiemaatregelAanbodReeks;
+      mu:uuid "b460cfa7-915b-4c06-990c-605aa6cbc682";
+      dct:title "Oproep 2023"@nl;
+      dct:description ""@nl ; 
+      common:active <http://lblod.data.info/id/subsidie-application-flows/0c7e217b-fec9-4a56-9024-35c6db006fa3> ;
+      lblodSubsidie:heeftSubsidieprocedurestap <http://data.lblod.info/id/subsidy-procedural-steps/903a4cf5-1b57-44ed-8c00-a0c71a0d3970>. 
+ }
+}
+WHERE {
+  VALUES ?bestuureenheid {
+    <http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4> # Aalst
+    <http://data.lblod.info/id/bestuurseenheden/ba4d960fe3e01984e15fd0b141028bab8f2b9b240bf1e5ab639ba0d7fe4dc522> # Aarschot
+    <http://data.lblod.info/id/bestuurseenheden/670db1d66c0de3b931962e1044033ccfa9d6e3023aa9828a5f252c3bc69bd32c> # Antwerpen
+    <http://data.lblod.info/id/bestuurseenheden/28346950e285b8b816133fece5ac9408097c3f190c7f32573cf0c640d6c34b1a> # Brugge
+    <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8>                             # Deinze
+    <http://data.lblod.info/id/bestuurseenheden/a605a770e69d0af2d501614a41b446c76328d2f32165be238458468fbd5f8b88> # Dendermonde
+    <http://data.lblod.info/id/bestuurseenheden/b4ff2bb483e5a18fed7b115a2da7af8447e1a3bec4283fb5cf480810608a1e76> # Diest
+    <http://data.lblod.info/id/bestuurseenheden/8745182191882c1185893960aecc2ed4f91825d7a5ea2e62e9f2d7acca082a5e> # Eeklo
+    <http://data.lblod.info/id/bestuurseenheden/764278b3ceac360476b418c108d1b022b6e0cc8fb676f3f6b6b9faf78a2375ba> # Geel
+    <http://data.lblod.info/id/bestuurseenheden/09f5b10fbd078fcb1e0e4910d32e47146a5eb31d8138dcbaec798309e64dd059> # Genk
+    <http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5> # Gent
+    <http://data.lblod.info/id/bestuurseenheden/e84ba36959d82fc95bb17b25d2e70c135d8805737ba27bab572af670a2768338> # Halle
+    <http://data.lblod.info/id/bestuurseenheden/9db1b46874a57fe63c08fb5f16b117e6f61fdd98e7f64f745d0fceb9d3731169> # Hasselt
+    <http://data.lblod.info/id/bestuurseenheden/70b79f6678036bf05e970aa3885d1779f143d4eab63ecf339ea6263e7e76ad1d> # Herentals
+    <http://data.lblod.info/id/bestuurseenheden/3b6163727a5930106e631885999aa8e1dbd24eaf1931367b7f38123a89f14f10> # Ieper
+    <http://data.lblod.info/id/bestuurseenheden/6cec176758a515b339ebca3b863b8f2b7caf7da58d329ebceee830ab6518bd86> # Knokke Heist
+    <http://data.lblod.info/id/bestuurseenheden/8fd5ea9aeb61c45ec79986650bee55142b2f8a599d5d611dd578114216a58430> # Kortrijk
+    <http://data.lblod.info/id/bestuurseenheden/c648ea5d12626ee3364a02debb223908a71e68f53d69a7a7136585b58a083e77> # Leuven
+    <http://data.lblod.info/id/bestuurseenheden/319016d52cb54b416721b0c5fc74f211fdd4dd576d13a34aa9210759401dc7f2> # Lier
+    <http://data.lblod.info/id/bestuurseenheden/cb2a6e0a490ee881ddd0d9ded7f2b3d1dc2df7e57a19d014caac054bfa355f5a> # Lokeren
+    <http://data.lblod.info/id/bestuurseenheden/be278471a2a318edba32e7ac4294c0eafbe4c8077a34dcbb9c2e43211d4a78a6> # Mechelen
+    <http://data.lblod.info/id/bestuurseenheden/55155a78bd145df7bfa3caaa17ba491fb4dd238f4f4d2c5485bff1be96ca3036> # Mol
+    <http://data.lblod.info/id/bestuurseenheden/764a0c6bbc866153ae70cf75d745b9477fa010567246cfe6683b7bb8aec541b4> # Oostende
+    <http://data.lblod.info/id/bestuurseenheden/d9f7c0ab4920fdecf3f9a60b92e921b5ca07248fcb0eac2113eb97392ddd6c6c> # Oudenaarde
+    <http://data.lblod.info/id/bestuurseenheden/3e58880a542424b73f85c9ffba8837b0da40d8c43e936c92603cde2015f5cdae> # Roeselare
+    <http://data.lblod.info/id/bestuurseenheden/59eaecae469f80eccaf6d36a165927eb8ee8749b9866ab1730e6b1ba45dfaaa7> # Ronse
+    <http://data.lblod.info/id/bestuurseenheden/71f6925a4b895c2a91dce039c87d227809edcda82963714814141b1e41631b08> # Sint Niklaas
+    <http://data.lblod.info/id/bestuurseenheden/416aada66520f1b6f4eb79177cefa7c5815bfb85fd455431c1ef91fd333769fd> # Sint Truiden
+    <http://data.lblod.info/id/bestuurseenheden/b36da606fba6dd4dc99ae1ef5f4a52bba3268d33f4bc2cd1e65b87f01f35101a> # Tielt
+    <http://data.lblod.info/id/bestuurseenheden/da17a1c564c4f0aecbe800efaedcee7428e80c127b4a1bc829519b375ad20707> # Tienen
+    <http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625> # Tongeren
+    <http://data.lblod.info/id/bestuurseenheden/800ce18716ba451af47c2e05c2a7bdd29ab9305eaa61068629c1ea2ae6c08f4c> # Turnhout
+    <http://data.lblod.info/id/bestuurseenheden/8fd72c4cd5f095c508af05e3406aa63114279e8bde54e9f5b83a59c7794dac72> # Vilvoorde
+    <http://data.lblod.info/id/bestuurseenheden/9e6b6eb3-2f0b-4723-876b-178dfaecfddf>                             # Vlaamse gemeenschapscommissie
+    <http://data.lblod.info/id/bestuurseenheden/5a8f9c6bde6c6b01bee07d9dbed16a8b685851865d5083edbf617a4dbd2e51ce> # Waregem
+ }
+
+ ?bestuureenheid mu:uuid ?uuid.
+ BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", STR(?uuid), "/LoketLB-subsidies")) as ?newGraph)
+}


### PR DESCRIPTION
Currently thematische subsidies is visible for everyone (public graph). This PR removes it from public graph and puts it in org graphs of those that should be able to see the subsidie.

To test:
- setup stack en make sure migration has run
- login as different bestuurseenheden and check that the subsidie is only available for the ones that are in the list.
( you can see permissions list in migration file itself )

