### PR TITLE
Bump automatic-submission-service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,7 +260,7 @@ services:
     restart: always
     logging: *default-logging
   automatic-submission:
-    image: lblod/automatic-submission-service:1.3.0
+    image: lblod/automatic-submission-service:1.3.1
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
This version of the `automatic-submission-service` reverts API changes to resemble a previous version to restore interoperability with the vendors.