### PR TITLE
Extend fietssubsidie configuration

### DIFF
--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -117,7 +117,15 @@
         "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/usesSocialImpactBound",
         "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#estimatedCostTable",
         "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveTable",
-        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#identifier"
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#identifier",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/decision-upload/FormData",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/pictures-upload/FormData",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/report-upload/FormData",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/award-report-upload/FormData",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/accountability-note-upload/FormData",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-costs-upload/FormData",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-expropriations-upload/FormData",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/invoice-upload/FormData"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -116,7 +116,8 @@
         "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/unresolvedSocialProblems",
         "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/usesSocialImpactBound",
         "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#estimatedCostTable",
-        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveTable"
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveTable",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#identifier"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -118,14 +118,14 @@
         "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#estimatedCostTable",
         "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveTable",
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#identifier",
-        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/decision-upload/FormData",
-        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/pictures-upload/FormData",
-        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/report-upload/FormData",
-        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/award-report-upload/FormData",
-        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/accountability-note-upload/FormData",
-        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-costs-upload/FormData",
-        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-expropriations-upload/FormData",
-        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/invoice-upload/FormData"
+        "http://lblod.data.gift/vocabularies/subsidie/accountabilityNoteUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/awardReportUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/decisionUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/invoiceUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/justificationExpropriationsUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/picturesUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/picturesUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/picturesUpload"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -126,7 +126,9 @@
         "http://lblod.data.gift/vocabularies/subsidie/picturesUpload",
         "http://lblod.data.gift/vocabularies/subsidie/picturesUpload",
         "http://lblod.data.gift/vocabularies/subsidie/picturesUpload",
-        "http://lblod.data.gift/vocabularies/subsidie/projectName"
+        "http://lblod.data.gift/vocabularies/subsidie/projectName",
+        "http://lblod.data.gift/vocabularies/subsidie/justificationCostsUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/reportUpload"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -125,7 +125,8 @@
         "http://lblod.data.gift/vocabularies/subsidie/justificationExpropriationsUpload",
         "http://lblod.data.gift/vocabularies/subsidie/picturesUpload",
         "http://lblod.data.gift/vocabularies/subsidie/picturesUpload",
-        "http://lblod.data.gift/vocabularies/subsidie/picturesUpload"
+        "http://lblod.data.gift/vocabularies/subsidie/picturesUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/projectName"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -114,7 +114,9 @@
         "http://www.w3.org/ns/adms#status",
         "http://schema.org/bankAccount",
         "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/unresolvedSocialProblems",
-        "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/usesSocialImpactBound"
+        "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/usesSocialImpactBound",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#estimatedCostTable",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveTable"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
@@ -321,6 +323,150 @@
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
       ],
       "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/decision-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/pictures-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/report-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/award-report-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/accountability-note-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-costs-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-expropriations-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/invoice-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://schema.org/identifier",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://schema.org/BankAccount"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#validEstimatedCostTable",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#estimatedCostEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#EstimatedCostTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://mu.semte.ch/vocabularies/ext/index",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#costEstimationType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#cost",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#share"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#EstimatedCostEntry"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#validObjectiveTable",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#ObjectiveTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#approachType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#directionType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#bikeLaneType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#kilometers"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#ObjectiveEntry"
     }
   ]
 }

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122172250-add-accountability-note-upload-form-data-type.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122172250-add-accountability-note-upload-form-data-type.sparql
@@ -9,7 +9,7 @@ WHERE {
     ?formData ?p_f ?o_f .
   }
 
