### PR TITLE
add migration updating lekp 1 & 2 indienen periode

### DIFF
--- a/config/migrations/2023/20230713123426-update-lekp-aanvraag-step-deadline.sparql
+++ b/config/migrations/2023/20230713123426-update-lekp-aanvraag-step-deadline.sparql
@@ -9,7 +9,7 @@ DELETE {
 INSERT {
   GRAPH ?g {
     ?s m8g:startTime "2023-09-01T21:59:59Z"^^xsd:dateTime .
-    ?s m8g:endTime "2023-12-06T21:59:59Z"^^xsd:dateTime .
+    ?s m8g:endTime "2023-12-06T22:59:59Z"^^xsd:dateTime .
   }
 }
 WHERE {

--- a/config/migrations/2023/20230713123426-update-lekp-aanvraag-step-deadline.sparql
+++ b/config/migrations/2023/20230713123426-update-lekp-aanvraag-step-deadline.sparql
@@ -1,0 +1,24 @@
+PREFIX m8g: <http://data.europa.eu/m8g/>
+
+DELETE {
+  GRAPH ?g {
+    ?s m8g:startTime ?start .
+    ?s m8g:endTime ?end .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s m8g:startTime "2023-09-01T23:59:59Z"^^xsd:dateTime .
+    ?s m8g:endTime "2023-12-06T23:59:59Z"^^xsd:dateTime .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?s {
+      <http://data.lblod.info/id/periodes/0bbe9eb8-8814-4c86-8c3d-5d3aa12a7389> # LEKP 1.0 - Indienen Pact - periode
+      <http://data.lblod.info/id/periodes/18374b39-b34b-43d1-b135-5e14007ca512> # LEKP 2.0 - Indienen Pact - periode
+    }
+    ?s m8g:startTime ?start.
+    ?s m8g:endTime ?end .
+  }
+} 

--- a/config/migrations/2023/20230713123426-update-lekp-aanvraag-step-deadline.sparql
+++ b/config/migrations/2023/20230713123426-update-lekp-aanvraag-step-deadline.sparql
@@ -8,8 +8,8 @@ DELETE {
 }
 INSERT {
   GRAPH ?g {
-    ?s m8g:startTime "2023-09-01T23:59:59Z"^^xsd:dateTime .
-    ?s m8g:endTime "2023-12-06T23:59:59Z"^^xsd:dateTime .
+    ?s m8g:startTime "2023-09-01T21:59:59Z"^^xsd:dateTime .
+    ?s m8g:endTime "2023-12-06T21:59:59Z"^^xsd:dateTime .
   }
 }
 WHERE {


### PR DESCRIPTION
 ## ID
DL-5188
 ## Description

This PR contains a simple migration that updates the periode start- & endtime for the LEKP 1.0 & LEKP 2.0 "indienen pact" step subsidies

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## How to test

Setup digitaal loket & make sure the migrations finish running. Log in as a bestuurseenheid (e.g. Vilvoorde gemeente) & go to the "new subsidy" page. 

Important is that the startdate has been changed to september 1st. This means that we should not see the subsidies in the list yet. Remove the following line in the frontend code to make the subsidy appear:

https://github.com/lblod/frontend-loket/blob/development/app/routes/subsidy/applications/available-subsidies.js#L43

Make sure the subsidies LEKP 1.0 & 2.0 appear in the list
