### PR TITLE
Task: extend ukraine deadlines and update oproep

### DIFF
--- a/config/migrations/2023/subsidies/20231107094100-update-ukraine-nooddorpen-deadline-oproep.sparql
+++ b/config/migrations/2023/subsidies/20231107094100-update-ukraine-nooddorpen-deadline-oproep.sparql
@@ -1,25 +1,25 @@
-PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX m8g: <http://data.europa.eu/m8g/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
 
-# Change deadline from 2023-09-30 to 2024-05-31
-DELETE DATA {
+# Extend Deadline Nooddorpen Oekraïne
+DELETE WHERE {
   GRAPH <http://mu.semte.ch/graphs/public> {
-    # Deadline of Nooddorpen Oekraïne
-    <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c> m8g:endTime ?endTime .
-
-    # SubsidiemaatregelAanbodReeks for the Nooddorpen Oekraïne
-    # Title to be deleted is "Oproep 1"
     <http://lblod.data.info/id/subsidy-measure-offer-series/4a40d903-d77f-49e0-8cf4-daa3ce623439> dct:title ?title .
+    <http://lblod.data.info/id/subsidy-measure-offer-series/4a40d903-d77f-49e0-8cf4-daa3ce623439> dct:description ?description .
+
+    <http://data.lblod.info/id/periodes/5ecb1512-e8b3-40bf-a0c4-a4087090c093> m8g:endTime ?endTimeSubsidy .
+    <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c> m8g:endTime ?endTimeStep .
   }
-}
-;
+};
+
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.info/id/subsidy-measure-offer-series/4a40d903-d77f-49e0-8cf4-daa3ce623439> dct:title "Oproep"@nl .
+    <http://lblod.data.info/id/subsidy-measure-offer-series/4a40d903-d77f-49e0-8cf4-daa3ce623439> dct:description "14/03/2022 — 31/05/2024"@nl .
+  
     # Time is set to 21:59:00 because Belgium time is UTC+2 instead of UTC+1 in May.
-   <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c> mg8:endTime "2024-05-31T21:59:00Z"^^xsd:dateTime.
-
-   # Title to be added is "Oproep"
-   <http://lblod.data.info/id/subsidy-measure-offer-series/4a40d903-d77f-49e0-8cf4-daa3ce623439> dct:title "Oproep"@nl .
+    <http://data.lblod.info/id/periodes/5ecb1512-e8b3-40bf-a0c4-a4087090c093> m8g:endTime "2024-05-31T21:59:00Z"^^xsd:dateTime.
+    <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c> m8g:endTime "2024-05-31T21:59:00Z"^^xsd:dateTime.
   }
 }

--- a/config/migrations/2023/subsidies/20231107094100-update-ukraine-nooddorpen-deadline-oproep.sparql
+++ b/config/migrations/2023/subsidies/20231107094100-update-ukraine-nooddorpen-deadline-oproep.sparql
@@ -1,0 +1,25 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX m8g: <http://data.europa.eu/m8g/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+# Change deadline from 2023-09-30 to 2024-05-31
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Deadline of Nooddorpen Oekraïne
+    <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c> m8g:endTime ?endTime .
+
+    # SubsidiemaatregelAanbodReeks for the Nooddorpen Oekraïne
+    # Title to be deleted is "Oproep 1"
+    <http://lblod.data.info/id/subsidy-measure-offer-series/4a40d903-d77f-49e0-8cf4-daa3ce623439> dct:title ?title .
+  }
+}
+;
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Time is set to 21:59:00 because Belgium time is UTC+2 instead of UTC+1 in May.
+   <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c> mg8:endTime "2024-05-31T21:59:00Z"^^xsd:dateTime.
+
+   # Title to be added is "Oproep"
+   <http://lblod.data.info/id/subsidy-measure-offer-series/4a40d903-d77f-49e0-8cf4-daa3ce623439> dct:title "Oproep"@nl .
+  }
+}


### PR DESCRIPTION
## ID
 DGS-91

 ## Description

Migration that does 2 things to Nooddorpen oekraine subsidies:
- Update the deadline to 31 mei 2024 23:59 local time.
- Update the SubsidiemaatregelAanbodReeks from 'Oproep 1' to 'Oproep'. 

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Other

 ## How to test

Visit subsidiebeheer in loket and verify the subsidies of 'Nooddorpen oekraine' now have a new deadline of 31 mei 2024. And verify that their SubsidiemaatregelAanbodReeks now says 'Oproep'.
