### PR TITLE
Fix predicate used to export postal codes of leidinggevenden

### DIFF
--- a/config/delta-producer/leidinggevenden/export.json
+++ b/config/delta-producer/leidinggevenden/export.json
@@ -155,7 +155,7 @@
         "http://www.w3.org/ns/locn#thoroughfare",
         "https://data.vlaanderen.be/ns/adres#verwijstNaar",
         "https://data.vlaanderen.be/ns/adres#gemeentenaam",
-        "https://data.vlaanderen.be/ns/adres#postcode"
+        "http://www.w3.org/ns/locn#postCode"
       ]
     },
     {


### PR DESCRIPTION
OP-2559

Postal codes of leidinggevenden are not produced and exported to consuming applications because the configured predicate is not the correct one.