### PR TITLE
Share subsidy attachments over delta-sync

### DIFF
--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -316,6 +316,9 @@
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
         "http://www.w3.org/ns/adms#status"
       ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
       "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject"
     }
   ]

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -33,9 +33,7 @@
       "type": "http://data.europa.eu/m8g/Participation"
     },
     {
-      "properties": [
-        "http://data.europa.eu/m8g/playsRole"
-      ],
+      "properties": ["http://data.europa.eu/m8g/playsRole"],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
       ],
@@ -128,9 +126,7 @@
         "http://www.w3.org/2004/02/skos/core#prefLabel",
         "http://www.w3.org/2004/02/skos/core#inScheme"
       ],
-      "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
-      ],
+      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
       "type": "http://lblod.data.gift/vocabularies/subsidie/SubsidiemaatregelConsumptieStatus"
     },
     {
@@ -145,9 +141,7 @@
         "http://purl.org/vocab/cpsv#follows",
         "http://www.w3.org/2004/02/skos/core#related"
       ],
-      "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
-      ],
+      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
       "type": "http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelAanbod"
     },
     {
@@ -163,9 +157,7 @@
         "https://data.vlaanderen.be/ns/mobiliteit#periode",
         "http://purl.org/vocab/cpsv#follows"
       ],
-      "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
-      ],
+      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
       "type": "http://lblod.data.gift/vocabularies/subsidie/SubsidiemaatregelAanbodReeks"
     },
     {
@@ -175,9 +167,7 @@
         "http://rdf-vocabulary.ddialliance.org/xkos#belongsTo",
         "http://rdf-vocabulary.ddialliance.org/xkos#next"
       ],
-      "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
-      ],
+      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
       "type": "http://lblod.data.gift/vocabularies/subsidie/ApplicationFlow"
     },
     {
@@ -191,9 +181,7 @@
         "http://purl.org/dc/terms/source",
         "http://purl.org/linked-data/cube#order"
       ],
-      "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
-      ],
+      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
       "type": "http://lblod.data.gift/vocabularies/subsidie/ApplicationStep"
     },
     {
@@ -204,9 +192,7 @@
         "https://data.vlaanderen.be/ns/mobiliteit#periode",
         "http://data.vlaanderen.be/ns/subsidie#Subsidieprocedurestap.type"
       ],
-      "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
-      ],
+      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
       "type": "http://data.vlaanderen.be/ns/subsidie#Subsidieprocedurestap"
     },
     {
@@ -217,9 +203,7 @@
         "http://data.europa.eu/m8g/endTime",
         "http://data.europa.eu/m8g/startTime"
       ],
-      "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
-      ],
+      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
       "type": "http://data.europa.eu/m8g/PeriodOfTime"
     },
     {
@@ -231,9 +215,7 @@
         "http://purl.org/dc/terms/isPartOf",
         "http://data.europa.eu/m8g/criterionType"
       ],
-      "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
-      ],
+      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
       "type": "http://data.europa.eu/m8g/Criterion"
     },
     {
@@ -243,9 +225,7 @@
         "http://purl.org/dc/terms/description",
         "http://data.europa.eu/m8g/hasCriterionRequirement"
       ],
-      "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
-      ],
+      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
       "type": "http://data.europa.eu/m8g/RequirementGroup"
     },
     {
@@ -256,9 +236,7 @@
         "http://purl.org/dc/terms/description",
         "http://lblod.data.gift/vocabularies/subsidie/isSatisfiableBy"
       ],
-      "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
-      ],
+      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
       "type": "http://data.europa.eu/m8g/CriterionRequirement"
     },
     {
@@ -281,6 +259,23 @@
         "http://purl.org/linked-data/cube#order"
       ],
       "type": "http://www.w3.org/2004/02/skos/core#Concept"
+    },
+    {
+      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName",
+        "http://purl.org/dc/terms/format",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize",
+        "http://dbpedia.org/ontology/fileExtension",
+        "http://purl.org/dc/terms/created",
+        "http://purl.org/dc/terms/modified",
+        "http://purl.org/dc/terms/type",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url"
+      ],
+      "additionalFilter": "?subject <http://schema.org/publication> <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325>."
     }
   ]
 }

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -33,7 +33,9 @@
       "type": "http://data.europa.eu/m8g/Participation"
     },
     {
-      "properties": ["http://data.europa.eu/m8g/playsRole"],
+      "properties": [
+        "http://data.europa.eu/m8g/playsRole"
+      ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
       ],
@@ -261,7 +263,6 @@
       "type": "http://www.w3.org/2004/02/skos/core#Concept"
     },
     {
-      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
       "properties": [
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
         "http://mu.semte.ch/vocabularies/core/uuid",
@@ -274,10 +275,13 @@
         "http://purl.org/dc/terms/type",
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url"
-      ]
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject"
     },
     {
-      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject",
       "properties": [
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
         "http://mu.semte.ch/vocabularies/core/uuid",
@@ -291,7 +295,8 @@
         "http://purl.org/dc/terms/type",
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
         "http://www.w3.org/ns/adms#status"
-      ]
+      ],
+      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject"
     }
   ]
 }

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -275,6 +275,23 @@
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url"
       ]
