### PR TITLE
Update meldingsplicht APIs

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -341,7 +341,14 @@ defmodule Acl.UserGroups.Config do
                         "http://lblod.data.gift/vocabularies/besluit/TaxRate",
                         "http://lblod.data.gift/vocabularies/automatische-melding/FormData",
                         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
+                        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer",
+                        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#LocalFileDataObject",
                         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject",
+                        "http://lblod.data.gift/services/Service",
+                        "http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection",
+                        "http://redpencil.data.gift/vocabularies/tasks/Operation",
+                        "http://redpencil.data.gift/vocabularies/tasks/Task",
+                        "http://vocab.deri.ie/cogs#ExecutionStatus",
                       ] } } ] },
 
       # // SUBSIDIES

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -295,7 +295,7 @@ defmodule Dispatcher do
   #################################################################
   # Automatic submission
   #################################################################
-  match "/melding/*path" do
+  post "/melding/*path" do
     forward conn, path, "http://automatic-submission/melding"
   end
 

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -299,6 +299,10 @@ defmodule Dispatcher do
     forward conn, path, "http://automatic-submission/melding"
   end
 
+  post "/delete-melding" do
+    Proxy.forward conn, [], "http://clean-up-submission/delete-melding"
+  end
+
   #################################################################
   # Toezicht / supervision
   #################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,7 +260,7 @@ services:
     restart: always
     logging: *default-logging
   automatic-submission:
-    image: lblod/automatic-submission-service:1.2.1
+    image: lblod/automatic-submission-service:1.3.0
     labels:
       - "logging=true"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -492,7 +492,7 @@ services:
     restart: always
     logging: *default-logging
   vendor-data-distribution:
-    image: lblod/vendor-data-distribution-service:1.0.1-rc1
+    image: lblod/vendor-data-distribution-service:1.1.0
     restart: always
     logging: *default-logging
   ################################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -416,7 +416,7 @@ services:
     restart: always
     logging: *default-logging
   jobs-controller:
-    image: lblod/job-controller-service:0.7.0
+    image: lblod/job-controller-service:1.0.0
     volumes:
       - ./config/jobs-controller/:/config/
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -317,7 +317,7 @@ services:
     restart: always
     logging: *default-logging
   clean-up-submission:
-    image: lblod/clean-up-submission-service:0.3.3
+    image: lblod/clean-up-submission-service:1.1.0
     volumes:
       - ./data/files:/share
     labels:


### PR DESCRIPTION
This PR updates the services related to the Meldingsplicht API. The most notable feature is the removal of meldingen in concept with a new part of the Vendor API, and improved security on the `clean-up-submission-service`.

(See https://github.com/lblod/app-meldingsplichtige-api/pull/32 and https://github.com/lblod/app-meldingsplichtige-api/pull/33.)