### PR TITLE
Add a `download-url` attribute to the `file` resource

### DIFF
--- a/config/resources/master-files-domain.lisp
+++ b/config/resources/master-files-domain.lisp
@@ -11,6 +11,7 @@
                 (:format :string ,(s-prefix "dct:format"))
                 (:size :number ,(s-prefix "nfo:fileSize"))
                 (:extension :string ,(s-prefix "dbpedia:fileExtension"))
+                (:download-url :url ,(s-prefix "nie:url"))
                 (:created :datetime ,(s-prefix "dct:created")))
   :has-one `((file :via ,(s-prefix "nie:dataSource")
                    :inverse t


### PR DESCRIPTION
This allows us to set the url from the frontend for testing purposes.

This is a requirement for the frontend PR: for https://github.com/lblod/frontend-loket/pull/339