### PR TITLE
task: Add extra 'document opladden' for LEKP

### DIFF
--- a/config/subsidy-application-management/forms/climate/oproep-2/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
+++ b/config/subsidy-application-management/forms/climate/oproep-2/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
@@ -37,7 +37,7 @@
         ]
       },
       {
-        "s-prefix": "lblodSubsidie:attachmentLEKP",
+        "s-prefix": "lblodSubsidie:attachmentLEKPReport",
         "properties": [
           {
             "s-prefix": "dct:hasPart",

--- a/config/subsidy-application-management/forms/climate/oproep-2/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
+++ b/config/subsidy-application-management/forms/climate/oproep-2/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
@@ -35,6 +35,17 @@
             ]
           }
         ]
+      },
+      {
+        "s-prefix": "lblodSubsidie:attachmentLEKP",
+        "properties": [
+          {
+            "s-prefix": "dct:hasPart",
+            "properties": [
+              "rdf:type"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/config/subsidy-application-management/forms/climate/oproep-2/step-submit-opvolgmoment-2024/versions/20231116154454/form.ttl
+++ b/config/subsidy-application-management/forms/climate/oproep-2/step-submit-opvolgmoment-2024/versions/20231116154454/form.ttl
@@ -144,7 +144,7 @@ fields:5c573f2a-581a-4a32-8a7c-0e9ecd7cf34b a form:Field ;
     mu:uuid "5c573f2a-581a-4a32-8a7c-0e9ecd7cf34b" ;
     sh:name "Laad hier vrijblijvend uw LEKP rapport op" ;
     sh:order 50 ;
-    sh:path ( lblodSubsidie:attachmentLEKP dct:hasPart ) ;
+    sh:path ( lblodSubsidie:attachmentLEKPReport dct:hasPart ) ;
     form:displayType displayTypes:files ;
     sh:group fields:70f45080-8a18-473f-bb3f-abf6ce9c678e .
 

--- a/config/subsidy-application-management/forms/climate/oproep-2/step-submit-opvolgmoment-2024/versions/20231116154454/form.ttl
+++ b/config/subsidy-application-management/forms/climate/oproep-2/step-submit-opvolgmoment-2024/versions/20231116154454/form.ttl
@@ -139,6 +139,15 @@ fields:f6f972c0-e796-42e8-87c1-c689dab0a690 a form:Field ;
     form:displayType displayTypes:files ;
     sh:group fields:70f45080-8a18-473f-bb3f-abf6ce9c678e .
 
+
+fields:5c573f2a-581a-4a32-8a7c-0e9ecd7cf34b a form:Field ;
+    mu:uuid "5c573f2a-581a-4a32-8a7c-0e9ecd7cf34b" ;
+    sh:name "Laad hier vrijblijvend uw LEKP rapport op" ;
+    sh:order 50 ;
+    sh:path ( lblodSubsidie:attachmentLEKP dct:hasPart ) ;
+    form:displayType displayTypes:files ;
+    sh:group fields:70f45080-8a18-473f-bb3f-abf6ce9c678e .
+
 ##########################################################
 # Hidden field required for all variations of URL or FILE
 # input field which require validation.
@@ -175,6 +184,9 @@ fieldGroups:main a form:FieldGroup ;
 
         ### Attachment
         fields:f6f972c0-e796-42e8-87c1-c689dab0a690 ,
+
+        ### Attachment LEKP (optional)
+        fields:5c573f2a-581a-4a32-8a7c-0e9ecd7cf34b ,
 
         ### Attachment [hidden]
         fields:08ebe38b-9b5f-43be-9b61-e1ee58da1168 .


### PR DESCRIPTION
## ID
DGS-51

 ## Description

You can upload an extra document (optionally) for LEKP rapports in opvolgmoment 2024 of the LEKP 1.0 subsidies. 

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## How to test

Visit subsidiebeheer in Loket and create a new LEKP 1.0 subsidy, go through all the steps. In the last step 'opvolgmoment 2024' you should now see an additional optional document upload zone for LEKP rapports.
