### PR TITLE
Rewrite reports worship with RDF libraries

### DIFF
--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -146,7 +146,8 @@
         "http://www.w3.org/2004/02/skos/core#related"
       ],
       "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
+        "http://mu.semte.ch/graphs/public",
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
       ],
       "type": "http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelAanbod"
     },

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -281,6 +281,45 @@
         "http://purl.org/linked-data/cube#order"
       ],
       "type": "http://www.w3.org/2004/02/skos/core#Concept"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName",
+        "http://purl.org/dc/terms/format",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize",
+        "http://dbpedia.org/ontology/fileExtension",
+        "http://purl.org/dc/terms/created",
+        "http://purl.org/dc/terms/modified",
+        "http://purl.org/dc/terms/type",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName",
+        "http://purl.org/dc/terms/format",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize",
+        "http://dbpedia.org/ontology/fileExtension",
+        "http://purl.org/dc/terms/created",
+        "http://purl.org/dc/terms/modified",
+        "http://purl.org/dc/terms/type",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
+        "http://www.w3.org/ns/adms#status"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject"
     }
   ]
 }

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -482,7 +482,7 @@ defmodule Dispatcher do
   # loket-subsidies sync
   #################################################################
   post "/sync/subsidies/login/*path" do
-    forward conn, path, "http://delta-producer-publication-graph-maintainer-subsidies/submissions/login/"
+    forward conn, path, "http://delta-producer-publication-graph-maintainer-subsidies/login/"
   end
 
   #################################################################
@@ -754,7 +754,7 @@ defmodule Dispatcher do
   match "/public-services/*path" do
     forward conn, path, "http://cache/public-services/"
   end
-  
+
   match "/concept-display-configurations/*path" do
     forward conn, path, "http://cache/concept-display-configurations/"
   end

--- a/config/reports/worship/bedienaren.js
+++ b/config/reports/worship/bedienaren.js
@@ -1,6 +1,11 @@
 import * as mas from '@lblod/mu-auth-sudo';
 import * as queries from './queries';
 import * as hel from '../../helpers';
+import * as n3 from 'n3';
+import * as uti from './utils';
+import { NAMESPACES as ns } from './namespaces';
+import { SparqlJsonParser } from 'sparqljson-parse';
+const sparqlJsonParser = new SparqlJsonParser();
 
 const BATCH_SIZE = 100;
 
@@ -9,9 +14,10 @@ async function generate() {
     queries.allBedienaren(),
     BATCH_SIZE
   );
-  const bedienaren = bedienarenResponse.results.bindings.sort(
-    (a, b) => a.bedienaar.value < b.bedienaar.value
-  );
+  const bedienaren = sparqlJsonParser
+    .parseJsonResults(bedienarenResponse)
+    .map((b) => b.bedienaar)
+    .sort((a, b) => a.value < b.value);
 
   let allData = [];
 
@@ -24,179 +30,121 @@ async function generate() {
       bedienaarCounter,
       bedienaarCounter + BATCH_SIZE
     );
-    const bedienarenURIsSlice = bedienarenSlice.map((b) => b.bedienaar.value);
 
     //Personen
     const persoonQuery = queries.domainToRange(
-      bedienarenURIsSlice,
-      'http://www.w3.org/ns/org#heldBy',
-      'http://www.w3.org/ns/person#Person'
+      bedienarenSlice,
+      ns.org`heldBy`,
+      ns.person`Person`
     );
     const personenResponse = await mas.querySudo(persoonQuery);
-    const personen = [
-      ...new Set(personenResponse.results.bindings.map((p) => p.range.value)),
-    ];
-    const personenLinks = personenResponse.results.bindings.map((r) => {
-      return {
-        bedienaar: r.domain.value,
-        persoon: r.range.value,
-      };
-    });
+    const personen = sparqlJsonParser
+      .parseJsonResults(personenResponse)
+      .map((i) => i.range);
 
     //Identifiers
     const identifierQuery = queries.domainToRange(
       personen,
-      'http://www.w3.org/ns/adms#identifier',
-      'http://www.w3.org/ns/adms#Identifier'
+      ns.adms`identifier`,
+      ns.adms`Identifier`
     );
     const identifierResponse = await mas.querySudo(identifierQuery);
-    const identifiers = [
-      ...new Set(identifierResponse.results.bindings.map((i) => i.range.value)),
-    ];
-    const identifierLinks = identifierResponse.results.bindings.map((r) => {
-      return {
-        persoon: r.domain.value,
-        identifier: r.range.value,
-      };
-    });
+    const identifiers = sparqlJsonParser
+      .parseJsonResults(identifierResponse)
+      .map((i) => i.range);
 
     //Geboortes
     const geboorteQuery = queries.domainToRange(
       personen,
-      'http://data.vlaanderen.be/ns/persoon#heeftGeboorte',
-      'http://data.vlaanderen.be/ns/persoon#Geboorte'
+      ns.persoon`heeftGeboorte`,
+      ns.persoon`Geboorte`
     );
     const geboortesResponse = await mas.querySudo(geboorteQuery);
-    const geboortes = [
-      ...new Set(geboortesResponse.results.bindings.map((g) => g.range.value)),
-    ];
-    const geboorteLinks = geboortesResponse.results.bindings.map((r) => {
-      return {
-        persoon: r.domain.value,
-        geboorte: r.range.value,
-      };
-    });
+    const geboortes = sparqlJsonParser
+      .parseJsonResults(geboortesResponse)
+      .map((i) => i.range);
 
     //Contacts
     const contactQuery = queries.domainToRange(
-      bedienarenURIsSlice,
-      'http://schema.org/contactPoint',
-      'http://schema.org/ContactPoint'
+      bedienarenSlice,
+      ns.sch`contactPoint`,
+      ns.sch`ContactPoint`
     );
     const contactsResponse = await mas.querySudo(contactQuery);
-    const contacts = [
-      ...new Set(contactsResponse.results.bindings.map((c) => c.range.value)),
-    ];
-    const contactLinks = contactsResponse.results.bindings.map((r) => {
-      return {
-        bedienaar: r.domain.value,
-        contact: r.range.value,
-      };
-    });
+    const contacts = sparqlJsonParser
+      .parseJsonResults(contactsResponse)
+      .map((i) => i.range);
 
     //Adresses
     const adresQuery = queries.domainToRange(
       contacts,
-      'http://www.w3.org/ns/locn#address',
-      'http://www.w3.org/ns/locn#Address'
+      ns.locn`address`,
+      ns.locn`Address`
     );
     const addressResponse = await mas.querySudo(adresQuery);
-    const addresses = [
-      ...new Set(addressResponse.results.bindings.map((a) => a.range.value)),
-    ];
-    const addressLinks = addressResponse.results.bindings.map((r) => {
-      return {
-        contact: r.domain.value,
-        address: r.range.value,
-      };
-    });
+    const addresses = sparqlJsonParser
+      .parseJsonResults(addressResponse)
+      .map((i) => i.range);
 
     //Positions
     const positionQuery = queries.domainToRange(
-      bedienarenURIsSlice,
-      'http://www.w3.org/ns/org#holds',
-      'http://data.lblod.info/vocabularies/erediensten/PositieBedienaar'
+      bedienarenSlice,
+      ns.org`holds`,
+      ns.ere`PositieBedienaar`
     );
     const positionsResponse = await mas.querySudo(positionQuery);
