### PR TITLE
Rewrite worship reports

### DIFF
--- a/config/reports/worship/bedienaren.js
+++ b/config/reports/worship/bedienaren.js
@@ -325,85 +325,93 @@ function combineBedienarenData(
 
       const geboorteLink =
         geboorteLinks.find((g) => g.persoon === persoonLink.persoon) || [];
-      const geboorteDatum = tripleData.find(
-        (d) =>
-          d.s.value === geboorteLink.geboorte &&
-          d.p.value === 'http://data.vlaanderen.be/ns/persoon#datum'
-      )?.o?.value;
-      collect.geboorteDatum = geboorteDatum;
+      if (geboorteLink) {
+        const geboorteDatum = tripleData.find(
+          (d) =>
+            d.s.value === geboorteLink.geboorte &&
+            d.p.value === 'http://data.vlaanderen.be/ns/persoon#datum'
+        )?.o?.value;
+        collect.geboorteDatum = geboorteDatum;
+      }
 
       const identifierLink =
         identifierLinks.find((g) => g.persoon === persoonLink.persoon) || [];
-      const identifier = tripleData.find(
-        (d) =>
-          d.s.value === identifierLink.identifier &&
-          d.p.value === 'http://www.w3.org/2004/02/skos/core#notation'
-      )?.o?.value;
-      collect.rrnummer = identifier;
+      if (identifierLink) {
+        const identifier = tripleData.find(
+          (d) =>
+            d.s.value === identifierLink.identifier &&
+            d.p.value === 'http://www.w3.org/2004/02/skos/core#notation'
+        )?.o?.value;
+        collect.rrnummer = identifier;
+      }
 
       const contactLink = contactLinks.find((c) => c.bedienaar === bedienaar);
-      const contactSoort = tripleData.find(
-        (d) =>
-          d.s.value === contactLink.contact &&
-          d.p.value === 'http://schema.org/contactType'
-      )?.o?.value;
-      const email = tripleData.find(
-        (d) =>
-          d.s.value === contactLink.contact &&
-          d.p.value === 'http://schema.org/email'
-      )?.o?.value;
-      const telefoon = tripleData.find(
-        (d) =>
-          d.s.value === contactLink.contact &&
-          d.p.value === 'http://schema.org/telephone'
-      )?.o?.value;
-      collect.contact = contactLink.contact;
-      collect.contactSoort = contactSoort;
-      collect.email = email;
-      collect.telefoon = telefoon;
+      if (contactLink) {
+        const contactSoort = tripleData.find(
+          (d) =>
+            d.s.value === contactLink.contact &&
+            d.p.value === 'http://schema.org/contactType'
+        )?.o?.value;
+        const email = tripleData.find(
+          (d) =>
+            d.s.value === contactLink.contact &&
+            d.p.value === 'http://schema.org/email'
+        )?.o?.value;
+        const telefoon = tripleData.find(
+          (d) =>
+            d.s.value === contactLink.contact &&
+            d.p.value === 'http://schema.org/telephone'
+        )?.o?.value;
+        collect.contact = contactLink.contact;
+        collect.contactSoort = contactSoort;
+        collect.email = email;
+        collect.telefoon = telefoon;
 
-      const adresLink = addressLinks.find(
-        (c) => c.contact === contactLink.contact
-      );
-      const straat = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value === 'http://www.w3.org/ns/locn#thoroughfare'
-      )?.o?.value;
-      const huisnummer = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value ===
-            'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer'
-      )?.o?.value;
-      const busnummer = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value ===
-            'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer'
-      )?.o?.value;
-      const postcode = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value === 'http://www.w3.org/ns/locn#postCode'
-      )?.o?.value;
-      const stad = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value === 'https://data.vlaanderen.be/ns/adres#gemeentenaam'
-      )?.o?.value;
-      const land = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value === 'https://data.vlaanderen.be/ns/adres#land'
-      )?.o?.value;
-      collect.adres = adresLink.address;
-      collect.straat = straat;
-      collect.huisnummer = huisnummer;
-      collect.busnummer = busnummer;
-      collect.postcode = postcode;
-      collect.stad = stad;
-      collect.land = land;
+        const adresLink = addressLinks.find(
+          (c) => c.contact === contactLink.contact
+        );
+        if (adresLink) {
+          const straat = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value === 'http://www.w3.org/ns/locn#thoroughfare'
+          )?.o?.value;
+          const huisnummer = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value ===
+                'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer'
+          )?.o?.value;
+          const busnummer = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value ===
+                'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer'
+          )?.o?.value;
+          const postcode = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value === 'http://www.w3.org/ns/locn#postCode'
+          )?.o?.value;
+          const stad = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value === 'https://data.vlaanderen.be/ns/adres#gemeentenaam'
+          )?.o?.value;
+          const land = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value === 'https://data.vlaanderen.be/ns/adres#land'
+          )?.o?.value;
+          collect.adres = adresLink.address;
+          collect.straat = straat;
+          collect.huisnummer = huisnummer;
+          collect.busnummer = busnummer;
+          collect.postcode = postcode;
+          collect.stad = stad;
+          collect.land = land;
+        }
+      }
 
       data.push(collect);
     }

