### PR TITLE
Enable the Virtuoso compatibility option in mu-auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       # heavy queries
       QUERY_MAX_PROCESSING_TIME: 605000
       QUERY_MAX_EXECUTION_TIME: 605000
+      DATABASE_COMPATIBILITY: "Virtuoso"
     volumes:
       - ./config/authorization:/config
     labels:


### PR DESCRIPTION
This solves an issue where some state isn't properly updated in the database due to a Virtuoso bug.

More information: https://github.com/mu-semtech/mu-authorization/#database-compatibility

I only tested it in combination with `redpencil/virtuoso:1.1.0` so it still needs to be verified that it works on the current image as well. We potentially need to merge #426 as well.

DL-5205