### PR TITLE
Add status to worship mandates producer

### DIFF
--- a/config/delta-producer/worship-services-sensitive/export.json
+++ b/config/delta-producer/worship-services-sensitive/export.json
@@ -23,7 +23,8 @@
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://schema.org/contactPoint",
         "http://www.w3.org/ns/org#heldBy",
-        "http://www.w3.org/ns/org#holds"
+        "http://www.w3.org/ns/org#holds",
+        "http://data.vlaanderen.be/ns/mandaat#status"
       ]
     },
     {
@@ -47,7 +48,8 @@
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://schema.org/contactPoint",
         "http://www.w3.org/ns/org#heldBy",
-        "http://www.w3.org/ns/org#holds"
+        "http://www.w3.org/ns/org#holds",
+        "http://data.vlaanderen.be/ns/mandaat#status"
       ]
     },
     {
@@ -92,7 +94,8 @@
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://schema.org/contactPoint",
         "http://www.w3.org/ns/org#heldBy",
-        "http://www.w3.org/ns/org#holds"
+        "http://www.w3.org/ns/org#holds",
+        "http://data.vlaanderen.be/ns/mandaat#status"
       ]
     },
     {


### PR DESCRIPTION
## ID
OP-2327

 ## Description

The status of mandates was properly defined in the producer of non-worship mandates, but not for worship mandates, causing OP not to receive those statuses. This PR adds the missing predicate to the worship sensitive producer.

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Other - data flow fix/enhancement

 ## Related services

 - delta-producer-background-jobs-initiator-worship-services-sensitive

 ## How to test

With the Loket stack up and running, you can test via the following path:
```
drc restart delta-producer-background-jobs-initiator-worship-services-sensitive
dr inspect app-digitaal-loket-delta-producer-background-jobs-initiator-worship-services-sensitive-1
curl -X POST <ip of delta-producer-background-jobs-initiator-worship-services-sensitive>/healing-jobs
```
Then wait until the healing job completes and check, either in the healing logs or in the generated delta files in `data/files/deltas/worship-services-sensitive`, that the statuses have been added to the export