--- a/config/reports/worship/bedienaren.js
+++ b/config/reports/worship/bedienaren.js
@@ -205,6 +205,7 @@ async function generate() {
     [
       'bestuurnaam',
       'bedienaar',
+      'afkomstGegevens',
       'functienaam',
       'startDatum',
       'eindeDatum',
@@ -250,6 +251,11 @@ function combineBedienarenData(
   const data = [];
 
   for (const bedienaar of bedienaren) {
+    const afkomstGegevens = tripleData.find(
+      (d) =>
+        d.s.value === bedienaar &&
+        d.p.value === 'http://www.w3.org/ns/prov#wasGeneratedBy'
+    )?.o?.value;
     const startDatum = tripleData.find(
       (d) =>
         d.s.value === bedienaar &&
@@ -263,7 +269,7 @@ function combineBedienarenData(
           'http://data.lblod.info/vocabularies/contacthub/eindedatum'
     )?.o?.value;
 
-    const collect = { bedienaar, startDatum, eindeDatum };
+    const collect = { bedienaar, afkomstGegevens, startDatum, eindeDatum };
 
     const positionLink = positionLinks.find((p) => p.bedienaar === bedienaar);
 

--- a/config/reports/worship/bedienaren.js
+++ b/config/reports/worship/bedienaren.js
@@ -1,18 +1,207 @@
 import * as mas from '@lblod/mu-auth-sudo';
 import * as queries from './queries';
-import { generateReportFromData } from '../../helpers';
+import * as hel from '../../helpers';
+
+const BATCH_SIZE = 100;
 
 async function generate() {
-  const data = await mas.querySudo(queries.getQueryBedienaren());
-  const bindings = data?.results?.bindings || [];
-  const stringified = bindings.map((binding) => {
-    const res = {};
-    for (const key in binding) res[key] = binding[key].value;
-    return res;
-  });
-  stringified.sort((a, b) => a.bedienaar < b.bedienaar);
-  await generateReportFromData(
-    stringified,
+  const bedienarenResponse = await hel.batchedQuery(
+    queries.allBedienaren(),
+    BATCH_SIZE
+  );
+  const bedienaren = bedienarenResponse.results.bindings.sort(
+    (a, b) => a.bedienaar.value < b.bedienaar.value
+  );
+
+  let allData = [];
+
+  for (
+    let bedienaarCounter = 0;
+    bedienaarCounter < bedienaren.length;
+    bedienaarCounter += BATCH_SIZE
+  ) {
+    const bedienarenSlice = bedienaren.slice(
+      bedienaarCounter,
+      bedienaarCounter + BATCH_SIZE
+    );
+    const bedienarenURIsSlice = bedienarenSlice.map((b) => b.bedienaar.value);
+
+    //Personen
+    const persoonQuery = queries.domainToRange(
+      bedienarenURIsSlice,
+      'http://www.w3.org/ns/org#heldBy',
+      'http://www.w3.org/ns/person#Person'
+    );
+    const personenResponse = await mas.querySudo(persoonQuery);
+    const personen = [
+      ...new Set(personenResponse.results.bindings.map((p) => p.range.value)),
+    ];
+    const personenLinks = personenResponse.results.bindings.map((r) => {
+      return {
+        bedienaar: r.domain.value,
+        persoon: r.range.value,
+      };
+    });
+
+    //Identifiers
+    const identifierQuery = queries.domainToRange(
+      personen,
+      'http://www.w3.org/ns/adms#identifier',
+      'http://www.w3.org/ns/adms#Identifier'
+    );
+    const identifierResponse = await mas.querySudo(identifierQuery);
+    const identifiers = [
+      ...new Set(identifierResponse.results.bindings.map((i) => i.range.value)),
+    ];
+    const identifierLinks = identifierResponse.results.bindings.map((r) => {
+      return {
+        persoon: r.domain.value,
+        identifier: r.range.value,
+      };
+    });
+
+    //Geboortes
+    const geboorteQuery = queries.domainToRange(
+      personen,
+      'http://data.vlaanderen.be/ns/persoon#heeftGeboorte',
+      'http://data.vlaanderen.be/ns/persoon#Geboorte'
+    );
+    const geboortesResponse = await mas.querySudo(geboorteQuery);
+    const geboortes = [
+      ...new Set(geboortesResponse.results.bindings.map((g) => g.range.value)),
+    ];
+    const geboorteLinks = geboortesResponse.results.bindings.map((r) => {
+      return {
+        persoon: r.domain.value,
+        geboorte: r.range.value,
+      };
+    });
+
+    //Contacts
+    const contactQuery = queries.domainToRange(
+      bedienarenURIsSlice,
+      'http://schema.org/contactPoint',
+      'http://schema.org/ContactPoint'
+    );
+    const contactsResponse = await mas.querySudo(contactQuery);
+    const contacts = [
+      ...new Set(contactsResponse.results.bindings.map((c) => c.range.value)),
+    ];
+    const contactLinks = contactsResponse.results.bindings.map((r) => {
+      return {
+        bedienaar: r.domain.value,
+        contact: r.range.value,
+      };
+    });
+
+    //Adresses
+    const adresQuery = queries.domainToRange(
+      contacts,
+      'http://www.w3.org/ns/locn#address',
+      'http://www.w3.org/ns/locn#Address'
+    );
+    const addressResponse = await mas.querySudo(adresQuery);
+    const addresses = [
+      ...new Set(addressResponse.results.bindings.map((a) => a.range.value)),
+    ];
+    const addressLinks = addressResponse.results.bindings.map((r) => {
+      return {
+        contact: r.domain.value,
+        address: r.range.value,
+      };
+    });
+
+    //Positions
+    const positionQuery = queries.domainToRange(
+      bedienarenURIsSlice,
+      'http://www.w3.org/ns/org#holds',
+      'http://data.lblod.info/vocabularies/erediensten/PositieBedienaar'
+    );
+    const positionsResponse = await mas.querySudo(positionQuery);
+    const positions = [
+      ...new Set(positionsResponse.results.bindings.map((p) => p.range.value)),
+    ];
+    const positionLinks = positionsResponse.results.bindings.map((p) => {
+      return {
+        bedienaar: p.domain.value,
+        position: p.range.value,
+      };
+    });
+
+    //Functions
+    const functionQuery = queries.domainToRange(
+      positions,
+      'http://data.lblod.info/vocabularies/erediensten/functie',
+      'http://lblod.data.gift/vocabularies/organisatie/EredienstBeroepen'
+    );
+    const functionResponse = await mas.querySudo(functionQuery);
+    const functions = [
+      ...new Set(functionResponse.results.bindings.map((p) => p.range.value)),
+    ];
+    const functionLinks = functionResponse.results.bindings.map((p) => {
+      return {
+        position: p.domain.value,
+        functie: p.range.value,
+      };
+    });
+
+    //Besturen
+    const besturenQuery = queries.rangeToDomain(
+      positions,
+      'http://data.lblod.info/vocabularies/erediensten/wordtBediendDoor',
+      'http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst'
+    );
+    const besturenResponse = await mas.querySudo(besturenQuery);
+    const besturen = [
+      ...new Set(besturenResponse.results.bindings.map((p) => p.range.value)),
+    ];
+    const besturenLinks = besturenResponse.results.bindings.map((p) => {
+      return {
+        positie: p.domain.value,
+        bestuur: p.range.value,
+      };
+    });
+
+    let allURIs = new Set();
+    [
+      ...bedienarenURIsSlice,
+      ...personen,
+      ...identifiers,
+      ...geboortes,
+      ...contacts,
+      ...addresses,
+      ...positions,
+      ...functions,
+      ...besturen,
+    ].forEach((e) => allURIs.add(e));
+    allURIs = [...allURIs];
+
+    const tripleData = [];
+
+    for (let counter = 0; counter < allURIs.length; counter += BATCH_SIZE) {
+      const URIslice = allURIs.slice(counter, counter + BATCH_SIZE);
+      const dataQuery = queries.dataForSubjects(URIslice);
+      const dataResponse = await mas.querySudo(dataQuery);
+      dataResponse.results.bindings.forEach((e) => tripleData.push(e));
+    }
+
+    const combinedData = combineBedienarenData(
+      tripleData,
+      bedienarenURIsSlice,
+      personenLinks,
+      identifierLinks,
+      geboorteLinks,
+      contactLinks,
+      addressLinks,
+      positionLinks,
+      functionLinks,
+      besturenLinks
+    );
+    allData = allData.concat(combinedData);
+  }
+
+  await hel.generateReportFromData(
+    allData,
     [
       'bestuurnaam',
       'bedienaar',
@@ -31,14 +220,12 @@ async function generate() {
       'email',
       'telefoon',
       'adres',
-      'busnummer',
-      'huisnummer',
       'straat',
+      'huisnummer',
+      'busnummer',
       'postcode',
       'stad',
       'land',
-      'volAdress',
-      'adresVerwijzing',
     ],
     {
       title: 'Eredienst Bedienaren Report',
@@ -46,6 +233,176 @@ async function generate() {
       filePrefix: 'eredienst-bedienaren',
     }
   );
+}
+
+function combineBedienarenData(
+  tripleData,
+  bedienaren,
+  personenLinks,
+  identifierLinks,
+  geboorteLinks,
+  contactLinks,
+  addressLinks,
+  positionLinks,
+  functionLinks,
+  besturenLinks
+) {
+  const data = [];
+
+  for (const bedienaar of bedienaren) {
+    const startDatum = tripleData.find(
+      (d) =>
+        d.s.value === bedienaar &&
+        d.p.value ===
+          'http://data.lblod.info/vocabularies/contacthub/startdatum'
+    )?.o?.value;
+    const eindeDatum = tripleData.find(
+      (d) =>
+        d.s.value === bedienaar &&
+        d.p.value ===
+          'http://data.lblod.info/vocabularies/contacthub/eindedatum'
+    )?.o?.value;
+
+    const collect = { bedienaar, startDatum, eindeDatum };
+
+    const positionLink = positionLinks.find((p) => p.bedienaar === bedienaar);
+
+    const functionLink = functionLinks.find(
+      (f) => f.position === positionLink.position
+    );
+    const functienaam = tripleData.find(
+      (d) =>
+        d.s.value === functionLink.functie &&
+        d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
+    )?.o?.value;
+    collect.functienaam = functienaam;
+
+    const bestuurLink = besturenLinks.find(
+      (b) => positionLink.position === b.positie
+    );
+    const bestuurnaam = tripleData.find(
+      (d) =>
+        d.s.value === bestuurLink.bestuur &&
+        d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
+    )?.o?.value;
+    collect.bestuurnaam = bestuurnaam;
+
+    const personen = personenLinks.filter((p) => p.bedienaar === bedienaar);
+
+    for (const persoonLink of personen) {
+      const familienaam = tripleData.find(
+        (d) =>
+          d.s.value === persoonLink.persoon &&
+          d.p.value === 'http://xmlns.com/foaf/0.1/familyName'
+      )?.o?.value;
+      const voornaam = tripleData.find(
+        (d) =>
+          d.s.value === persoonLink.persoon &&
+          d.p.value === 'http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam'
+      )?.o?.value;
+      const nationaliteit = tripleData.find(
+        (d) =>
+          d.s.value === persoonLink.persoon &&
+          d.p.value ===
+            'http://data.vlaanderen.be/ns/persoon#heeftNationaliteit'
+      )?.o?.value;
+      const geslacht = tripleData.find(
+        (d) =>
+          d.s.value === persoonLink.persoon &&
+          d.p.value === 'http://data.vlaanderen.be/ns/persoon#geslacht'
+      )?.o?.value;
+      collect.persoon = persoonLink.persoon;
+      collect.familienaam = familienaam;
+      collect.voornaam = voornaam;
+      collect.nationaliteit = nationaliteit;
+      collect.geslacht = geslacht;
+
+      const geboorteLink =
+        geboorteLinks.find((g) => g.persoon === persoonLink.persoon) || [];
+      const geboorteDatum = tripleData.find(
+        (d) =>
+          d.s.value === geboorteLink.geboorte &&
+          d.p.value === 'http://data.vlaanderen.be/ns/persoon#datum'
+      )?.o?.value;
+      collect.geboorteDatum = geboorteDatum;
+
+      const identifierLink =
+        identifierLinks.find((g) => g.persoon === persoonLink.persoon) || [];
+      const identifier = tripleData.find(
+        (d) =>
+          d.s.value === identifierLink.identifier &&
+          d.p.value === 'http://www.w3.org/2004/02/skos/core#notation'
+      )?.o?.value;
+      collect.rrnummer = identifier;
+
+      const contactLink = contactLinks.find((c) => c.bedienaar === bedienaar);
+      const contactSoort = tripleData.find(
+        (d) =>
+          d.s.value === contactLink.contact &&
+          d.p.value === 'http://schema.org/contactType'
+      )?.o?.value;
+      const email = tripleData.find(
+        (d) =>
+          d.s.value === contactLink.contact &&
+          d.p.value === 'http://schema.org/email'
+      )?.o?.value;
+      const telefoon = tripleData.find(
+        (d) =>
+          d.s.value === contactLink.contact &&
+          d.p.value === 'http://schema.org/telephone'
+      )?.o?.value;
+      collect.contact = contactLink.contact;
+      collect.contactSoort = contactSoort;
+      collect.email = email;
+      collect.telefoon = telefoon;
+
+      const adresLink = addressLinks.find(
+        (c) => c.contact === contactLink.contact
+      );
+      const straat = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value === 'http://www.w3.org/ns/locn#thoroughfare'
+      )?.o?.value;
+      const huisnummer = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value ===
+            'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer'
+      )?.o?.value;
+      const busnummer = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value ===
+            'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer'
+      )?.o?.value;
+      const postcode = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value === 'http://www.w3.org/ns/locn#postCode'
+      )?.o?.value;
+      const stad = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value === 'https://data.vlaanderen.be/ns/adres#gemeentenaam'
+      )?.o?.value;
+      const land = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value === 'https://data.vlaanderen.be/ns/adres#land'
+      )?.o?.value;
+      collect.adres = adresLink.address;
+      collect.straat = straat;
+      collect.huisnummer = huisnummer;
+      collect.busnummer = busnummer;
+      collect.postcode = postcode;
+      collect.stad = stad;
+      collect.land = land;
+
+      data.push(collect);
+    }
+  }
+  return data;
 }
 
 export default {

--- a/config/reports/worship/bedienaren.js
+++ b/config/reports/worship/bedienaren.js
@@ -273,25 +273,31 @@ function combineBedienarenData(
 
     const positionLink = positionLinks.find((p) => p.bedienaar === bedienaar);
 
-    const functionLink = functionLinks.find(
-      (f) => f.position === positionLink.position
-    );
-    const functienaam = tripleData.find(
-      (d) =>
-        d.s.value === functionLink.functie &&
-        d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
-    )?.o?.value;
-    collect.functienaam = functienaam;
+    if (positionLink) {
+      const functionLink = functionLinks.find(
+        (f) => f.position === positionLink.position
+      );
+      if (functionLink) {
+        const functienaam = tripleData.find(
+          (d) =>
+            d.s.value === functionLink.functie &&
+            d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
+        )?.o?.value;
+        collect.functienaam = functienaam;
+      }
 
-    const bestuurLink = besturenLinks.find(
-      (b) => positionLink.position === b.positie
-    );
-    const bestuurnaam = tripleData.find(
-      (d) =>
-        d.s.value === bestuurLink.bestuur &&
-        d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
-    )?.o?.value;
-    collect.bestuurnaam = bestuurnaam;
+      const bestuurLink = besturenLinks.find(
+        (b) => positionLink.position === b.positie
+      );
+      if (bestuurLink) {
+        const bestuurnaam = tripleData.find(
+          (d) =>
+            d.s.value === bestuurLink.bestuur &&
+            d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
+        )?.o?.value;
+        collect.bestuurnaam = bestuurnaam;
+      }
+    }
 
     const personen = personenLinks.filter((p) => p.bedienaar === bedienaar);
 

--- a/config/reports/worship/mandatarissen.js
+++ b/config/reports/worship/mandatarissen.js
@@ -351,85 +351,93 @@ function combineMandatarissenData(
 
       const geboorteLink =
         geboorteLinks.find((g) => g.persoon === persoonLink.persoon) || [];
-      const geboorteDatum = tripleData.find(
-        (d) =>
-          d.s.value === geboorteLink.geboorte &&
-          d.p.value === 'http://data.vlaanderen.be/ns/persoon#datum'
-      )?.o?.value;
-      collect.geboorteDatum = geboorteDatum;
+      if (geboorteLink) {
+        const geboorteDatum = tripleData.find(
+          (d) =>
+            d.s.value === geboorteLink.geboorte &&
+            d.p.value === 'http://data.vlaanderen.be/ns/persoon#datum'
+        )?.o?.value;
+        collect.geboorteDatum = geboorteDatum;
+      }
 
       const identifierLink =
         identifierLinks.find((g) => g.persoon === persoonLink.persoon) || [];
-      const identifier = tripleData.find(
-        (d) =>
-          d.s.value === identifierLink.identifier &&
-          d.p.value === 'http://www.w3.org/2004/02/skos/core#notation'
-      )?.o?.value;
-      collect.rrnummer = identifier;
+      if (identifierLink) {
+        const identifier = tripleData.find(
+          (d) =>
+            d.s.value === identifierLink.identifier &&
+            d.p.value === 'http://www.w3.org/2004/02/skos/core#notation'
+        )?.o?.value;
+        collect.rrnummer = identifier;
+      }
 
       const contactLink = contactLinks.find((c) => c.mandataris === mandataris);
-      const contactSoort = tripleData.find(
-        (d) =>
-          d.s.value === contactLink.contact &&
-          d.p.value === 'http://schema.org/contactType'
-      )?.o?.value;
-      const email = tripleData.find(
-        (d) =>
-          d.s.value === contactLink.contact &&
-          d.p.value === 'http://schema.org/email'
-      )?.o?.value;
-      const telefoon = tripleData.find(
-        (d) =>
-          d.s.value === contactLink.contact &&
-          d.p.value === 'http://schema.org/telephone'
-      )?.o?.value;
-      collect.contact = contactLink.contact;
-      collect.contactSoort = contactSoort;
-      collect.email = email;
-      collect.telefoon = telefoon;
+      if (contactLink) {
+        const contactSoort = tripleData.find(
+          (d) =>
+            d.s.value === contactLink.contact &&
+            d.p.value === 'http://schema.org/contactType'
+        )?.o?.value;
+        const email = tripleData.find(
+          (d) =>
+            d.s.value === contactLink.contact &&
+            d.p.value === 'http://schema.org/email'
+        )?.o?.value;
+        const telefoon = tripleData.find(
+          (d) =>
+            d.s.value === contactLink.contact &&
+            d.p.value === 'http://schema.org/telephone'
+        )?.o?.value;
+        collect.contact = contactLink.contact;
+        collect.contactSoort = contactSoort;
+        collect.email = email;
+        collect.telefoon = telefoon;
 
-      const adresLink = addressLinks.find(
-        (c) => c.contact === contactLink.contact
-      );
-      const straat = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value === 'http://www.w3.org/ns/locn#thoroughfare'
-      )?.o?.value;
-      const huisnummer = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value ===
-            'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer'
-      )?.o?.value;
-      const busnummer = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value ===
-            'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer'
-      )?.o?.value;
-      const postcode = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value === 'http://www.w3.org/ns/locn#postCode'
-      )?.o?.value;
-      const stad = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value === 'https://data.vlaanderen.be/ns/adres#gemeentenaam'
-      )?.o?.value;
-      const land = tripleData.find(
-        (d) =>
-          d.s.value === adresLink.address &&
-          d.p.value === 'https://data.vlaanderen.be/ns/adres#land'
-      )?.o?.value;
-      collect.adres = adresLink.address;
-      collect.straat = straat;
-      collect.huisnummer = huisnummer;
-      collect.busnummer = busnummer;
-      collect.postcode = postcode;
-      collect.stad = stad;
-      collect.land = land;
+        const adresLink = addressLinks.find(
+          (c) => c.contact === contactLink.contact
+        );
+        if (adresLink) {
+          const straat = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value === 'http://www.w3.org/ns/locn#thoroughfare'
+          )?.o?.value;
+          const huisnummer = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value ===
+                'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer'
+          )?.o?.value;
+          const busnummer = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value ===
+                'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer'
+          )?.o?.value;
+          const postcode = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value === 'http://www.w3.org/ns/locn#postCode'
+          )?.o?.value;
+          const stad = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value === 'https://data.vlaanderen.be/ns/adres#gemeentenaam'
+          )?.o?.value;
+          const land = tripleData.find(
+            (d) =>
+              d.s.value === adresLink.address &&
+              d.p.value === 'https://data.vlaanderen.be/ns/adres#land'
+          )?.o?.value;
+          collect.adres = adresLink.address;
+          collect.straat = straat;
+          collect.huisnummer = huisnummer;
+          collect.busnummer = busnummer;
+          collect.postcode = postcode;
+          collect.stad = stad;
+          collect.land = land;
+        }
+      }
 
       data.push(collect);
     }

