### PR TITLE
fix: add missing graphsFilter for SubsidiemaatregelAanbodReeks

### DIFF
--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -165,7 +165,8 @@
         "http://purl.org/vocab/cpsv#follows"
       ],
       "graphsFilter": [
-        "http://mu.semte.ch/graphs/public"
+        "http://mu.semte.ch/graphs/public",
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
       ],
       "type": "http://lblod.data.gift/vocabularies/subsidie/SubsidiemaatregelAanbodReeks"
     },


### PR DESCRIPTION
## ID
 DGS-98

 ## Description

There was a missing graphsFilter for `SubsidiemaatregelAanbodReeks` which didn't sync the subsidies series for certain subsidies (stadsvernieuwing, LEKP 2.1). 

 ## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## Related services

 - subsidiedatabank


 ## How to test

Run both loket and subsidiedatabank. Create a stadsvernieuwing or LEKP 2.1 subsidy and wait until it's synced to subsidiedatabank. The oproep subtitle should now be filled in with the correct SubsidiemaatregelAanbodReeks.