-    const positions = [
-      ...new Set(positionsResponse.results.bindings.map((p) => p.range.value)),
-    ];
-    const positionLinks = positionsResponse.results.bindings.map((p) => {
-      return {
-        bedienaar: p.domain.value,
-        position: p.range.value,
-      };
-    });
+    const positions = sparqlJsonParser
+      .parseJsonResults(positionsResponse)
+      .map((i) => i.range);
 
     //Functions
     const functionQuery = queries.domainToRange(
       positions,
-      'http://data.lblod.info/vocabularies/erediensten/functie',
-      'http://lblod.data.gift/vocabularies/organisatie/EredienstBeroepen'
+      ns.ere`functie`,
+      ns.organ`EredienstBeroepen`
     );
     const functionResponse = await mas.querySudo(functionQuery);
-    const functions = [
-      ...new Set(functionResponse.results.bindings.map((p) => p.range.value)),
-    ];
-    const functionLinks = functionResponse.results.bindings.map((p) => {
-      return {
-        position: p.domain.value,
-        functie: p.range.value,
-      };
-    });
+    const functions = sparqlJsonParser
+      .parseJsonResults(functionResponse)
+      .map((i) => i.range);
 
     //Besturen
     const besturenQuery = queries.rangeToDomain(
       positions,
-      'http://data.lblod.info/vocabularies/erediensten/wordtBediendDoor',
-      'http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst'
+      ns.ere`wordtBediendDoor`,
+      ns.ere`BestuurVanDeEredienst`
     );
     const besturenResponse = await mas.querySudo(besturenQuery);
-    const besturen = [
-      ...new Set(besturenResponse.results.bindings.map((p) => p.range.value)),
-    ];
-    const besturenLinks = besturenResponse.results.bindings.map((p) => {
-      return {
-        positie: p.domain.value,
-        bestuur: p.range.value,
-      };
-    });
+    const besturen = sparqlJsonParser
+      .parseJsonResults(besturenResponse)
+      .map((i) => i.range);
 
-    let allURIs = new Set();
-    [
-      ...bedienarenURIsSlice,
-      ...personen,
-      ...identifiers,
-      ...geboortes,
-      ...contacts,
-      ...addresses,
-      ...positions,
-      ...functions,
-      ...besturen,
-    ].forEach((e) => allURIs.add(e));
-    allURIs = [...allURIs];
+    const allSubjects = uti.dedup(
+      [
+        ...bedienarenSlice,
+        ...personen,
+        ...identifiers,
+        ...geboortes,
+        ...contacts,
+        ...addresses,
+        ...positions,
+        ...functions,
+        ...besturen,
+      ],
+      'value'
+    );
 
-    const tripleData = [];
+    const tripleData = new n3.Store();
 
-    for (let counter = 0; counter < allURIs.length; counter += BATCH_SIZE) {
-      const URIslice = allURIs.slice(counter, counter + BATCH_SIZE);
-      const dataQuery = queries.dataForSubjects(URIslice);
+    for (let counter = 0; counter < allSubjects.length; counter += BATCH_SIZE) {
+      const subjectSlice = allSubjects.slice(counter, counter + BATCH_SIZE);
+      const dataQuery = queries.dataForSubjects(subjectSlice);
       const dataResponse = await mas.querySudo(dataQuery);
-      dataResponse.results.bindings.forEach((e) => tripleData.push(e));
+      const dataParsed = sparqlJsonParser.parseJsonResults(dataResponse);
+      dataParsed.forEach((e) => tripleData.addQuad(e.s, e.p, e.o, e.g));
     }
 
-    const combinedData = combineBedienarenData(
-      tripleData,
-      bedienarenURIsSlice,
-      personenLinks,
-      identifierLinks,
-      geboorteLinks,
-      contactLinks,
-      addressLinks,
-      positionLinks,
-      functionLinks,
-      besturenLinks
-    );
+    const combinedData = combineBedienarenData(tripleData);
     allData = allData.concat(combinedData);
   }
 
@@ -236,191 +184,138 @@ async function generate() {
   );
 }
 