--- a/config/reports/worship/mandatarissen.js
+++ b/config/reports/worship/mandatarissen.js
@@ -1,18 +1,231 @@
 import * as mas from '@lblod/mu-auth-sudo';
 import * as queries from './queries';
-import { generateReportFromData } from '../../helpers';
+import * as hel from '../../helpers';
+
+const BATCH_SIZE = 100;
 
 async function generate() {
-  const data = await mas.querySudo(queries.getQueryMandatarissen());
-  const bindings = data?.results?.bindings || [];
-  const stringified = bindings.map((binding) => {
-    const res = {};
-    for (const key in binding) res[key] = binding[key].value;
-    return res;
-  });
-  stringified.sort((a, b) => a.mandataris < b.mandataris);
-  await generateReportFromData(
-    stringified,
+  const mandatarissenResponse = await hel.batchedQuery(
+    queries.allMandatarissen(),
+    BATCH_SIZE
+  );
+  const mandatarissen = mandatarissenResponse.results.bindings.sort(
+    (a, b) => a.mandataris.value < b.mandataris.value
+  );
+
+  let allData = [];
+
+  for (
+    let mandatarisCounter = 0;
+    mandatarisCounter < mandatarissen.length;
+    mandatarisCounter += BATCH_SIZE
+  ) {
+    const mandatarissenSlice = mandatarissen.slice(
+      mandatarisCounter,
+      mandatarisCounter + BATCH_SIZE
+    );
+    const mandatarissenURIsSlice = mandatarissenSlice.map(
+      (b) => b.mandataris.value
+    );
+
+    //Personen
+    const persoonQuery = queries.domainToRange(
+      mandatarissenURIsSlice,
+      'http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan',
+      'http://www.w3.org/ns/person#Person'
+    );
+    const personenResponse = await mas.querySudo(persoonQuery);
+    const personen = [
+      ...new Set(personenResponse.results.bindings.map((p) => p.range.value)),
+    ];
+    const personenLinks = personenResponse.results.bindings.map((r) => {
+      return {
+        mandataris: r.domain.value,
+        persoon: r.range.value,
+      };
+    });
+
+    //Identifiers
+    const identifierQuery = queries.domainToRange(
+      personen,
+      'http://www.w3.org/ns/adms#identifier',
+      'http://www.w3.org/ns/adms#Identifier'
+    );
+    const identifierResponse = await mas.querySudo(identifierQuery);
+    const identifiers = [
+      ...new Set(identifierResponse.results.bindings.map((i) => i.range.value)),
+    ];
+    const identifierLinks = identifierResponse.results.bindings.map((r) => {
+      return {
+        persoon: r.domain.value,
+        identifier: r.range.value,
+      };
+    });
+
+    //Geboortes
+    const geboorteQuery = queries.domainToRange(
+      personen,
+      'http://data.vlaanderen.be/ns/persoon#heeftGeboorte',
+      'http://data.vlaanderen.be/ns/persoon#Geboorte'
+    );
+    const geboortesResponse = await mas.querySudo(geboorteQuery);
+    const geboortes = [
+      ...new Set(geboortesResponse.results.bindings.map((g) => g.range.value)),
+    ];
+    const geboorteLinks = geboortesResponse.results.bindings.map((r) => {
+      return {
+        persoon: r.domain.value,
+        geboorte: r.range.value,
+      };
+    });
+
+    //Contacts
+    const contactQuery = queries.domainToRange(
+      mandatarissenURIsSlice,
+      'http://schema.org/contactPoint',
+      'http://schema.org/ContactPoint'
+    );
+    const contactsResponse = await mas.querySudo(contactQuery);
+    const contacts = [
+      ...new Set(contactsResponse.results.bindings.map((c) => c.range.value)),
+    ];
+    const contactLinks = contactsResponse.results.bindings.map((r) => {
+      return {
+        mandataris: r.domain.value,
+        contact: r.range.value,
+      };
+    });
+
+    //Adresses
+    const adresQuery = queries.domainToRange(
+      contacts,
+      'http://www.w3.org/ns/locn#address',
+      'http://www.w3.org/ns/locn#Address'
+    );
+    const addressResponse = await mas.querySudo(adresQuery);
+    const addresses = [
+      ...new Set(addressResponse.results.bindings.map((a) => a.range.value)),
+    ];
+    const addressLinks = addressResponse.results.bindings.map((r) => {
+      return {
+        contact: r.domain.value,
+        address: r.range.value,
+      };
+    });
+
+    //Positions
+    const positionQuery = queries.domainToRange(
+      mandatarissenURIsSlice,
+      'http://www.w3.org/ns/org#holds',
+      'http://data.vlaanderen.be/ns/mandaat#Mandaat'
+    );
+    const positionsResponse = await mas.querySudo(positionQuery);
+    const positions = [
+      ...new Set(positionsResponse.results.bindings.map((p) => p.range.value)),
+    ];
+    const positionLinks = positionsResponse.results.bindings.map((p) => {
+      return {
+        mandataris: p.domain.value,
+        position: p.range.value,
+      };
+    });
+
+    //Functions
+    const functionQuery = queries.domainToRange(
+      positions,
+      'http://www.w3.org/ns/org#role',
+      'http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode'
+    );
+    const functionResponse = await mas.querySudo(functionQuery);
+    const functions = [
+      ...new Set(functionResponse.results.bindings.map((p) => p.range.value)),
+    ];
+    const functionLinks = functionResponse.results.bindings.map((p) => {
+      return {
+        position: p.domain.value,
+        functie: p.range.value,
+      };
+    });
+
+    //Besturen
+    const besturenInTijdQuery = queries.rangeToDomain(
+      positions,
+      'http://www.w3.org/ns/org#hasPost',
+      'http://data.vlaanderen.be/ns/besluit#Bestuursorgaan'
+    );
+    const besturenInTijdResponse = await mas.querySudo(besturenInTijdQuery);
+    const besturenInTijd = [
+      ...new Set(
+        besturenInTijdResponse.results.bindings.map((p) => p.range.value)
+      ),
+    ];
+    const besturenInTijdLinks = besturenInTijdResponse.results.bindings.map(
+      (p) => {
+        return {
+          positie: p.domain.value,
+          bestuurInTijd: p.range.value,
+        };
+      }
+    );
+
+    const besturenQuery = queries.domainToRange(
+      besturenInTijd,
+      'http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan',
+      'http://data.vlaanderen.be/ns/besluit#Bestuursorgaan'
+    );
+    const besturenResponse = await mas.querySudo(besturenQuery);
+    const besturen = [
+      ...new Set(besturenResponse.results.bindings.map((p) => p.range.value)),
+    ];
+    const besturenLinks = besturenResponse.results.bindings.map((p) => {
+      return {
+        positie: p.domain.value,
+        bestuur: p.range.value,
+      };
+    });
+
+    let allURIs = new Set();
+    [
+      ...mandatarissenURIsSlice,
+      ...personen,
+      ...identifiers,
+      ...geboortes,
+      ...contacts,
+      ...addresses,
+      ...positions,
+      ...functions,
+      ...besturenInTijd,
+      ...besturen,
+    ].forEach((e) => allURIs.add(e));
+    allURIs = [...allURIs];
+
+    const tripleData = [];
+
+    for (let counter = 0; counter < allURIs.length; counter += BATCH_SIZE) {
+      const URIslice = allURIs.slice(counter, counter + BATCH_SIZE);
+      const dataQuery = queries.dataForSubjects(URIslice);
+      const dataResponse = await mas.querySudo(dataQuery);
+      dataResponse.results.bindings.forEach((e) => tripleData.push(e));
+    }
+
+    const combinedData = combineMandatarissenData(
+      tripleData,
+      mandatarissenURIsSlice,
+      personenLinks,
+      identifierLinks,
+      geboorteLinks,
+      contactLinks,
+      addressLinks,
+      positionLinks,
+      functionLinks,
+      besturenInTijdLinks,
+      besturenLinks
+    );
+    allData = allData.concat(combinedData);
+  }
+
+  await hel.generateReportFromData(
+    allData,
     [
       'bestuurnaam',
       'mandataris',
@@ -31,14 +244,12 @@ async function generate() {
       'email',
       'telefoon',
       'adres',
-      'busnummer',
-      'huisnummer',
       'straat',
+      'huisnummer',
+      'busnummer',
       'postcode',
       'stad',
       'land',
-      'volAdress',
-      'adresVerwijzing',
     ],
     {
       title: 'Eredienst Mandatarissen Report',
@@ -48,8 +259,180 @@ async function generate() {
   );
 }
 
+function combineMandatarissenData(
+  tripleData,
+  mandatarissen,
+  personenLinks,
+  identifierLinks,
+  geboorteLinks,
+  contactLinks,
+  addressLinks,
+  positionLinks,
+  functionLinks,
+  besturenInTijdLinks,
+  besturenLinks
+) {
+  const data = [];
+
+  for (const mandataris of mandatarissen) {
+    const startDatum = tripleData.find(
+      (d) =>
+        d.s.value === mandataris &&
+        d.p.value === 'http://data.vlaanderen.be/ns/mandaat#start'
+    )?.o?.value;
+    const eindeDatum = tripleData.find(
+      (d) =>
+        d.s.value === mandataris &&
+        d.p.value === 'http://data.vlaanderen.be/ns/mandaat#einde'
+    )?.o?.value;
+
+    const collect = { mandataris, startDatum, eindeDatum };
+
+    const positionLink = positionLinks.find((p) => p.mandataris === mandataris);
+
+    const functionLink = functionLinks.find(
+      (f) => f.position === positionLink.position
+    );
+    const functienaam = tripleData.find(
+      (d) =>
+        d.s.value === functionLink.functie &&
+        d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
+    )?.o?.value;
+    collect.rolnaam = functienaam;
+
+    const bestuurInTijdLink = besturenInTijdLinks.find(
+      (b) => positionLink.position === b.positie
+    );
+    const bestuurLink = besturenLinks.find(
+      (b) => bestuurInTijdLink.bestuur === b.bestuurInTijd
+    );
+    const bestuurnaam = tripleData.find(
+      (d) =>
+        d.s.value === bestuurLink.bestuur &&
+        d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
+    )?.o?.value;
+    collect.bestuurnaam = bestuurnaam;
+
+    const personen = personenLinks.filter((p) => p.mandataris === mandataris);
+
+    for (const persoonLink of personen) {
+      const familienaam = tripleData.find(
+        (d) =>
+          d.s.value === persoonLink.persoon &&
+          d.p.value === 'http://xmlns.com/foaf/0.1/familyName'
+      )?.o?.value;
+      const voornaam = tripleData.find(
+        (d) =>
+          d.s.value === persoonLink.persoon &&
+          d.p.value === 'http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam'
+      )?.o?.value;
+      const nationaliteit = tripleData.find(
+        (d) =>
+          d.s.value === persoonLink.persoon &&
+          d.p.value ===
+            'http://data.vlaanderen.be/ns/persoon#heeftNationaliteit'
+      )?.o?.value;
+      const geslacht = tripleData.find(
+        (d) =>
+          d.s.value === persoonLink.persoon &&
+          d.p.value === 'http://data.vlaanderen.be/ns/persoon#geslacht'
+      )?.o?.value;
+      collect.persoon = persoonLink.persoon;
+      collect.familienaam = familienaam;
+      collect.voornaam = voornaam;
+      collect.nationaliteit = nationaliteit;
+      collect.geslacht = geslacht;
+
+      const geboorteLink =
+        geboorteLinks.find((g) => g.persoon === persoonLink.persoon) || [];
+      const geboorteDatum = tripleData.find(
+        (d) =>
+          d.s.value === geboorteLink.geboorte &&
+          d.p.value === 'http://data.vlaanderen.be/ns/persoon#datum'
+      )?.o?.value;
+      collect.geboorteDatum = geboorteDatum;
+
+      const identifierLink =
+        identifierLinks.find((g) => g.persoon === persoonLink.persoon) || [];
+      const identifier = tripleData.find(
+        (d) =>
+          d.s.value === identifierLink.identifier &&
+          d.p.value === 'http://www.w3.org/2004/02/skos/core#notation'
+      )?.o?.value;
+      collect.rrnummer = identifier;
+
+      const contactLink = contactLinks.find((c) => c.mandataris === mandataris);
+      const contactSoort = tripleData.find(
+        (d) =>
+          d.s.value === contactLink.contact &&
+          d.p.value === 'http://schema.org/contactType'
+      )?.o?.value;
+      const email = tripleData.find(
+        (d) =>
+          d.s.value === contactLink.contact &&
+          d.p.value === 'http://schema.org/email'
+      )?.o?.value;
+      const telefoon = tripleData.find(
+        (d) =>
+          d.s.value === contactLink.contact &&
+          d.p.value === 'http://schema.org/telephone'
+      )?.o?.value;
+      collect.contact = contactLink.contact;
+      collect.contactSoort = contactSoort;
+      collect.email = email;
+      collect.telefoon = telefoon;
+
+      const adresLink = addressLinks.find(
+        (c) => c.contact === contactLink.contact
+      );
+      const straat = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value === 'http://www.w3.org/ns/locn#thoroughfare'
+      )?.o?.value;
+      const huisnummer = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value ===
+            'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer'
+      )?.o?.value;
+      const busnummer = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value ===
+            'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer'
+      )?.o?.value;
+      const postcode = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value === 'http://www.w3.org/ns/locn#postCode'
+      )?.o?.value;
+      const stad = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value === 'https://data.vlaanderen.be/ns/adres#gemeentenaam'
+      )?.o?.value;
+      const land = tripleData.find(
+        (d) =>
+          d.s.value === adresLink.address &&
+          d.p.value === 'https://data.vlaanderen.be/ns/adres#land'
+      )?.o?.value;
+      collect.adres = adresLink.address;
+      collect.straat = straat;
+      collect.huisnummer = huisnummer;
+      collect.busnummer = busnummer;
+      collect.postcode = postcode;
+      collect.stad = stad;
+      collect.land = land;
+
+      data.push(collect);
+    }
+  }
+  return data;
+}
+
 export default {
-  cronPattern: '5 1 * * *',
+  cronPattern: '20 1 * * *',
   name: 'eredienst-mandatarissen',
   execute: generate,
 };

