### PR TITLE
Adding worship publication flag to existing ROs submissions

### DIFF
--- a/config/migrations/2023/20231023101111-flag-concepts.sparql
+++ b/config/migrations/2023/20231023101111-flag-concepts.sparql
@@ -1,0 +1,14 @@
+INSERT {
+  GRAPH ?g {
+    ?s <http://schema.org/publication> <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1>.
+  }
+}
+WHERE {
+  VALUES ?s {
+  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213>
+  <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943>
+  }
+ GRAPH ?g {
+   ?s a <http://www.w3.org/2004/02/skos/core#Concept>; ?p ?o.
+ }
+}

--- a/config/migrations/2023/20231023101143-flag-for-ro-submissions.sparql
+++ b/config/migrations/2023/20231023101143-flag-for-ro-submissions.sparql
@@ -1,0 +1,77 @@
+PREFIX meb:     <http://rdf.myexperiment.org/ontologies/base/>
+PREFIX adms:    <http://www.w3.org/ns/adms#>
+PREFIX prov:    <http://www.w3.org/ns/prov#>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+PREFIX eli:     <http://data.europa.eu/eli/ontology#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX pav:     <http://purl.org/pav/>
+prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX schema:  <http://schema.org/>
+PREFIX dct:     <http://purl.org/dc/terms/>
+
+INSERT {
+  GRAPH ?h {
+    # Flag for export
+    ?submission schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> . 
+    ?submissionDocument schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+    ?submissionDocumentStatus schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+    ?formData schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+    ?props schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+    ?submissionDocumentFile schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+  }
+
+  GRAPH ?j {
+    ?concept schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Get bestuurseenheden by bestuursorgaan & -eenheid classificatie code
+    # Representatief Orgaan
+    VALUES (?bestuursorgaanClassificatieCode ?bestuurseenheidClassificatieCode) {
+        (<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> )
+    }
+
+    ?bestuursorgaan mandaat:isTijdspecialisatieVan/besluit:classificatie ?bestuursorgaanClassificatieCode .
+    ?bestuurseenheid besluit:classificatie ?bestuurseenheidClassificatieCode .
+  }
+  
+  GRAPH ?g {
+    # Get all submissions in the decisionTypeSet & status SENT
+    ?submission a meb:Submission ;
+      adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> ; # SENT
+      prov:generated/ext:decisionType ?decisionType ;
+      prov:generated ?formData ;
+      dct:subject ?submissionDocument;
+      pav:createdBy ?bestuurseenheid .
+  
+     FILTER (?decisionType IN (<https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a>, # Samenvoeging (RO)
+      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73>, # Erkenning - reguliere procedure (RO)
+      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777>, # Naamswijziging (RO)
+      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b>, # Wijziging gebiedsomschrijving (RO)
+      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e> # Opheffing van annexe kerken en kapelanijen (RO)
+      ))
+
+     # Ignore already flagged submissions
+     FILTER NOT EXISTS {
+       ?submission schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+     }
+
+    # Get file refs
+    ?submissionDocument <http://purl.org/dc/terms/source> ?submissionDocumentFile .
+
+    # Give me formData props limited to following list of types
+    ?formData ?formDataPred ?props.
+
+    FILTER (?formDataPred IN (
+      <http://lblod.data.gift/vocabularies/besluit/authenticityType>, 
+      <http://mu.semte.ch/vocabularies/ext/regulationType>,
+      <http://mu.semte.ch/vocabularies/ext/decisionType>,
+      <http://mu.semte.ch/vocabularies/ext/taxType>,
+      <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart>
+    ))    
+
+    BIND(?g as ?h)
+    BIND(?i as ?j)
+  }
+}

--- a/config/migrations/2023/20231023101303-flag-for-ro-submissions-attachements.sparql
+++ b/config/migrations/2023/20231023101303-flag-for-ro-submissions-attachements.sparql
@@ -1,0 +1,49 @@
+PREFIX schema: <http://schema.org/>
+PREFIX pav: <http://purl.org/pav/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX lblodBesluit: <http://lblod.data.gift/vocabularies/besluit/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX eli: <http://data.europa.eu/eli/ontology#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+INSERT {
+  GRAPH ?h {
+    ?attachment schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+  }
+}
+WHERE {
+  {
+    ?submission schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> ;
+      nie:hasPart |
+      nie:hasPart/^nie:dataSource |
+      dct:hasPart/^nie:dataSource |
+      nie:hasPart/^nie:dataSource/^nie:dataSource |
+      prov:generated/dct:hasPart |
+      prov:generated/dct:hasPart/nie:dataSource ?attachment .
+  }
+  UNION
+  {
+    ?submission schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> ;
+      dct:subject/dct:source ?attachment.
+    ?attachment dct:type ?type .
+
+    FILTER (?type IN (
+      <http://data.lblod.gift/concepts/meta-file-type>,
+      <http://data.lblod.gift/concepts/form-data-file-type>,
+      <http://data.lblod.gift/concepts/form-file-type>
+    ))
+  }
+
+  FILTER NOT EXISTS { ?attachment schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> . }
+
+  GRAPH ?g {
+    ?attachment a ?attachmentType .
+  }
+  FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))
+
+  BIND(?g as ?h)
+}

