### PR TITLE
Bump berichtencentrum-sync-with-kalliope-service to v0.16.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,7 @@ services:
     restart: always
     logging: *default-logging
   berichtencentrum-sync-with-kalliope:
-    image: lblod/berichtencentrum-sync-with-kalliope-service:0.15.0
+    image: lblod/berichtencentrum-sync-with-kalliope-service:0.16.0
     environment:
       MU_SPARQL_ENDPOINT: "http://database:8890/sparql"
       MU_SPARQL_UPDATEPOINT: "http://database:8890/sparql"


### PR DESCRIPTION
# Description

DL-5409

This PR bumps the version of berichtencentrum-sync-with-kalliope-service to v0.16.0 

This adds an hardcoded string "Origineel bericht in bijlage" to the prop schema:text as this content is not used in loket but internally in Kalliope.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- berichtencentrum-sync-with-kalliope-service

# How to test 

- N/A

# What to check

- N/A

# Links to other PR's

- N/A

# Notes

drc up -d berichtencentrum-sync-with-kalliope