-function combineBedienarenData(
-  tripleData,
-  bedienaren,
-  personenLinks,
-  identifierLinks,
-  geboorteLinks,
-  contactLinks,
-  addressLinks,
-  positionLinks,
-  functionLinks,
-  besturenLinks
-) {
+function combineBedienarenData(store) {
   const data = [];
+  const bedienaren = store.getSubjects(ns.rdf`type`, ns.ere`RolBedienaar`);
 
   for (const bedienaar of bedienaren) {
-    const afkomstGegevens = tripleData.find(
-      (d) =>
-        d.s.value === bedienaar &&
-        d.p.value === 'http://www.w3.org/ns/prov#wasGeneratedBy'
-    )?.o?.value;
-    const startDatum = tripleData.find(
-      (d) =>
-        d.s.value === bedienaar &&
-        d.p.value ===
-          'http://data.lblod.info/vocabularies/contacthub/startdatum'
-    )?.o?.value;
-    const eindeDatum = tripleData.find(
-      (d) =>
-        d.s.value === bedienaar &&
-        d.p.value ===
-          'http://data.lblod.info/vocabularies/contacthub/eindedatum'
-    )?.o?.value;
+    const afkomstGegevens = store
+      .readQuads(bedienaar, ns.prov`wasGeneratedBy`)
+      .next().value?.object?.value;
+    const startDatum = store.readQuads(bedienaar, ns.contact`startdatum`).next()
+      .value?.object?.value;
+    const eindeDatum = store.readQuads(bedienaar, ns.contact`eindedatum`).next()
+      .value?.object?.value;
 
-    const collect = { bedienaar, afkomstGegevens, startDatum, eindeDatum };
+    const collect = {
+      bedienaar: bedienaar.value,
+      afkomstGegevens,
+      startDatum,
+      eindeDatum,
+    };
 
-    const positionLink = positionLinks.find((p) => p.bedienaar === bedienaar);
+    const position = store
+      .getObjects(bedienaar, ns.org`holds`)
+      .filter((p) => store.has(p, ns.rdf`type`, ns.ere`PositieBedienaar`))[0];
 
-    if (positionLink) {
-      const functionLink = functionLinks.find(
-        (f) => f.position === positionLink.position
-      );
-      if (functionLink) {
-        const functienaam = tripleData.find(
-          (d) =>
-            d.s.value === functionLink.functie &&
-            d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
-        )?.o?.value;
-        collect.functienaam = functienaam;
-      }
+    if (position) {
+      const functienaam = store
+        .getObjects(position, ns.ere`functie`)
+        .filter((p) => store.has(p, ns.rdf`type`, ns.organ`EredienstBeroepen`))
+        .map(
+          (f) =>
+            store.readQuads(f, ns.skos`prefLabel`).next().value?.object?.value
+        )[0];
+      collect.functienaam = functienaam;
 
-      const bestuurLink = besturenLinks.find(
-        (b) => positionLink.position === b.positie
-      );
-      if (bestuurLink) {
-        const bestuurnaam = tripleData.find(
-          (d) =>
-            d.s.value === bestuurLink.bestuur &&
-            d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
-        )?.o?.value;
-        collect.bestuurnaam = bestuurnaam;
-      }
+      const bestuurnaam = store
+        .getSubjects(ns.ere`wordtBediendDoor`, position)
+        .filter((p) =>
+          store.has(p, ns.rdf`type`, ns.ere`BestuurVanDeEredienst`)
+        )
+        .map(
+          (b) =>
+            store.readQuads(b, ns.skos`prefLabel`).next().value?.object?.value
+        )[0];
+      collect.bestuurnaam = bestuurnaam;
     }
 
-    const personen = personenLinks.filter((p) => p.bedienaar === bedienaar);
+    const persoon = store
+      .getObjects(bedienaar, ns.org`heldBy`)
+      .filter((p) => store.has(p, ns.rdf`type`, ns.person`Person`))[0];
 
-    for (const persoonLink of personen) {
-      const familienaam = tripleData.find(
-        (d) =>
-          d.s.value === persoonLink.persoon &&
-          d.p.value === 'http://xmlns.com/foaf/0.1/familyName'
-      )?.o?.value;
-      const voornaam = tripleData.find(
-        (d) =>
-          d.s.value === persoonLink.persoon &&
-          d.p.value === 'http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam'
-      )?.o?.value;
-      const nationaliteit = tripleData.find(
-        (d) =>
-          d.s.value === persoonLink.persoon &&
-          d.p.value ===
-            'http://data.vlaanderen.be/ns/persoon#heeftNationaliteit'
-      )?.o?.value;
-      const geslacht = tripleData.find(
-        (d) =>
-          d.s.value === persoonLink.persoon &&
-          d.p.value === 'http://data.vlaanderen.be/ns/persoon#geslacht'
-      )?.o?.value;
-      collect.persoon = persoonLink.persoon;
+    if (persoon) {
+      const familienaam = store.readQuads(persoon, ns.foaf`familyName`).next()
+        .value?.object?.value;
+      const voornaam = store
+        .readQuads(persoon, ns.persoon`gebruikteVoornaam`)
+        .next().value?.object?.value;
+      const nationaliteit = store
+        .readQuads(persoon, ns.persoon`heeftNationaliteit`)
+        .next().value?.object?.value;
+      const geslacht = store.readQuads(persoon, ns.persoon`geslacht`).next()
+        .value?.object?.value;
+      collect.persoon = persoon.value;
       collect.familienaam = familienaam;
       collect.voornaam = voornaam;
       collect.nationaliteit = nationaliteit;
       collect.geslacht = geslacht;
 
-      const geboorteLink =
-        geboorteLinks.find((g) => g.persoon === persoonLink.persoon) || [];
-      if (geboorteLink) {
-        const geboorteDatum = tripleData.find(
-          (d) =>
-            d.s.value === geboorteLink.geboorte &&
-            d.p.value === 'http://data.vlaanderen.be/ns/persoon#datum'
-        )?.o?.value;
-        collect.geboorteDatum = geboorteDatum;
-      }
+      const geboorteDatum = store
+        .getObjects(persoon, ns.persoon`heeftGeboorte`)
+        .filter((p) => store.has(p, ns.rdf`type`, ns.persoon`Geboorte`))
+        .map(
+          (f) =>
+            store.readQuads(f, ns.persoon`datum`).next().value?.object?.value
+        )[0];
+      collect.geboorteDatum = geboorteDatum;
 
-      const identifierLink =
-        identifierLinks.find((g) => g.persoon === persoonLink.persoon) || [];
-      if (identifierLink) {
-        const identifier = tripleData.find(
-          (d) =>
-            d.s.value === identifierLink.identifier &&
-            d.p.value === 'http://www.w3.org/2004/02/skos/core#notation'
-        )?.o?.value;
-        collect.rrnummer = identifier;
-      }
-
-      const contactLink = contactLinks.find((c) => c.bedienaar === bedienaar);
-      if (contactLink) {
-        const contactSoort = tripleData.find(
-          (d) =>
-            d.s.value === contactLink.contact &&
-            d.p.value === 'http://schema.org/contactType'
-        )?.o?.value;
-        const email = tripleData.find(
-          (d) =>
-            d.s.value === contactLink.contact &&
-            d.p.value === 'http://schema.org/email'
-        )?.o?.value;
-        const telefoon = tripleData.find(
-          (d) =>
-            d.s.value === contactLink.contact &&
-            d.p.value === 'http://schema.org/telephone'
-        )?.o?.value;
-        collect.contact = contactLink.contact;
-        collect.contactSoort = contactSoort;
-        collect.email = email;
-        collect.telefoon = telefoon;
-
-        const adresLink = addressLinks.find(
-          (c) => c.contact === contactLink.contact
-        );
-        if (adresLink) {
-          const straat = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value === 'http://www.w3.org/ns/locn#thoroughfare'
-          )?.o?.value;
-          const huisnummer = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value ===
-                'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer'
-          )?.o?.value;
-          const busnummer = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value ===
-                'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer'
-          )?.o?.value;
-          const postcode = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value === 'http://www.w3.org/ns/locn#postCode'
-          )?.o?.value;
-          const stad = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value === 'https://data.vlaanderen.be/ns/adres#gemeentenaam'
-          )?.o?.value;
-          const land = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value === 'https://data.vlaanderen.be/ns/adres#land'
-          )?.o?.value;
-          collect.adres = adresLink.address;
-          collect.straat = straat;
-          collect.huisnummer = huisnummer;
-          collect.busnummer = busnummer;
-          collect.postcode = postcode;
-          collect.stad = stad;
-          collect.land = land;
-        }
-      }
-
-      data.push(collect);
+      const identifier = store
+        .getObjects(persoon, ns.adms`identifier`)
+        .filter((p) => store.has(p, ns.rdf`type`, ns.adms`Identifier`))
+        .map(
+          (f) =>
+            store.readQuads(f, ns.skos`notation`).next().value?.object?.value
+        )[0];
+      collect.rrnummer = identifier;
     }
+
+    const contact = store
+      .getObjects(bedienaar, ns.sch`contactPoint`)
+      .filter((p) => store.has(p, ns.rdf`type`, ns.sch`ContactPoint`))[0];
+
+    if (contact) {
+      const contactSoort = store.readQuads(contact, ns.sch`contactType`).next()
+        .value?.object?.value;
+      const email = store.readQuads(contact, ns.sch`email`).next().value
+        ?.object?.value;
+      const telefoon = store.readQuads(contact, ns.sch`telephone`).next().value
+        ?.object?.value;
+      collect.contact = contact.value;
+      collect.contactSoort = contactSoort;
+      collect.email = email;
+      collect.telefoon = telefoon;
+
+      const adres = store
+        .getObjects(contact, ns.locn`address`)
+        .filter((a) => store.has(a, ns.rdf`type`, ns.locn`Address`))[0];
+
+      if (adres) {
+        const straat = store.readQuads(adres, ns.locn`thoroughfare`).next()
+          .value?.object?.value;
+        const huisnummer = store
+          .readQuads(adres, ns.adres`Adresvoorstelling.huisnummer`)
+          .next().value?.object?.value;
+        const busnummer = store
+          .readQuads(adres, ns.adres`Adresvoorstelling.busnummer`)
+          .next().value?.object?.value;
+        const postcode = store.readQuads(adres, ns.locn`postCode`).next().value
+          ?.object?.value;
+        const stad = store.readQuads(adres, ns.adres`gemeentenaam`).next().value
+          ?.object?.value;
+        const land = store.readQuads(adres, ns.adres`land`).next().value
+          ?.object?.value;
+        collect.adres = adres.value;
+        collect.straat = straat;
+        collect.huisnummer = huisnummer;
+        collect.busnummer = busnummer;
+        collect.postcode = postcode;
+        collect.stad = stad;
+        collect.land = land;
+      }
+    }
+
+    data.push(collect);
   }
   return data;
 }

--- a/config/reports/worship/bedienaren.js
+++ b/config/reports/worship/bedienaren.js
@@ -7,7 +7,11 @@ import { NAMESPACES as ns } from './namespaces';
 import { SparqlJsonParser } from 'sparqljson-parse';
 const sparqlJsonParser = new SparqlJsonParser();
 