--- a/config/migrations/2023/20231023133318-flag-for-ro-submissions.sparql
+++ b/config/migrations/2023/20231023133318-flag-for-ro-submissions.sparql
@@ -1,0 +1,79 @@
+PREFIX meb:     <http://rdf.myexperiment.org/ontologies/base/>
+PREFIX adms:    <http://www.w3.org/ns/adms#>
+PREFIX prov:    <http://www.w3.org/ns/prov#>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+PREFIX eli:     <http://data.europa.eu/eli/ontology#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX pav:     <http://purl.org/pav/>
+prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX schema:  <http://schema.org/>
+PREFIX dct:     <http://purl.org/dc/terms/>
+
+INSERT {
+  GRAPH ?h {
+    # Flag for export
+    ?submission schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> . 
+    ?submissionDocument schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+    ?submissionDocumentStatus schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+    ?formData schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+    ?props schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+    ?submissionFile schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+    ?submissionDocumentFile schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+  }
+
+  GRAPH ?j {
+    ?concept schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Get bestuurseenheden by bestuursorgaan & -eenheid classificatie code
+    # Representatief Orgaan
+    VALUES (?bestuursorgaanClassificatieCode ?bestuurseenheidClassificatieCode) {
+        ( <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> )
+    }
+
+    ?bestuursorgaan mandaat:isTijdspecialisatieVan/besluit:classificatie ?bestuursorgaanClassificatieCode .
+    ?bestuurseenheid besluit:classificatie ?bestuurseenheidClassificatieCode .
+  }
+  
+  GRAPH ?g {
+    # Get all submissions in the decisionTypeSet & status SENT
+    ?submission a meb:Submission ;
+      adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> ; # SENT
+      prov:generated/ext:decisionType ?decisionType ; 
+      prov:generated ?formData ;
+      dct:subject ?submissionDocument;
+      pav:createdBy ?bestuurseenheid .
+
+     FILTER (?decisionType IN (<https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a>, # Samenvoeging (RO)
+      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73>, # Erkenning - reguliere procedure (RO)
+      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777>, # Naamswijziging (RO)
+      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b>, # Wijziging gebiedsomschrijving (RO)
+      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e> # Opheffing van annexe kerken en kapelanijen (RO)
+      ))
+
+     # Ignore already flagged submissions
+     FILTER NOT EXISTS {
+       ?submission schema:publication <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> .
+     }
+
+    # Get file refs
+    ?submission <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> ?submissionFile. 
+    ?submissionDocument <http://purl.org/dc/terms/source> ?submissionDocumentFile .
+
+    # Give me formData props limited to following list of types
+    ?formData ?formDataPred ?props.
+
+    FILTER (?formDataPred IN (
+      <http://lblod.data.gift/vocabularies/besluit/authenticityType>, 
+      <http://mu.semte.ch/vocabularies/ext/regulationType>,
+      <http://mu.semte.ch/vocabularies/ext/decisionType>,
+      <http://mu.semte.ch/vocabularies/ext/taxType>,
+      <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart>
+    ))    
+
+    BIND(?g as ?h)
+    BIND(?i as ?j)
+  }
+}


### PR DESCRIPTION
# Description

DL-5420

This PR adds the worship flag, `<http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1>`, to mark previously sent submissions. The purpose of this flag is to enable these submissions to be included in the export process performed by the `prepare-submissions-for-export-service`.

While the service now has the necessary URIs, it's important to note that a migration is required to ensure data consistency. Without this migration, previously sent submissions that lack the export flag will not be included in the export process, even if the decisions types has the flag.

This PR is aimed at addressing this issue by adding the flag to applicable submissions and their attachments to ensure that they are properly prepared for export.

Here's the submissions decisions types that misses export :

- "https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a", // Samenvoeging (RO)
- "https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73", // Erkenning - reguliere procedure (RO)
- "https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777", // Naamswijziging (RO)
- "https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b", // Wijziging gebiedsomschrijving (RO)
- "https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e", // Opheffing van annexe kerken en kapelanijen (RO)

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- prepare-submissions-for-export-service
- mu-migrations

# How to test 

1. Before running the migrations make sure you check data (QA or PROD sample), there is missing flags on ROs decisions types submissions listed in the description but you can also find them with this query :
```sparql
PREFIX prov: <http://www.w3.org/ns/prov#>
PREFIX schema: <http://schema.org/>

select distinct ?submission ?decisionType ?date ?publicationFlag WHERE {
  GRAPH ?g {
    ?s ?p ?decisionType .
    ?submission prov:generated ?s ;
     <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#sentDate> ?date .

    FILTER (?decisionType IN (<https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a>, # Samenvoeging (RO)
      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73>, # Erkenning - reguliere procedure (RO)
      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777>, # Naamswijziging (RO)
      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b>, # Wijziging gebiedsomschrijving (RO)
      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e> # Opheffing van annexe kerken en kapelanijen (RO)
      ))

    FILTER NOT EXISTS {
      ?submission schema:publication ?publicationFlag .
    }
  }
}
```
2. You can then use this branch and run the migrations, check the migration : `drc logs -f --tail=200 migrations`
3. You should expect old submissions to have the worship flag now 
```sparql
PREFIX prov: <http://www.w3.org/ns/prov#>
PREFIX schema: <http://schema.org/>

select distinct ?submission ?decisionType ?date ?publicationFlag WHERE {
  GRAPH ?g {
    ?s ?p ?decisionType .
    ?submission prov:generated ?s ;
     <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#sentDate> ?date ;
     schema:publication ?publicationFlag .

    FILTER (?decisionType IN (<https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a>, # Samenvoeging (RO)
      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73>, # Erkenning - reguliere procedure (RO)
      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777>, # Naamswijziging (RO)
      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b>, # Wijziging gebiedsomschrijving (RO)
      <https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e> # Opheffing van annexe kerken en kapelanijen (RO)
      ))
    }
}
```
4. You can also check their attachments with the same process 

# What to check

- Any data issue

# Links to other PR's

- N/A

# Notes

drc restart migrations resource cache
