### PR TITLE
Bumping berichtencentrum-sync-with-kalliope from v0.14.0 to 0.15.0-rc.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,7 @@ services:
     restart: always
     logging: *default-logging
   berichtencentrum-sync-with-kalliope:
-    image: lblod/berichtencentrum-sync-with-kalliope-service:0.14.0
+    image: lblod/berichtencentrum-sync-with-kalliope-service:0.15.0-rc.1
     environment:
       MU_SPARQL_ENDPOINT: "http://database:8890/sparql"
       MU_SPARQL_UPDATEPOINT: "http://database:8890/sparql"


### PR DESCRIPTION
# Description
DL-5305

Bumping the service version.
Changes are visible in https://github.com/lblod/berichtencentrum-sync-with-kalliope-service/commit/ff2c4f4d3719ab053a9cad55a26a2d67d45ba7a6

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- [berichtencentrum-sync-with-kalliope](https://github.com/lblod/berichtencentrum-sync-with-kalliope-service)

# What to check

- Submissions should flow like expected if they don't meet the exclusion criteria (see in https://github.com/lblod/berichtencentrum-sync-with-kalliope-service/commit/ff2c4f4d3719ab053a9cad55a26a2d67d45ba7a6).

# Links to other PR's

- N/A

# Notes

- drc up -d berichtencentrum-sync-with-kalliope
