### PR TITLE
Add VGC criterion

### DIFF
--- a/config/migrations/2023/20230426112611-thematische-subsidie/20230718145155-add-VGC-criterion.sparql
+++ b/config/migrations/2023/20230426112611-thematische-subsidie/20230718145155-add-VGC-criterion.sparql
@@ -1,0 +1,10 @@
+INSERT {
+  GRAPH ?g {
+    ?subsidy <http://data.europa.eu/m8g/hasCriterion> <http://data.lblod.info/id/criterions/80301a63-927c-48e5-8678-048c87c25847> # Allow VGC criterion
+  }
+} WHERE {
+ BIND(<http://lblod.data.info/id/subsidy-measure-offers/80737eb2-4f1b-4a0b-b8c7-3f69d296b6a3> as ?subsidy) # Thematische subsidy
+  GRAPH ?g {
+    ?subsidy a <http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelAanbod>
+  }
+}


### PR DESCRIPTION
 ## ID
 DL-5302

 ## Description
 Add vgc criterion to thematische subsidy so vgc has access to the subsidy

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## Related services

 - migrations

 ## How to test

 - Run the stack
 - Make sure the new migration finishes running
 - start frontend and log in as vlaamse gemeenschapscommissie
 - go to 'add new subsidy' and make sure thematische subsidie is in the list