-const BATCH_SIZE = 100;
+const BATCH_SIZE = 20;
+const connectionOptions = {
+  sparqlEndpoint: 'http://virtuoso:8890/sparql',
+  mayRetry: true,
+};
 
 async function generate() {
   const bedienarenResponse = await hel.batchedQuery(
@@ -37,7 +41,11 @@ async function generate() {
       ns.org`heldBy`,
       ns.person`Person`
     );
-    const personenResponse = await mas.querySudo(persoonQuery);
+    const personenResponse = await mas.querySudo(
+      persoonQuery,
+      undefined,
+      connectionOptions
+    );
     const personen = sparqlJsonParser
       .parseJsonResults(personenResponse)
       .map((i) => i.range);
@@ -48,7 +56,11 @@ async function generate() {
       ns.adms`identifier`,
       ns.adms`Identifier`
     );
-    const identifierResponse = await mas.querySudo(identifierQuery);
+    const identifierResponse = await mas.querySudo(
+      identifierQuery,
+      undefined,
+      connectionOptions
+    );
     const identifiers = sparqlJsonParser
       .parseJsonResults(identifierResponse)
       .map((i) => i.range);
@@ -59,7 +71,11 @@ async function generate() {
       ns.persoon`heeftGeboorte`,
       ns.persoon`Geboorte`
     );
-    const geboortesResponse = await mas.querySudo(geboorteQuery);
+    const geboortesResponse = await mas.querySudo(
+      geboorteQuery,
+      undefined,
+      connectionOptions
+    );
     const geboortes = sparqlJsonParser
       .parseJsonResults(geboortesResponse)
       .map((i) => i.range);
@@ -70,7 +86,11 @@ async function generate() {
       ns.sch`contactPoint`,
       ns.sch`ContactPoint`
     );
-    const contactsResponse = await mas.querySudo(contactQuery);
+    const contactsResponse = await mas.querySudo(
+      contactQuery,
+      undefined,
+      connectionOptions
+    );
     const contacts = sparqlJsonParser
       .parseJsonResults(contactsResponse)
       .map((i) => i.range);
@@ -81,7 +101,11 @@ async function generate() {
       ns.locn`address`,
       ns.locn`Address`
     );
-    const addressResponse = await mas.querySudo(adresQuery);
+    const addressResponse = await mas.querySudo(
+      adresQuery,
+      undefined,
+      connectionOptions
+    );
     const addresses = sparqlJsonParser
       .parseJsonResults(addressResponse)
       .map((i) => i.range);
@@ -92,7 +116,11 @@ async function generate() {
       ns.org`holds`,
       ns.ere`PositieBedienaar`
     );
-    const positionsResponse = await mas.querySudo(positionQuery);
+    const positionsResponse = await mas.querySudo(
+      positionQuery,
+      undefined,
+      connectionOptions
+    );
     const positions = sparqlJsonParser
       .parseJsonResults(positionsResponse)
       .map((i) => i.range);
@@ -103,7 +131,11 @@ async function generate() {
       ns.ere`functie`,
       ns.organ`EredienstBeroepen`
     );
-    const functionResponse = await mas.querySudo(functionQuery);
+    const functionResponse = await mas.querySudo(
+      functionQuery,
+      undefined,
+      connectionOptions
+    );
     const functions = sparqlJsonParser
       .parseJsonResults(functionResponse)
       .map((i) => i.range);
@@ -114,7 +146,11 @@ async function generate() {
       ns.ere`wordtBediendDoor`,
       ns.ere`BestuurVanDeEredienst`
     );
-    const besturenResponse = await mas.querySudo(besturenQuery);
+    const besturenResponse = await mas.querySudo(
+      besturenQuery,
+      undefined,
+      connectionOptions
+    );
     const besturen = sparqlJsonParser
       .parseJsonResults(besturenResponse)
       .map((i) => i.range);
@@ -139,7 +175,11 @@ async function generate() {
     for (let counter = 0; counter < allSubjects.length; counter += BATCH_SIZE) {
       const subjectSlice = allSubjects.slice(counter, counter + BATCH_SIZE);
       const dataQuery = queries.dataForSubjects(subjectSlice);
-      const dataResponse = await mas.querySudo(dataQuery);
+      const dataResponse = await mas.querySudo(
+        dataQuery,
+        undefined,
+        connectionOptions
+      );
       const dataParsed = sparqlJsonParser.parseJsonResults(dataResponse);
       dataParsed.forEach((e) => tripleData.addQuad(e.s, e.p, e.o, e.g));
     }
@@ -203,32 +243,6 @@ function combineBedienarenData(store) {
       startDatum,
       eindeDatum,
     };
-
-    const position = store
-      .getObjects(bedienaar, ns.org`holds`)
-      .filter((p) => store.has(p, ns.rdf`type`, ns.ere`PositieBedienaar`))[0];
-
-    if (position) {
-      const functienaam = store
-        .getObjects(position, ns.ere`functie`)
-        .filter((p) => store.has(p, ns.rdf`type`, ns.organ`EredienstBeroepen`))
-        .map(
-          (f) =>
-            store.readQuads(f, ns.skos`prefLabel`).next().value?.object?.value
-        )[0];
-      collect.functienaam = functienaam;
-
-      const bestuurnaam = store
-        .getSubjects(ns.ere`wordtBediendDoor`, position)
-        .filter((p) =>
-          store.has(p, ns.rdf`type`, ns.ere`BestuurVanDeEredienst`)
-        )
-        .map(
-          (b) =>
-            store.readQuads(b, ns.skos`prefLabel`).next().value?.object?.value
-        )[0];
-      collect.bestuurnaam = bestuurnaam;
-    }
 
     const persoon = store
       .getObjects(bedienaar, ns.org`heldBy`)
@@ -315,6 +329,31 @@ function combineBedienarenData(store) {
       }
     }
 
+    const position = store
+      .getObjects(bedienaar, ns.org`holds`)
+      .filter((p) => store.has(p, ns.rdf`type`, ns.ere`PositieBedienaar`))[0];
+
+    if (position) {
+      const functienaam = store
+        .getObjects(position, ns.ere`functie`)
+        .filter((p) => store.has(p, ns.rdf`type`, ns.organ`EredienstBeroepen`))
+        .map(
+          (f) =>
+            store.readQuads(f, ns.skos`prefLabel`).next().value?.object?.value
+        )[0];
+      collect.functienaam = functienaam;
+
+      const bestuurnaam = store
+        .getSubjects(ns.ere`wordtBediendDoor`, position)
+        .filter((p) =>
+          store.has(p, ns.rdf`type`, ns.ere`BestuurVanDeEredienst`)
+        )
+        .map(
+          (b) =>
+            store.readQuads(b, ns.skos`prefLabel`).next().value?.object?.value
+        )[0];
+      collect.bestuurnaam = bestuurnaam;
+    }
     data.push(collect);
   }
   return data;

--- a/config/reports/worship/mandatarissen.js
+++ b/config/reports/worship/mandatarissen.js
@@ -1,6 +1,11 @@
 import * as mas from '@lblod/mu-auth-sudo';
 import * as queries from './queries';
 import * as hel from '../../helpers';
+import * as n3 from 'n3';
+import * as uti from './utils';
+import { NAMESPACES as ns } from './namespaces';
+import { SparqlJsonParser } from 'sparqljson-parse';
+const sparqlJsonParser = new SparqlJsonParser();
 
 const BATCH_SIZE = 100;
 
@@ -9,9 +14,10 @@ async function generate() {
     queries.allMandatarissen(),
     BATCH_SIZE
   );
-  const mandatarissen = mandatarissenResponse.results.bindings.sort(
-    (a, b) => a.mandataris.value < b.mandataris.value
-  );
+  const mandatarissen = sparqlJsonParser
+    .parseJsonResults(mandatarissenResponse)
+    .map((m) => m.mandataris)
+    .sort((a, b) => a.value < b.value);
 
   let allData = [];
 
@@ -24,203 +30,132 @@ async function generate() {
       mandatarisCounter,
       mandatarisCounter + BATCH_SIZE
     );
-    const mandatarissenURIsSlice = mandatarissenSlice.map(
-      (b) => b.mandataris.value
-    );
 
     //Personen
     const persoonQuery = queries.domainToRange(
-      mandatarissenURIsSlice,
-      'http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan',
-      'http://www.w3.org/ns/person#Person'
+      mandatarissenSlice,
+      ns.mandaat`isBestuurlijkeAliasVan`,
+      ns.person`Person`
     );
     const personenResponse = await mas.querySudo(persoonQuery);
-    const personen = [
-      ...new Set(personenResponse.results.bindings.map((p) => p.range.value)),
-    ];
-    const personenLinks = personenResponse.results.bindings.map((r) => {
-      return {
-        mandataris: r.domain.value,
-        persoon: r.range.value,
-      };
-    });
+    const personen = sparqlJsonParser
+      .parseJsonResults(personenResponse)
+      .map((i) => i.range);
 
     //Identifiers
     const identifierQuery = queries.domainToRange(
       personen,
-      'http://www.w3.org/ns/adms#identifier',
-      'http://www.w3.org/ns/adms#Identifier'
+      ns.adms`identifier`,
+      ns.adms`Identifier`
     );
     const identifierResponse = await mas.querySudo(identifierQuery);
-    const identifiers = [
-      ...new Set(identifierResponse.results.bindings.map((i) => i.range.value)),
-    ];
-    const identifierLinks = identifierResponse.results.bindings.map((r) => {
-      return {
-        persoon: r.domain.value,
-        identifier: r.range.value,
-      };
-    });
+    const identifiers = sparqlJsonParser
+      .parseJsonResults(identifierResponse)
+      .map((i) => i.range);
 
     //Geboortes
     const geboorteQuery = queries.domainToRange(
       personen,
-      'http://data.vlaanderen.be/ns/persoon#heeftGeboorte',
-      'http://data.vlaanderen.be/ns/persoon#Geboorte'
+      ns.persoon`heeftGeboorte`,
+      ns.persoon`Geboorte`
     );
     const geboortesResponse = await mas.querySudo(geboorteQuery);
-    const geboortes = [
-      ...new Set(geboortesResponse.results.bindings.map((g) => g.range.value)),
-    ];
-    const geboorteLinks = geboortesResponse.results.bindings.map((r) => {
-      return {
-        persoon: r.domain.value,
-        geboorte: r.range.value,
-      };
-    });
+    const geboortes = sparqlJsonParser
+      .parseJsonResults(geboortesResponse)
+      .map((i) => i.range);
 
     //Contacts
     const contactQuery = queries.domainToRange(
-      mandatarissenURIsSlice,
-      'http://schema.org/contactPoint',
-      'http://schema.org/ContactPoint'
+      mandatarissenSlice,
+      ns.sch`contactPoint`,
+      ns.sch`ContactPoint`
     );
     const contactsResponse = await mas.querySudo(contactQuery);
-    const contacts = [
-      ...new Set(contactsResponse.results.bindings.map((c) => c.range.value)),
-    ];
-    const contactLinks = contactsResponse.results.bindings.map((r) => {
-      return {
-        mandataris: r.domain.value,
-        contact: r.range.value,
-      };
-    });
+    const contacts = sparqlJsonParser
+      .parseJsonResults(contactsResponse)
+      .map((i) => i.range);
 
     //Adresses
     const adresQuery = queries.domainToRange(
       contacts,
-      'http://www.w3.org/ns/locn#address',
-      'http://www.w3.org/ns/locn#Address'
+      ns.locn`address`,
+      ns.locn`Address`
     );
     const addressResponse = await mas.querySudo(adresQuery);
-    const addresses = [
-      ...new Set(addressResponse.results.bindings.map((a) => a.range.value)),
-    ];
-    const addressLinks = addressResponse.results.bindings.map((r) => {
-      return {
-        contact: r.domain.value,
-        address: r.range.value,
-      };
-    });
+    const addresses = sparqlJsonParser
+      .parseJsonResults(addressResponse)
+      .map((i) => i.range);
 
     //Positions
     const positionQuery = queries.domainToRange(
-      mandatarissenURIsSlice,
-      'http://www.w3.org/ns/org#holds',
-      'http://data.vlaanderen.be/ns/mandaat#Mandaat'
+      mandatarissenSlice,
+      ns.org`holds`,
+      ns.mandaat`Mandaat`
     );
     const positionsResponse = await mas.querySudo(positionQuery);
-    const positions = [
-      ...new Set(positionsResponse.results.bindings.map((p) => p.range.value)),
-    ];
-    const positionLinks = positionsResponse.results.bindings.map((p) => {
-      return {
-        mandataris: p.domain.value,
-        position: p.range.value,
-      };
-    });
+    const positions = sparqlJsonParser
+      .parseJsonResults(positionsResponse)
+      .map((i) => i.range);
 
     //Functions
     const functionQuery = queries.domainToRange(
       positions,
-      'http://www.w3.org/ns/org#role',
-      'http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode'
+      ns.org`role`,
+      ns.ext`BestuursfunctieCode`
     );
     const functionResponse = await mas.querySudo(functionQuery);
-    const functions = [
-      ...new Set(functionResponse.results.bindings.map((p) => p.range.value)),
-    ];
-    const functionLinks = functionResponse.results.bindings.map((p) => {
-      return {
-        position: p.domain.value,
-        functie: p.range.value,
-      };
-    });
+    const functions = sparqlJsonParser
+      .parseJsonResults(functionResponse)
+      .map((i) => i.range);
 
     //Besturen
     const besturenInTijdQuery = queries.rangeToDomain(
       positions,
-      'http://www.w3.org/ns/org#hasPost',
-      'http://data.vlaanderen.be/ns/besluit#Bestuursorgaan'
+      ns.org`hasPost`,
+      ns.besluit`Bestuursorgaan`
     );
     const besturenInTijdResponse = await mas.querySudo(besturenInTijdQuery);
-    const besturenInTijd = [
-      ...new Set(
-        besturenInTijdResponse.results.bindings.map((p) => p.range.value)
-      ),
-    ];
-    const besturenInTijdLinks = besturenInTijdResponse.results.bindings.map(
-      (p) => {
-        return {
-          positie: p.domain.value,
-          bestuurInTijd: p.range.value,
-        };
-      }
-    );
+    const besturenInTijd = sparqlJsonParser
+      .parseJsonResults(besturenInTijdResponse)
+      .map((i) => i.range);
 
     const besturenQuery = queries.domainToRange(
       besturenInTijd,
-      'http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan',
-      'http://data.vlaanderen.be/ns/besluit#Bestuursorgaan'
+      ns.mandaat`isTijdspecialisatieVan`,
+      ns.besluit`Bestuursorgaan`
     );
     const besturenResponse = await mas.querySudo(besturenQuery);
-    const besturen = [
-      ...new Set(besturenResponse.results.bindings.map((p) => p.range.value)),
-    ];
-    const besturenLinks = besturenResponse.results.bindings.map((p) => {
-      return {
-        positie: p.domain.value,
-        bestuur: p.range.value,
-      };
-    });
+    const besturen = sparqlJsonParser
+      .parseJsonResults(besturenResponse)
+      .map((i) => i.range);
 
-    let allURIs = new Set();
-    [
-      ...mandatarissenURIsSlice,
-      ...personen,
-      ...identifiers,
-      ...geboortes,
-      ...contacts,
-      ...addresses,
-      ...positions,
-      ...functions,
-      ...besturenInTijd,
-      ...besturen,
-    ].forEach((e) => allURIs.add(e));
-    allURIs = [...allURIs];
+    const allSubjects = uti.dedup(
+      [
+        ...mandatarissenSlice,
+        ...personen,
+        ...identifiers,
+        ...geboortes,
+        ...contacts,
+        ...addresses,
+        ...positions,
+        ...functions,
+        ...besturenInTijd,
+        ...besturen,
+      ],
+      'value'
+    );
 
-    const tripleData = [];
+    const tripleData = new n3.Store();
 
-    for (let counter = 0; counter < allURIs.length; counter += BATCH_SIZE) {
-      const URIslice = allURIs.slice(counter, counter + BATCH_SIZE);
-      const dataQuery = queries.dataForSubjects(URIslice);
+    for (let counter = 0; counter < allSubjects.length; counter += BATCH_SIZE) {
+      const subjectSlice = allSubjects.slice(counter, counter + BATCH_SIZE);
+      const dataQuery = queries.dataForSubjects(subjectSlice);
       const dataResponse = await mas.querySudo(dataQuery);
-      dataResponse.results.bindings.forEach((e) => tripleData.push(e));
+      const dataParsed = sparqlJsonParser.parseJsonResults(dataResponse);
+      dataParsed.forEach((e) => tripleData.addQuad(e.s, e.p, e.o, e.g));
     }
 
-    const combinedData = combineMandatarissenData(
-      tripleData,
-      mandatarissenURIsSlice,
-      personenLinks,
-      identifierLinks,
-      geboorteLinks,
-      contactLinks,
-      addressLinks,
-      positionLinks,
-      functionLinks,
-      besturenInTijdLinks,
-      besturenLinks
-    );
+    const combinedData = combineMandatarissenData(tripleData);
     allData = allData.concat(combinedData);
   }
 
@@ -260,191 +195,143 @@ async function generate() {
   );
 }
 