+    },
+    {
+      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject",
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName",
+        "http://purl.org/dc/terms/format",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize",
+        "http://dbpedia.org/ontology/fileExtension",
+        "http://purl.org/dc/terms/created",
+        "http://purl.org/dc/terms/modified",
+        "http://purl.org/dc/terms/type",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
+        "http://www.w3.org/ns/adms#status"
+      ]
     }
   ]
 }

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -274,8 +274,7 @@
         "http://purl.org/dc/terms/type",
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url"
-      ],
-      "additionalFilter": "?subject <http://schema.org/publication> <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325>."
+      ]
     }
   ]
 }

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -128,7 +128,9 @@
         "http://www.w3.org/2004/02/skos/core#prefLabel",
         "http://www.w3.org/2004/02/skos/core#inScheme"
       ],
-      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
       "type": "http://lblod.data.gift/vocabularies/subsidie/SubsidiemaatregelConsumptieStatus"
     },
     {
@@ -143,7 +145,9 @@
         "http://purl.org/vocab/cpsv#follows",
         "http://www.w3.org/2004/02/skos/core#related"
       ],
-      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
       "type": "http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelAanbod"
     },
     {
@@ -159,7 +163,9 @@
         "https://data.vlaanderen.be/ns/mobiliteit#periode",
         "http://purl.org/vocab/cpsv#follows"
       ],
-      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
       "type": "http://lblod.data.gift/vocabularies/subsidie/SubsidiemaatregelAanbodReeks"
     },
     {
@@ -169,7 +175,9 @@
         "http://rdf-vocabulary.ddialliance.org/xkos#belongsTo",
         "http://rdf-vocabulary.ddialliance.org/xkos#next"
       ],
-      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
       "type": "http://lblod.data.gift/vocabularies/subsidie/ApplicationFlow"
     },
     {
@@ -183,7 +191,9 @@
         "http://purl.org/dc/terms/source",
         "http://purl.org/linked-data/cube#order"
       ],
-      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
       "type": "http://lblod.data.gift/vocabularies/subsidie/ApplicationStep"
     },
     {
@@ -194,7 +204,9 @@
         "https://data.vlaanderen.be/ns/mobiliteit#periode",
         "http://data.vlaanderen.be/ns/subsidie#Subsidieprocedurestap.type"
       ],
-      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
       "type": "http://data.vlaanderen.be/ns/subsidie#Subsidieprocedurestap"
     },
     {
@@ -205,7 +217,9 @@
         "http://data.europa.eu/m8g/endTime",
         "http://data.europa.eu/m8g/startTime"
       ],
-      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
       "type": "http://data.europa.eu/m8g/PeriodOfTime"
     },
     {
@@ -217,7 +231,9 @@
         "http://purl.org/dc/terms/isPartOf",
         "http://data.europa.eu/m8g/criterionType"
       ],
-      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
       "type": "http://data.europa.eu/m8g/Criterion"
     },
     {
@@ -227,7 +243,9 @@
         "http://purl.org/dc/terms/description",
         "http://data.europa.eu/m8g/hasCriterionRequirement"
       ],
-      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
       "type": "http://data.europa.eu/m8g/RequirementGroup"
     },
     {
@@ -238,7 +256,9 @@
         "http://purl.org/dc/terms/description",
         "http://lblod.data.gift/vocabularies/subsidie/isSatisfiableBy"
       ],
-      "graphsFilter": ["http://mu.semte.ch/graphs/public"],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
       "type": "http://data.europa.eu/m8g/CriterionRequirement"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -538,7 +538,7 @@ services:
       - ./data/files:/share
     environment:
       ALLOW_SUPER_CONSUMER: "true"
-      ALLOWED_ACCOUNTS: "http://services.lblod.info/diff-consumer/account,http://data.lblod.info/foaf/account/id/dd85f516-ee7c-406b-8245-91ce7f9545b7"
+      ALLOWED_ACCOUNTS: "http://services.lblod.info/diff-consumer/account,http://data.lblod.info/foaf/account/id/dd85f516-ee7c-406b-8245-91ce7f9545b7,http://data.lblod.info/foaf/account/id/4171b7a5-a4d6-42d0-bf37-f97b135fb885"
     restart: always
     logging: *default-logging
   ################################################################################


### PR DESCRIPTION
 ## Description

Simple PR which extends the allowed accounts and delta-producer of subsidies so the subsidy attachments can get shared over delta-sync. 

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## Related services

 - delta-files-share

 ## How to test


 ## Links to other PR's

TBD