### PR TITLE
Adjusting politiezone rivierenland classificatie and bindingStart

### DIFF
--- a/config/migrations/2023/20231024131233-fix-politizone-rivierenland.sparql
+++ b/config/migrations/2023/20231024131233-fix-politizone-rivierenland.sparql
@@ -2,19 +2,19 @@ PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#> 
 
 DELETE {
-  GRAPH ?g {
+  GRAPH <http://mu.semte.ch/graphs/public> {
     ?bestuursorgaan1 besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
     ?bestuursorgaan2 mandaat:bindingStart ?oldStartDate .
   }
 }
 INSERT {
-  GRAPH ?g {
+  GRAPH <http://mu.semte.ch/graphs/public> {
     ?bestuursorgaan1 besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
     ?bestuursorgaan2 mandaat:bindingStart "1971-11-03"^^<http://www.w3.org/2001/XMLSchema#date> .
   }
 }
 WHERE {
-  GRAPH ?g {
+  GRAPH <http://mu.semte.ch/graphs/public> {
     BIND (<http://data.lblod.info/id/bestuursorganen/17d1ecc1-e882-4dd1-9c72-419cb9dbce4a> AS ?bestuursorgaan1)
       ?bestuursorgaan1 besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> ;
       ^mandaat:isTijdspecialisatieVan ?bestuursorgaan2 .

--- a/config/migrations/2023/20231024131233-fix-politizone-rivierenland.sparql
+++ b/config/migrations/2023/20231024131233-fix-politizone-rivierenland.sparql
@@ -1,0 +1,23 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#> 
+
+DELETE {
+  GRAPH ?g {
+    ?bestuursorgaan1 besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+    ?bestuursorgaan2 mandaat:bindingStart ?oldStartDate .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?bestuursorgaan1 besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+    ?bestuursorgaan2 mandaat:bindingStart "1971-11-03"^^<http://www.w3.org/2001/XMLSchema#date> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    BIND (<http://data.lblod.info/id/bestuursorganen/17d1ecc1-e882-4dd1-9c72-419cb9dbce4a> AS ?bestuursorgaan1)
+      ?bestuursorgaan1 besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> ;
+      ^mandaat:isTijdspecialisatieVan ?bestuursorgaan2 .
+      ?bestuursorgaan2 mandaat:bindingStart ?oldStartDate .
+  }
+}


### PR DESCRIPTION
# Description
DL-5414

This PR fixes data where when creating a besluitenlijst with politiezone rivierenland the label was zoneraad sinds 2019 where it should be politieraad sinds 1971. So the classificatie and the bindingstart had to be adjusted.


![Screenshot 2023-10-24 at 11-19-39 Loket voor lokale besturen](https://github.com/lblod/app-digitaal-loket/assets/38471754/9a2d5b42-6c02-417b-a56d-ea8ef78c75fb)


# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- enrich-submissions

# How to test 

1. Log in as Politiezone Rivierenland
2. Create a submission in the Toezicht Module (Besluitenlijst)
3. Field "Welk beslissingsorgaan nam het besluit?" should show Politieraad sinds 1971
4. Form should save without errors

# What to check

- Any form issues

# Links to other PR's

- N/A

# Notes

drc restart migrations resource cache