-function combineMandatarissenData(
-  tripleData,
-  mandatarissen,
-  personenLinks,
-  identifierLinks,
-  geboorteLinks,
-  contactLinks,
-  addressLinks,
-  positionLinks,
-  functionLinks,
-  besturenInTijdLinks,
-  besturenLinks
-) {
+function combineMandatarissenData(store) {
   const data = [];
+  const mandatarissen = store.getSubjects(
+    ns.rdf`type`,
+    ns.ere`EredienstMandataris`
+  );
 
   for (const mandataris of mandatarissen) {
-    const afkomstGegevens = tripleData.find(
-      (d) =>
-        d.s.value === mandataris &&
-        d.p.value === 'http://www.w3.org/ns/prov#wasGeneratedBy'
-    )?.o?.value;
-    const startDatum = tripleData.find(
-      (d) =>
-        d.s.value === mandataris &&
-        d.p.value === 'http://data.vlaanderen.be/ns/mandaat#start'
-    )?.o?.value;
-    const eindeDatum = tripleData.find(
-      (d) =>
-        d.s.value === mandataris &&
-        d.p.value === 'http://data.vlaanderen.be/ns/mandaat#einde'
-    )?.o?.value;
+    const afkomstGegevens = store
+      .readQuads(mandataris, ns.prov`wasGeneratedBy`)
+      .next().value?.object?.value;
+    const startDatum = store.readQuads(mandataris, ns.mandaat`start`).next()
+      .value?.object?.value;
+    const eindeDatum = store.readQuads(mandataris, ns.mandaat`einde`).next()
+      .value?.object?.value;
 
-    const collect = { mandataris, afkomstGegevens, startDatum, eindeDatum };
+    const collect = {
+      mandataris: mandataris.value,
+      afkomstGegevens,
+      startDatum,
+      eindeDatum,
+    };
 
-    const positionLink = positionLinks.find((p) => p.mandataris === mandataris);
+    const position = store
+      .getObjects(mandataris, ns.org`holds`)
+      .filter((p) => store.has(p, ns.rdf`type`, ns.mandaat`Mandaat`))[0];
 
-    if (positionLink) {
-      const functionLink = functionLinks.find(
-        (f) => f.position === positionLink.position
-      );
-      if (functionLink) {
-        const functienaam = tripleData.find(
-          (d) =>
-            d.s.value === functionLink.functie &&
-            d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
-        )?.o?.value;
-        collect.rolnaam = functienaam;
-      }
+    if (position) {
+      const functienaam = store
+        .getObjects(position, ns.org`role`)
+        .filter((p) => store.has(p, ns.rdf`type`, ns.ext`BestuursfunctieCode`))
+        .map(
+          (f) =>
+            store.readQuads(f, ns.skos`prefLabel`).next().value?.object?.value
+        )[0];
+      collect.rolnaam = functienaam;
 
-      const bestuurInTijdLink = besturenInTijdLinks.find(
-        (b) => positionLink.position === b.positie
-      );
-      if (bestuurInTijdLink) {
-        const bestuurLink = besturenLinks.find(
-          (b) => bestuurInTijdLink.bestuur === b.bestuurInTijd
-        );
-        if (bestuurLink) {
-          const bestuurnaam = tripleData.find(
-            (d) =>
-              d.s.value === bestuurLink.bestuur &&
-              d.p.value === 'http://www.w3.org/2004/02/skos/core#prefLabel'
-          )?.o?.value;
-          collect.bestuurnaam = bestuurnaam;
-        }
+      const bestuurInTijd = store
+        .getSubjects(ns.org`hasPost`, position)
+        .filter((p) =>
+          store.has(p, ns.rdf`type`, ns.besluit`Bestuursorgaan`)
+        )[0];
+
+      if (bestuurInTijd) {
+        const bestuurnaam = store
+          .getObjects(bestuurInTijd, ns.mandaat`isTijdspecialisatieVan`)
+          .filter((p) => store.has(p, ns.rdf`type`, ns.besluit`Bestuursorgaan`))
+          .map(
+            (b) =>
+              store.readQuads(b, ns.skos`prefLabel`).next().value?.object?.value
+          )[0];
+        collect.bestuurnaam = bestuurnaam;
       }
     }
 
-    const personen = personenLinks.filter((p) => p.mandataris === mandataris);
+    const persoon = store
+      .getObjects(mandataris, ns.mandaat`isBestuurlijkeAliasVan`)
+      .filter((p) => store.has(p, ns.rdf`type`, ns.person`Person`))[0];
 
-    for (const persoonLink of personen) {
-      const familienaam = tripleData.find(
-        (d) =>
-          d.s.value === persoonLink.persoon &&
-          d.p.value === 'http://xmlns.com/foaf/0.1/familyName'
-      )?.o?.value;
-      const voornaam = tripleData.find(
-        (d) =>
-          d.s.value === persoonLink.persoon &&
-          d.p.value === 'http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam'
-      )?.o?.value;
-      const nationaliteit = tripleData.find(
-        (d) =>
-          d.s.value === persoonLink.persoon &&
-          d.p.value ===
-            'http://data.vlaanderen.be/ns/persoon#heeftNationaliteit'
-      )?.o?.value;
-      const geslacht = tripleData.find(
-        (d) =>
-          d.s.value === persoonLink.persoon &&
-          d.p.value === 'http://data.vlaanderen.be/ns/persoon#geslacht'
-      )?.o?.value;
-      collect.persoon = persoonLink.persoon;
+    if (persoon) {
+      const familienaam = store.readQuads(persoon, ns.foaf`familyName`).next()
+        .value?.object?.value;
+      const voornaam = store
+        .readQuads(persoon, ns.persoon`gebruikteVoornaam`)
+        .next().value?.object?.value;
+      const nationaliteit = store
+        .readQuads(persoon, ns.persoon`heeftNationaliteit`)
+        .next().value?.object?.value;
+      const geslacht = store.readQuads(persoon, ns.persoon`geslacht`).next()
+        .value?.object?.value;
+      collect.persoon = persoon.value;
       collect.familienaam = familienaam;
       collect.voornaam = voornaam;
       collect.nationaliteit = nationaliteit;
       collect.geslacht = geslacht;
 
-      const geboorteLink =
-        geboorteLinks.find((g) => g.persoon === persoonLink.persoon) || [];
-      if (geboorteLink) {
-        const geboorteDatum = tripleData.find(
-          (d) =>
-            d.s.value === geboorteLink.geboorte &&
-            d.p.value === 'http://data.vlaanderen.be/ns/persoon#datum'
-        )?.o?.value;
-        collect.geboorteDatum = geboorteDatum;
-      }
+      const geboorteDatum = store
+        .getObjects(persoon, ns.persoon`heeftGeboorte`)
+        .filter((p) => store.has(p, ns.rdf`type`, ns.persoon`Geboorte`))
+        .map(
+          (f) =>
+            store.readQuads(f, ns.persoon`datum`).next().value?.object?.value
+        )[0];
+      collect.geboorteDatum = geboorteDatum;
 
-      const identifierLink =
-        identifierLinks.find((g) => g.persoon === persoonLink.persoon) || [];
-      if (identifierLink) {
-        const identifier = tripleData.find(
-          (d) =>
-            d.s.value === identifierLink.identifier &&
-            d.p.value === 'http://www.w3.org/2004/02/skos/core#notation'
-        )?.o?.value;
-        collect.rrnummer = identifier;
-      }
+      const identifier = store
+        .getObjects(persoon, ns.adms`identifier`)
+        .filter((p) => store.has(p, ns.rdf`type`, ns.adms`Identifier`))
+        .map(
+          (f) =>
+            store.readQuads(f, ns.skos`notation`).next().value?.object?.value
+        )[0];
+      collect.rrnummer = identifier;
+    }
 
-      const contactLink = contactLinks.find((c) => c.mandataris === mandataris);
-      if (contactLink) {
-        const contactSoort = tripleData.find(
-          (d) =>
-            d.s.value === contactLink.contact &&
-            d.p.value === 'http://schema.org/contactType'
-        )?.o?.value;
-        const email = tripleData.find(
-          (d) =>
-            d.s.value === contactLink.contact &&
-            d.p.value === 'http://schema.org/email'
-        )?.o?.value;
-        const telefoon = tripleData.find(
-          (d) =>
-            d.s.value === contactLink.contact &&
-            d.p.value === 'http://schema.org/telephone'
-        )?.o?.value;
-        collect.contact = contactLink.contact;
-        collect.contactSoort = contactSoort;
-        collect.email = email;
-        collect.telefoon = telefoon;
+    const contact = store
+      .getObjects(mandataris, ns.sch`contactPoint`)
+      .filter((p) => store.has(p, ns.rdf`type`, ns.sch`ContactPoint`))[0];
 
-        const adresLink = addressLinks.find(
-          (c) => c.contact === contactLink.contact
-        );
-        if (adresLink) {
-          const straat = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value === 'http://www.w3.org/ns/locn#thoroughfare'
-          )?.o?.value;
-          const huisnummer = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value ===
-                'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer'
-          )?.o?.value;
-          const busnummer = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value ===
-                'https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer'
-          )?.o?.value;
-          const postcode = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value === 'http://www.w3.org/ns/locn#postCode'
-          )?.o?.value;
-          const stad = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value === 'https://data.vlaanderen.be/ns/adres#gemeentenaam'
-          )?.o?.value;
-          const land = tripleData.find(
-            (d) =>
-              d.s.value === adresLink.address &&
-              d.p.value === 'https://data.vlaanderen.be/ns/adres#land'
-          )?.o?.value;
-          collect.adres = adresLink.address;
-          collect.straat = straat;
-          collect.huisnummer = huisnummer;
-          collect.busnummer = busnummer;
-          collect.postcode = postcode;
-          collect.stad = stad;
-          collect.land = land;
-        }
+    if (contact) {
+      const contactSoort = store.readQuads(contact, ns.sch`contactType`).next()
+        .value?.object?.value;
+      const email = store.readQuads(contact, ns.sch`email`).next().value
+        ?.object?.value;
+      const telefoon = store.readQuads(contact, ns.sch`telephone`).next().value
+        ?.object?.value;
+      collect.contact = contact.value;
+      collect.contactSoort = contactSoort;
+      collect.email = email;
+      collect.telefoon = telefoon;
+
+      const adres = store
+        .getObjects(contact, ns.locn`address`)
+        .filter((a) => store.has(a, ns.rdf`type`, ns.locn`Address`))[0];
+
+      if (adres) {
+        const straat = store.readQuads(adres, ns.locn`thoroughfare`).next()
+          .value?.object?.value;
+        const huisnummer = store
+          .readQuads(adres, ns.adres`Adresvoorstelling.huisnummer`)
+          .next().value?.object?.value;
+        const busnummer = store
+          .readQuads(adres, ns.adres`Adresvoorstelling.busnummer`)
+          .next().value?.object?.value;
+        const postcode = store.readQuads(adres, ns.locn`postCode`).next().value
+          ?.object?.value;
+        const stad = store.readQuads(adres, ns.adres`gemeentenaam`).next().value
+          ?.object?.value;
+        const land = store.readQuads(adres, ns.adres`land`).next().value
+          ?.object?.value;
+        collect.adres = adres.value;
+        collect.straat = straat;
+        collect.huisnummer = huisnummer;
+        collect.busnummer = busnummer;
+        collect.postcode = postcode;
+        collect.stad = stad;
+        collect.land = land;
       }
 
       data.push(collect);

--- a/config/reports/worship/namespaces.js
+++ b/config/reports/worship/namespaces.js
@@ -1,0 +1,31 @@
+import * as n3 from 'n3';
+const { namedNode } = n3.DataFactory;
+
+const PREFIXES = {
+  rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+  xsd: 'http://www.w3.org/2001/XMLSchema#',
+  mu: 'http://mu.semte.ch/vocabularies/core/',
+  ere: 'http://data.lblod.info/vocabularies/erediensten/',
+  prov: 'http://www.w3.org/ns/prov#',
+  contact: 'http://data.lblod.info/vocabularies/contacthub/',
+  org: 'http://www.w3.org/ns/org#',
+  skos: 'http://www.w3.org/2004/02/skos/core#',
+  organ: 'http://lblod.data.gift/vocabularies/organisatie/',
+  person: 'http://www.w3.org/ns/person#',
+  foaf: 'http://xmlns.com/foaf/0.1/',
+  persoon: 'http://data.vlaanderen.be/ns/persoon#',
+  adms: 'http://www.w3.org/ns/adms#',
+  sch: 'http://schema.org/',
+  locn: 'http://www.w3.org/ns/locn#',
+  adres: 'https://data.vlaanderen.be/ns/adres#',
+  mandaat: 'http://data.vlaanderen.be/ns/mandaat#',
+  ext: 'http://mu.semte.ch/vocabularies/ext/',
+  besluit: 'http://data.vlaanderen.be/ns/besluit#',
+};
+
+export const NAMESPACES = (() => {
+  const all = {};
+  for (const key in PREFIXES)
+    all[key] = (pred) => namedNode(`${PREFIXES[key]}${pred}`);
+  return all;
+})();

--- a/config/reports/worship/queries.js
+++ b/config/reports/worship/queries.js
@@ -1,3 +1,5 @@
+import * as rst from 'rdf-string-ttl';
+
 /**
  * Produces a query to get all the data for the given collection of subjects.
  *
@@ -8,12 +10,12 @@
  * is one of the subjects in the array.
  * @returns {String} The query to execute.
  */
-export function dataForSubjects(subjectURIs) {
-  const subjectValues = subjectURIs.map((uri) => `<${uri}>`).join(' ');
+export function dataForSubjects(subjects) {
+  const subjectsSparql = subjects.map(rst.termToString).join(' ');
   return `
 SELECT ?g ?s ?p ?o WHERE {
   VALUES ?s {
-    ${subjectValues}
+    ${subjectsSparql}
   }
   GRAPH ?g {
     ?s ?p ?o .
@@ -90,15 +92,15 @@ SELECT DISTINCT ?mandataris WHERE {
  * @param {String} type - Represents the `rdf:type` of the related subject.
  * @returns {String} The SPARQL query to execute.
  */
-export function domainToRange(domainURIs, predicate, type) {
-  const domainValues = domainURIs.map((uri) => `<${uri}>`).join(' ');
+export function domainToRange(domains, predicate, type) {
+  const domainValues = domains.map(rst.termToString).join(' ');
   return `
 SELECT DISTINCT ?domain ?range {
   VALUES ?domain {
     ${domainValues}
   }
-  ?domain <${predicate}> ?range .
-  ?range a <${type}> .
+  ?domain ${rst.termToString(predicate)} ?range .
+  ?range a ${rst.termToString(type)} .
 }
   `;
 }
@@ -114,15 +116,15 @@ SELECT DISTINCT ?domain ?range {
  * @param {String} type - Represents the `rdf:type` of the related subject.
  * @returns {String} The SPARQL query to execute.
  */
-export function rangeToDomain(domainURIs, predicate, type) {
-  const domainValues = domainURIs.map((uri) => `<${uri}>`).join(' ');
+export function rangeToDomain(domains, predicate, type) {
+  const domainValues = domains.map(rst.termToString).join(' ');
   return `
 SELECT DISTINCT ?domain ?range {
   VALUES ?domain {
     ${domainValues}
   }
-  ?range <${predicate}> ?domain .
-  ?range a <${type}> .
+  ?range ${rst.termToString(predicate)} ?domain .
+  ?range a ${rst.termToString(type)} .
 }
   `;
 }
@@ -137,10 +139,10 @@ SELECT DISTINCT ?domain ?range {
  * contents of.
  * @returns {String} The SPARQL query to execute.
  */
-export function allFromGraph(graphURI) {
+export function allFromGraph(graph) {
   return `
 SELECT DISTINCT ?s ?p ?o WHERE {
-  GRAPH <${graphURI}> {
+  GRAPH ${rst.termToString(graph)} {
     ?s ?p ?o .
   }
 }

--- a/config/reports/worship/temp-deletes.js
+++ b/config/reports/worship/temp-deletes.js
@@ -1,32 +1,30 @@
 import * as mas from '@lblod/mu-auth-sudo';
-import * as utils from './utils';
 import * as queries from './queries';
+import * as rst from 'rdf-string-ttl';
 import { generateReportFromData } from '../../helpers';
+import { SparqlJsonParser } from 'sparqljson-parse';
+const sparqlJsonParser = new SparqlJsonParser();
 
 const TEMP_DELETES_GRAPH =
   'http://eredienst-mandatarissen-consumer/temp-deletes';
 
 async function generate() {
-  let collectedData =
-    (await mas.querySudo(queries.allFromGraph(TEMP_DELETES_GRAPH)))?.results
-      ?.bindings || [];
-  collectedData = collectedData.map((res) => {
-    return {
-      subject: utils.formatTerm(res.s),
-      predicate: utils.formatTerm(res.p),
-      object: utils.formatTerm(res.o),
-    };
+  const collectQuery = queries.allFromGraph(TEMP_DELETES_GRAPH);
+  const collectResponse = await mas.querySudo(collectQuery);
+  const collected = sparqlJsonParser
+    .parseJsonResults(collectResponse)
+    .map((c) => {
+      return {
+        subject: rst.termToString(c.s),
+        predicate: rst.termToString(c.p),
+        object: rst.termToString(c.o),
+      };
+    });
+  await generateReportFromData(collected, ['subject', 'predicate', 'object'], {
+    title: 'Eredienst Temporary Deletes Report',
+    description: 'All eredienst triples ready for deletion from organisations.',
+    filePrefix: 'eredienst-temp-deletes',
   });
-  await generateReportFromData(
-    collectedData,
-    ['subject', 'predicate', 'object'],
-    {
-      title: 'Eredienst Temporary Deletes Report',
-      description:
-        'All eredienst triples ready for deletion from organisations.',
-      filePrefix: 'eredienst-temp-deletes',
-    }
-  );
 }
 
 export default {

--- a/config/reports/worship/utils.js
+++ b/config/reports/worship/utils.js
@@ -20,3 +20,9 @@ export function formatTerm(term) {
       return term.value;
   }
 }
+
+export function dedup(data, property) {
+  return data.filter(function (i) {
+    return !this.has(i[property]) && this.add(i[property]);
+  }, new Set());
+}

--- a/config/resources/master-files-domain.lisp
+++ b/config/resources/master-files-domain.lisp
@@ -11,6 +11,7 @@
                 (:format :string ,(s-prefix "dct:format"))
                 (:size :number ,(s-prefix "nfo:fileSize"))
                 (:extension :string ,(s-prefix "dbpedia:fileExtension"))
+                (:download-url :url ,(s-prefix "nie:url"))
                 (:created :datetime ,(s-prefix "dct:created")))
   :has-one `((file :via ,(s-prefix "nie:dataSource")
                    :inverse t

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,7 +241,7 @@ services:
     restart: always
     logging: *default-logging
   report-generation:
-    image: lblod/loket-report-generation-service:0.6.4
+    image: lblod/loket-report-generation-service:0.6.5
     volumes:
       - ./data/files:/share
       - ./config/reports/:/config/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -538,7 +538,7 @@ services:
       - ./data/files:/share
     environment:
       ALLOW_SUPER_CONSUMER: "true"
-      ALLOWED_ACCOUNTS: "http://services.lblod.info/diff-consumer/account,http://data.lblod.info/foaf/account/id/dd85f516-ee7c-406b-8245-91ce7f9545b7"
+      ALLOWED_ACCOUNTS: "http://services.lblod.info/diff-consumer/account,http://data.lblod.info/foaf/account/id/dd85f516-ee7c-406b-8245-91ce7f9545b7,http://data.lblod.info/foaf/account/id/4171b7a5-a4d6-42d0-bf37-f97b135fb885"
     restart: always
     logging: *default-logging
   ################################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,7 @@ services:
     restart: always
     logging: *default-logging
   berichtencentrum-sync-with-kalliope:
-    image: lblod/berichtencentrum-sync-with-kalliope-service:0.15.0-rc.1
+    image: lblod/berichtencentrum-sync-with-kalliope-service:0.15.0
     environment:
       MU_SPARQL_ENDPOINT: "http://database:8890/sparql"
       MU_SPARQL_UPDATEPOINT: "http://database:8890/sparql"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   loket:
-    image: lblod/frontend-loket:0.85.0
+    image: lblod/frontend-loket:0.86.0
     links:
       - identifier:backend
     labels:


### PR DESCRIPTION
This PR has the reports for worship services rewritten using RDF libs. Doing so reduced the lines of code and made it easier to debug. There was also a bug with bestuursorganen in the mandatarissen that is now fixed.