-  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+  FILTER(REGEX(STR(?g), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"))
 
   FILTER NOT EXISTS {
     ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122172250-add-accountability-note-upload-form-data-type.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122172250-add-accountability-note-upload-form-data-type.sparql
@@ -1,0 +1,17 @@
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/accountability-note-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/accountabilityNoteUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122172332-add-award-report-upload-form-data-type-to-URIs.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122172332-add-award-report-upload-form-data-type-to-URIs.sparql
@@ -9,7 +9,7 @@ WHERE {
     ?formData ?p_f ?o_f .
   }
 
-  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+  FILTER(REGEX(STR(?g), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"))
 
   FILTER NOT EXISTS {
     ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122172332-add-award-report-upload-form-data-type-to-URIs.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122172332-add-award-report-upload-form-data-type-to-URIs.sparql
@@ -1,0 +1,17 @@
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/award-report-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/awardReportUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173536-add-decision-report-upload-form-data-type-to-URIs.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173536-add-decision-report-upload-form-data-type-to-URIs.sparql
@@ -1,0 +1,17 @@
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/decision-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/decisionUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173536-add-decision-report-upload-form-data-type-to-URIs.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173536-add-decision-report-upload-form-data-type-to-URIs.sparql
@@ -9,7 +9,7 @@ WHERE {
     ?formData ?p_f ?o_f .
   }
 
-  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+  FILTER(REGEX(STR(?g), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"))
 
   FILTER NOT EXISTS {
     ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173736-add-invoice-upload-form-data-type.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173736-add-invoice-upload-form-data-type.sparql
@@ -9,7 +9,7 @@ WHERE {
     ?formData ?p_f ?o_f .
   }
 
-  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+  FILTER(REGEX(STR(?g), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"))
 
   FILTER NOT EXISTS {
     ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173736-add-invoice-upload-form-data-type.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173736-add-invoice-upload-form-data-type.sparql
@@ -1,0 +1,17 @@
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/invoice-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/invoiceUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173802-add-justification-costs-upload-form-data-type.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173802-add-justification-costs-upload-form-data-type.sparql
@@ -9,7 +9,7 @@ WHERE {
     ?formData ?p_f ?o_f .
   }
 
-  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+  FILTER(REGEX(STR(?g), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"))
 
   FILTER NOT EXISTS {
     ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173802-add-justification-costs-upload-form-data-type.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173802-add-justification-costs-upload-form-data-type.sparql
@@ -1,0 +1,17 @@
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-costs-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/justificationCostsUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173934-add-justification-expropriations-upload-form-data-type.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173934-add-justification-expropriations-upload-form-data-type.sparql
@@ -9,7 +9,7 @@ WHERE {
     ?formData ?p_f ?o_f .
   }
 
-  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+  FILTER(REGEX(STR(?g), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"))
 
   FILTER NOT EXISTS {
     ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173934-add-justification-expropriations-upload-form-data-type.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173934-add-justification-expropriations-upload-form-data-type.sparql
@@ -1,0 +1,17 @@
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-expropriations-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/justificationExpropriationsUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173949-add-pictures-upload-form-data-type.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173949-add-pictures-upload-form-data-type.sparql
@@ -9,7 +9,7 @@ WHERE {
     ?formData ?p_f ?o_f .
   }
 
-  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+  FILTER(REGEX(STR(?g), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"))
 
   FILTER NOT EXISTS {
     ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173949-add-pictures-upload-form-data-type.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122173949-add-pictures-upload-form-data-type.sparql
@@ -1,0 +1,17 @@
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/pictures-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/picturesUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174003-add-report-upload-form-data-type-to-URIs.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174003-add-report-upload-form-data-type-to-URIs.sparql
@@ -1,0 +1,17 @@
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/report-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/reportUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174003-add-report-upload-form-data-type-to-URIs.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174003-add-report-upload-form-data-type-to-URIs.sparql
@@ -9,7 +9,7 @@ WHERE {
     ?formData ?p_f ?o_f .
   }
 
-  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+  FILTER(REGEX(STR(?g), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"))
 
   FILTER NOT EXISTS {
     ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174013-add-bank-account-form-data-type-to-URIs.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174013-add-bank-account-form-data-type-to-URIs.sparql
@@ -9,7 +9,7 @@ WHERE {
     ?formData ?p_f ?o_f .
   }
 
-  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+  FILTER(REGEX(STR(?g), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"))
 
   FILTER NOT EXISTS {
     ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174013-add-bank-account-form-data-type-to-URIs.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174013-add-bank-account-form-data-type-to-URIs.sparql
@@ -1,0 +1,17 @@
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/BankAccount> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://schema.org/bankAccount> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174023-add-contact-point-form-data-type-to-URIs.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174023-add-contact-point-form-data-type-to-URIs.sparql
@@ -9,7 +9,7 @@ WHERE {
     ?formData ?p_f ?o_f .
   }
 
-  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+  FILTER(REGEX(STR(?g), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"))
 
   FILTER NOT EXISTS {
     ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .

--- a/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174023-add-contact-point-form-data-type-to-URIs.sparql
+++ b/config/migrations/2023/subsidies/20231122155240-extend-fietssubsidie-configuration/20231122174023-add-contact-point-form-data-type-to-URIs.sparql
@@ -1,0 +1,17 @@
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/ContactPoint> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://schema.org/contactPoint> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER(REGEX(STR(?g)), "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies")
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}


### PR DESCRIPTION
This PR uses a [previous one](https://github.com/lblod/app-digitaal-loket/pull/456) as a reference with the goal of extending the configuration one subsidy at a time; this is to reduce the possible number of errors that may arise from exporting subsidies all at once.