--- a/config/reports/worship/mandatarissen.js
+++ b/config/reports/worship/mandatarissen.js
@@ -229,6 +229,7 @@ async function generate() {
     [
       'bestuurnaam',
       'mandataris',
+      'afkomstGegevens',
       'rolnaam',
       'startDatum',
       'eindeDatum',
@@ -275,6 +276,11 @@ function combineMandatarissenData(
   const data = [];
 
   for (const mandataris of mandatarissen) {
+    const afkomstGegevens = tripleData.find(
+      (d) =>
+        d.s.value === mandataris &&
+        d.p.value === 'http://www.w3.org/ns/prov#wasGeneratedBy'
+    )?.o?.value;
     const startDatum = tripleData.find(
       (d) =>
         d.s.value === mandataris &&
@@ -286,7 +292,7 @@ function combineMandatarissenData(
         d.p.value === 'http://data.vlaanderen.be/ns/mandaat#einde'
     )?.o?.value;
 
-    const collect = { mandataris, startDatum, eindeDatum };
+    const collect = { mandataris, afkomstGegevens, startDatum, eindeDatum };
 
     const positionLink = positionLinks.find((p) => p.mandataris === mandataris);
 

--- a/config/reports/worship/mandatarissen.js
+++ b/config/reports/worship/mandatarissen.js
@@ -296,28 +296,36 @@ function combineMandatarissenData(
 
     const positionLink = positionLinks.find((p) => p.mandataris === mandataris);
 
-    const functionLink = functionLinks.find(
-      (f) => f.position === positionLink.position
-    );
-    const functienaam = tripleData.find(
-      (d) =>
-        d.s.value === functionLink.functie &&
-        d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
-    )?.o?.value;
-    collect.rolnaam = functienaam;
+    if (positionLink) {
+      const functionLink = functionLinks.find(
+        (f) => f.position === positionLink.position
+      );
+      if (functionLink) {
+        const functienaam = tripleData.find(
+          (d) =>
+            d.s.value === functionLink.functie &&
+            d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
+        )?.o?.value;
+        collect.rolnaam = functienaam;
+      }
 
-    const bestuurInTijdLink = besturenInTijdLinks.find(
-      (b) => positionLink.position === b.positie
-    );
-    const bestuurLink = besturenLinks.find(
-      (b) => bestuurInTijdLink.bestuur === b.bestuurInTijd
-    );
-    const bestuurnaam = tripleData.find(
-      (d) =>
-        d.s.value === bestuurLink.bestuur &&
-        d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
-    )?.o?.value;
-    collect.bestuurnaam = bestuurnaam;
+      const bestuurInTijdLink = besturenInTijdLinks.find(
+        (b) => positionLink.position === b.positie
+      );
+      if (bestuurInTijdLink) {
+        const bestuurLink = besturenLinks.find(
+          (b) => bestuurInTijdLink.bestuur === b.bestuurInTijd
+        );
+        if (bestuurLink) {
+          const bestuurnaam = tripleData.find(
+            (d) =>
+              d.s.value === bestuurLink.bestuur &&
+              d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
+          )?.o?.value;
+          collect.bestuurnaam = bestuurnaam;
+        }
+      }
+    }
 
     const personen = personenLinks.filter((p) => p.mandataris === mandataris);
 

--- a/config/reports/worship/queries.js
+++ b/config/reports/worship/queries.js
@@ -8,19 +8,19 @@
  * is one of the subjects in the array.
  * @returns {String} The query to execute.
  */
-//export function dataForSubjects(subjectURIs) {
-//  const subjectValues = subjectURIs.map((uri) => `<${uri}>`).join(' ');
-//  return `
-//SELECT ?g ?s ?p ?o WHERE {
-//  VALUES ?s {
-//    ${subjectValues}
-//  }
-//  GRAPH ?g {
-//    ?s ?p ?o .
-//  }
-//}
-//  `;
-//}
+export function dataForSubjects(subjectURIs) {
+  const subjectValues = subjectURIs.map((uri) => `<${uri}>`).join(' ');
+  return `
+SELECT ?g ?s ?p ?o WHERE {
+  VALUES ?s {
+    ${subjectValues}
+  }
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+  `;
+}
 
 /**
  * Produces a query that returns all RolBedienaren that where harvested. The
@@ -40,10 +40,12 @@ SELECT DISTINCT ?bedienaar WHERE {
   FILTER (?g NOT IN (
     <http://eredienst-mandatarissen-consumer/temp-inserts>,
     <http://eredienst-mandatarissen-consumer/temp-deletes>))
-  ?bedienaar
-    a <http://data.lblod.info/vocabularies/erediensten/RolBedienaar> ;
-    <http://www.w3.org/ns/prov#wasGeneratedBy>
-      <http://lblod.data.gift/id/app/lblod-harvesting> .
+  GRAPH ?g {
+    ?bedienaar
+      a <http://data.lblod.info/vocabularies/erediensten/RolBedienaar> ;
+      <http://www.w3.org/ns/prov#wasGeneratedBy>
+        <http://lblod.data.gift/id/app/lblod-harvesting> .
+  }
 }
   `;
 }
@@ -60,19 +62,21 @@ SELECT DISTINCT ?bedienaar WHERE {
  * @function
  * @returns {String} The SPARQL query to execute.
  */
-//export function allMandatarissen() {
-//  return `
-//SELECT DISTINCT ?mandataris WHERE {
-//  FILTER (?g NOT IN (
-//    <http://eredienst-mandatarissen-consumer/temp-inserts>,
-//    <http://eredienst-mandatarissen-consumer/temp-deletes>))
-//  ?mandataris
-//    a <http://data.lblod.info/vocabularies/erediensten/EredienstMandataris> ;
-//    <http://www.w3.org/ns/prov#wasGeneratedBy>
-//      <http://lblod.data.gift/id/app/lblod-harvesting> .
-//}
-//  `;
-//}
+export function allMandatarissen() {
+  return `
+SELECT DISTINCT ?mandataris WHERE {
+  FILTER (?g NOT IN (
+    <http://eredienst-mandatarissen-consumer/temp-inserts>,
+    <http://eredienst-mandatarissen-consumer/temp-deletes>))
+  GRAPH ?g {
+    ?mandataris
+      a <http://data.lblod.info/vocabularies/erediensten/EredienstMandataris> ;
+      <http://www.w3.org/ns/prov#wasGeneratedBy>
+        <http://lblod.data.gift/id/app/lblod-harvesting> .
+  }
+}
+  `;
+}
 
 /**
  * Produces a query that collects subjects related to a collection of given
@@ -90,18 +94,42 @@ SELECT DISTINCT ?bedienaar WHERE {
  * @param {String} type - Represents the `rdf:type` of the related subject.
  * @returns {String} The SPARQL query to execute.
  */
-//export function subjectToRange(domainURIs, predicate, type) {
-//  const subjectValues = domainURIs.map((uri) => `<${uri}>`).join(' ');
-//  return `
-//SELECT DISTINCT ?range {
-//  VALUES ?s {
-//    ${subjectValues}
-//  }
-//  ?s <${predicate}> ?range .
-//  ?range a <${type}> .
-//}
-//  `;
-//}
+export function domainToRange(domainURIs, predicate, type) {
+  const domainValues = domainURIs.map((uri) => `<${uri}>`).join(' ');
+  return `
+SELECT DISTINCT ?domain ?range {
+  VALUES ?domain {
+    ${domainValues}
+  }
+  ?domain <${predicate}> ?range .
+  ?range a <${type}> .
+}
+  `;
+}
+
+/*
+ * Same as `domainToRange`, but backwards. This query now looks for entities
+ * of a certain type that point to the URIs via a given predicate.
+ * @see domainToRange
+ * @public
+ * @function
+ * @param {Array(String)} domainURIs - This collection contains subjects where you want related subjects of.
+ * @param {String} predicate - Represents the full RDF predicate to get related objects that are new RDF entities.
+ * @param {String} type - Represents the `rdf:type` of the related subject.
+ * @returns {String} The SPARQL query to execute.
+ */
+export function rangeToDomain(domainURIs, predicate, type) {
+  const domainValues = domainURIs.map((uri) => `<${uri}>`).join(' ');
+  return `
+SELECT DISTINCT ?domain ?range {
+  VALUES ?domain {
+    ${domainValues}
+  }
+  ?range <${predicate}> ?domain .
+  ?range a <${type}> .
+}
+  `;
+}
 
 /**
  * Produces a query to get all the triples from a graph. No pagination, just
@@ -118,234 +146,6 @@ export function allFromGraph(graphURI) {
 SELECT DISTINCT ?s ?p ?o WHERE {
   GRAPH <${graphURI}> {
     ?s ?p ?o .
-  }
-}
-  `;
-}
-
-//Reasonable performance, but data is missing. For example, if a geboorte is
-//missing, nothing is inluded in the results. Using optional on these
-//statements tanks performance to a point where it's unusable.
-//function getBedienarenSubjects(limit, offset) {
-//  return `
-//SELECT DISTINCT ?bedienaar ?persoon ?contact ?identifier ?geboorte ?adres WHERE {
-//  {
-//    SELECT DISTINCT ?bedienaar WHERE {
-//      FILTER (?g NOT IN (
-//        <http://eredienst-mandatarissen-consumer/temp-inserts>,
-//        <http://eredienst-mandatarissen-consumer/temp-deletes>))
-//      ?bedienaar a <http://data.lblod.info/vocabularies/erediensten/RolBedienaar> .
-//    }
-//    LIMIT ${limit}
-//    OFFSET ${offset}
-//  }
-//  ?bedienaar <http://www.w3.org/ns/org#heldBy> ?persoon ;
-//             <http://schema.org/contactPoint> ?contact .
-//  ?persoon <http://www.w3.org/ns/adms#identifier> ?identifier ;
-//           <http://data.vlaanderen.be/ns/persoon#heeftGeboorte> ?geboorte .
-//  ?contact <http://www.w3.org/ns/locn#address> ?adres .
-//}
-//  `;
-//}
-
-/**
- * Produces a query that returns all the Eredienst Bedienaren and the data
- * of their related properties.
- *
- * @public
- * @function
- * @returns {String} The SPARQL query to execute.
- */
-export function getQueryBedienaren() {
-  return `
-PREFIX schema:     <http://schema.org/>
-PREFIX rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX org:        <http://www.w3.org/ns/org#>
-PREFIX contactHub: <http://data.lblod.info/vocabularies/contacthub/>
-PREFIX person:     <http://www.w3.org/ns/person#>
-PREFIX persoon:    <http://data.vlaanderen.be/ns/persoon#>
-PREFIX adms:       <http://www.w3.org/ns/adms#>
-PREFIX foaf:       <http://xmlns.com/foaf/0.1/>
-PREFIX locn:       <http://www.w3.org/ns/locn#>
-PREFIX adres:      <https://data.vlaanderen.be/ns/adres#>
-PREFIX skos:       <http://www.w3.org/2004/02/skos/core#>
-PREFIX prov:       <http://www.w3.org/ns/prov#>
-PREFIX ere:        <http://data.lblod.info/vocabularies/erediensten/>
-PREFIX organis:    <http://lblod.data.gift/vocabularies/organisatie/>
-
-SELECT DISTINCT ?bestuurnaam ?bedienaar ?functienaam ?startDatum ?eindeDatum ?persoon ?familienaam ?voornaam ?geboorteDatum ?rrnummer ?nationaliteit ?geslacht ?contact ?contactSoort ?email ?telefoon ?adres ?busnummer ?huisnummer ?straat ?postcode ?stad ?land ?volAdress ?adresVerwijzing WHERE {
-  {
-    SELECT DISTINCT ?bedienaar WHERE {
-      FILTER (?g NOT IN (
-        <http://eredienst-mandatarissen-consumer/temp-inserts>,
-        <http://eredienst-mandatarissen-consumer/temp-deletes>))
-      GRAPH ?g {
-        ?bedienaar
-          rdf:type ere:RolBedienaar ;
-          prov:wasGeneratedBy
-            <http://lblod.data.gift/id/app/lblod-harvesting> .
-      }
-    }
-  }
-  GRAPH ?graph {
-  	?bedienaar
-      org:holds ?positie ;
-      org:heldBy ?persoon ;
-      schema:contactPoint ?contact .
-    OPTIONAL { ?bedienaar contactHub:startdatum ?startDatum . }
-    OPTIONAL { ?bedienaar contactHub:eindedatum ?eindeDatum . }
-
-    ?persoon
-      rdf:type person:Person ;
-      adms:identifier ?identifier .
-    OPTIONAL { ?persoon persoon:heeftGeboorte ?geboorte . }
-    OPTIONAL { ?persoon foaf:familyName ?familienaam . }
-    OPTIONAL { ?persoon persoon:gebruikteVoornaam ?voornaam . }
-    OPTIONAL { ?persoon persoon:heeftNationaliteit ?nationaliteit . }
-    OPTIONAL { ?persoon persoon:geslacht ?geslacht . }
-    
-    ?contact
-      rdf:type schema:ContactPoint ;
-      locn:address ?adres .
-    OPTIONAL { ?contact schema:contactType ?contactSoort . }
-    OPTIONAL { ?contact schema:email ?email . }
-    OPTIONAL { ?contact schema:telephone ?telefoon . }
-
-    ?adres
-      rdf:type locn:Address .
-    OPTIONAL { ?adres adres:Adresvoorstelling.busnummer ?busnummer . }
-    OPTIONAL { ?adres adres:Adresvoorstelling.huisnummer ?huisnummer . }
-    OPTIONAL { ?adres locn:thoroughfare ?straat . }
-    OPTIONAL { ?adres locn:postCode ?postcode . }
-    OPTIONAL { ?adres adres:gemeentenaam ?stad . }
-    OPTIONAL { ?adres adres:land ?land . }
-    OPTIONAL { ?adres locn:fullAddress ?volAdress . }
-    OPTIONAL { ?adres adres:verwijstNaar ?adresVerwijzing . }
-
-    ?geboorte
-      rdf:type persoon:Geboorte .
-    OPTIONAL { ?geboorte persoon:datum ?geboorteDatum . }
-
-    ?identifier
-      rdf:type adms:Identifier .
-    OPTIONAL { ?identifier skos:notation ?rrnummer . }
-  }
-  OPTIONAL {
-    ?positie
-      rdf:type ere:PositieBedienaar ;
-      ere:functie ?functie .
-    ?functie
-      rdf:type organis:EredienstBeroepen ;
-      skos:prefLabel ?functienaam .
-  }
-  OPTIONAL {
-    ?bestuur
-      ere:wordtBediendDoor ?positie ;
-      rdf:type ere:BestuurVanDeEredienst ;
-      skos:prefLabel ?bestuurnaam .
-  }
-}
-  `;
-}
-
-/**
- * Produces a query that returns all the Eredienst Mandatarissen and the data
- * of their related properties.
- *
- * @public
- * @function
- * @returns {String} The SPARQL query to execute.
- */
-export function getQueryMandatarissen() {
-  return `
-PREFIX schema:     <http://schema.org/>
-PREFIX rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX org:        <http://www.w3.org/ns/org#>
-PREFIX contactHub: <http://data.lblod.info/vocabularies/contacthub/>
-PREFIX person:     <http://www.w3.org/ns/person#>
-PREFIX persoon:    <http://data.vlaanderen.be/ns/persoon#>
-PREFIX adms:       <http://www.w3.org/ns/adms#>
-PREFIX foaf:       <http://xmlns.com/foaf/0.1/>
-PREFIX locn:       <http://www.w3.org/ns/locn#>
-PREFIX adres:      <https://data.vlaanderen.be/ns/adres#>
-PREFIX skos:       <http://www.w3.org/2004/02/skos/core#>
-PREFIX mandaat:    <http://data.vlaanderen.be/ns/mandaat#>
-PREFIX prov:       <http://www.w3.org/ns/prov#>
-PREFIX ere:        <http://data.lblod.info/vocabularies/erediensten/>
-PREFIX besluit:    <http://data.vlaanderen.be/ns/besluit#>
-
-SELECT DISTINCT ?bestuurnaam ?mandataris ?rolnaam ?startDatum ?eindeDatum ?persoon ?familienaam ?voornaam ?geboorteDatum ?rrnummer ?nationaliteit ?geslacht ?contact ?contactSoort ?email ?telefoon ?adres ?busnummer ?huisnummer ?straat ?postcode ?stad ?land ?volAdress ?adresVerwijzing WHERE {
-  {
-    SELECT DISTINCT ?mandataris WHERE {
-      FILTER (?g NOT IN (
-        <http://eredienst-mandatarissen-consumer/temp-inserts>,
-        <http://eredienst-mandatarissen-consumer/temp-deletes>))
-      GRAPH ?g {
-        ?mandataris
-          rdf:type ere:EredienstMandataris ;
-          prov:wasGeneratedBy
-            <http://lblod.data.gift/id/app/lblod-harvesting> .
-      }
-    }
-  }
-  GRAPH ?graph {
-  	?mandataris
-      org:holds ?mandaat ;
-      mandaat:isBestuurlijkeAliasVan ?persoon ;
-      schema:contactPoint ?contact .
-    OPTIONAL { ?bedienaar contactHub:startdatum ?startDatum . }
-    OPTIONAL { ?bedienaar contactHub:eindedatum ?eindeDatum . }
-
-    ?persoon
-      rdf:type person:Person ;
-      adms:identifier ?identifier .
-    OPTIONAL { ?persoon persoon:heeftGeboorte ?geboorte . }
-    OPTIONAL { ?persoon foaf:familyName ?familienaam . }
-    OPTIONAL { ?persoon persoon:gebruikteVoornaam ?voornaam . }
-    OPTIONAL { ?persoon persoon:heeftNationaliteit ?nationaliteit . }
-    OPTIONAL { ?persoon persoon:geslacht ?geslacht . }
-    
-    ?contact
-      rdf:type schema:ContactPoint ;
-      locn:address ?adres .
-    OPTIONAL { ?contact schema:contactType ?contactSoort . }
-    OPTIONAL { ?contact schema:email ?email . }
-    OPTIONAL { ?contact schema:telephone ?telefoon . }
-
-    ?adres
-      rdf:type locn:Address .
-    OPTIONAL { ?adres adres:Adresvoorstelling.busnummer ?busnummer . }
-    OPTIONAL { ?adres adres:Adresvoorstelling.huisnummer ?huisnummer . }
-    OPTIONAL { ?adres locn:thoroughfare ?straat . }
-    OPTIONAL { ?adres locn:postCode ?postcode . }
-    OPTIONAL { ?adres adres:gemeentenaam ?stad . }
-    OPTIONAL { ?adres adres:land ?land . }
-    OPTIONAL { ?adres locn:fullAddress ?volAdress . }
-    OPTIONAL { ?adres adres:verwijstNaar ?adresVerwijzing . }
-
-    ?geboorte
-      rdf:type persoon:Geboorte .
-    OPTIONAL { ?geboorte persoon:datum ?geboorteDatum . }
-
-    ?identifier
-      rdf:type adms:Identifier .
-    OPTIONAL { ?identifier skos:notation ?rrnummer . }
-  }
-  OPTIONAL {
-    ?bestuurintijd
-      rdf:type besluit:Bestuursorgaan ;
-      org:hasPost ?mandaat ;
-      mandaat:isTijdspecialisatieVan ?bestuur .
-    ?bestuur
-      rdf:type besluit:Bestuursorgaan ;
-      skos:prefLabel ?bestuurnaam .
-  }
-  OPTIONAL {
-    ?mandaat
-      org:role ?role .
-    ?role
-      rdf:type <http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode> ;
-      skos:prefLabel ?rolnaam .
   }
 }
   `;

--- a/config/reports/worship/queries.js
+++ b/config/reports/worship/queries.js
@@ -42,9 +42,7 @@ SELECT DISTINCT ?bedienaar WHERE {
     <http://eredienst-mandatarissen-consumer/temp-deletes>))
   GRAPH ?g {
     ?bedienaar
-      a <http://data.lblod.info/vocabularies/erediensten/RolBedienaar> ;
-      <http://www.w3.org/ns/prov#wasGeneratedBy>
-        <http://lblod.data.gift/id/app/lblod-harvesting> .
+      a <http://data.lblod.info/vocabularies/erediensten/RolBedienaar> .
   }
 }
   `;
@@ -70,9 +68,7 @@ SELECT DISTINCT ?mandataris WHERE {
     <http://eredienst-mandatarissen-consumer/temp-deletes>))
   GRAPH ?g {
     ?mandataris
-      a <http://data.lblod.info/vocabularies/erediensten/EredienstMandataris> ;
-      <http://www.w3.org/ns/prov#wasGeneratedBy>
-        <http://lblod.data.gift/id/app/lblod-harvesting> .
+      a <http://data.lblod.info/vocabularies/erediensten/EredienstMandataris> .
   }
 }
   `;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,7 +241,7 @@ services:
     restart: always
     logging: *default-logging
   report-generation:
-    image: lblod/loket-report-generation-service:0.6.3
+    image: lblod/loket-report-generation-service:0.6.4
     volumes:
       - ./data/files:/share
       - ./config/reports/:/config/


### PR DESCRIPTION
Rewriting the reports on worship services. This had to be done because the original large queries would time-out for both worship services reports. This version is now needlessly complex, but this can be improved with decent RDF libraries and such (to do). At least it is more stable because it produces smaller queries in loops to break up the model into smaller pieces. It then needs to combine all that data into rows of related data.

In the mean time, some columns have been dropped such as `adresVerwijzing` and `volAdres`. These where redundant. Some columns have also been reordered to make more sense. A column has also been added to indicate the provenance in case of harvesting.