### PR TITLE
Hotfix/further vdds optimisations and berichtencentrum

### DIFF
--- a/config/migrations/2023/berichten-melding/20231024160200-berichten-centrum-data-in-vendor-graph_conversations.sparql
+++ b/config/migrations/2023/berichten-melding/20231024160200-berichten-centrum-data-in-vendor-graph_conversations.sparql
@@ -25,7 +25,7 @@ WHERE {
       core:uuid ?organisationUUID .
   }
   GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
-    ?vendor
+    <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
       account:canActOnBehalfOf ?organisation ;
       a ext:Vendor ;
       core:uuid ?vendorUUID .

--- a/config/migrations/2023/berichten-melding/20231024160200-berichten-centrum-data-in-vendor-graph_conversations.sparql
+++ b/config/migrations/2023/berichten-melding/20231024160200-berichten-centrum-data-in-vendor-graph_conversations.sparql
@@ -19,16 +19,16 @@ INSERT {
   }
 }
 WHERE {
-  GRAPH <http://mu.semte.ch/graphs/public> {
-    ?organisation
-      a besluit:Bestuurseenheid ;
-      core:uuid ?organisationUUID .
-  }
   GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
     <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
       account:canActOnBehalfOf ?organisation ;
       a ext:Vendor ;
       core:uuid ?vendorUUID .
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?organisation
+      a besluit:Bestuurseenheid ;
+      core:uuid ?organisationUUID .
   }
   BIND (IRI(CONCAT("http://mu.semte.ch/graphs/vendors/", STR(?vendorUUID), "/", STR(?organisationUUID))) AS ?vendorGraph)
   BIND (IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", STR(?organisationUUID), "/LoketLB-berichtenGebruiker")) AS ?organisationGraph)
@@ -38,7 +38,7 @@ WHERE {
       sch:hasPart ?message .
     ?message
       a sch:Message .
-    
+
     FILTER NOT EXISTS {
       ?message adms:status deli:unconfirmed .
     }
@@ -49,4 +49,3 @@ WHERE {
     ?conversation ?pc ?oc .
   }
 }
-

--- a/config/migrations/2023/berichten-melding/20231024160201-berichten-centrum-data-in-vendor-graph_messages.sparql
+++ b/config/migrations/2023/berichten-melding/20231024160201-berichten-centrum-data-in-vendor-graph_messages.sparql
@@ -19,16 +19,16 @@ INSERT {
   }
 }
 WHERE {
-  GRAPH <http://mu.semte.ch/graphs/public> {
-    ?organisation
-      a besluit:Bestuurseenheid ;
-      core:uuid ?organisationUUID .
-  }
   GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
     <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
       account:canActOnBehalfOf ?organisation ;
       a ext:Vendor ;
       core:uuid ?vendorUUID .
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?organisation
+      a besluit:Bestuurseenheid ;
+      core:uuid ?organisationUUID .
   }
   BIND (IRI(CONCAT("http://mu.semte.ch/graphs/vendors/", STR(?vendorUUID), "/", STR(?organisationUUID))) AS ?vendorGraph)
   BIND (IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", STR(?organisationUUID), "/LoketLB-berichtenGebruiker")) AS ?organisationGraph)

--- a/config/migrations/2023/berichten-melding/20231024160201-berichten-centrum-data-in-vendor-graph_messages.sparql
+++ b/config/migrations/2023/berichten-melding/20231024160201-berichten-centrum-data-in-vendor-graph_messages.sparql
@@ -25,7 +25,7 @@ WHERE {
       core:uuid ?organisationUUID .
   }
   GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
-    ?vendor
+    <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
       account:canActOnBehalfOf ?organisation ;
       a ext:Vendor ;
       core:uuid ?vendorUUID .

--- a/config/migrations/2023/berichten-melding/20231024160202-berichten-centrum-data-in-vendor-graph_attachments.sparql
+++ b/config/migrations/2023/berichten-melding/20231024160202-berichten-centrum-data-in-vendor-graph_attachments.sparql
@@ -11,6 +11,7 @@ PREFIX dct:     <http://purl.org/dc/terms/>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 PREFIX account: <http://mu.semte.ch/vocabularies/account/>
 PREFIX core:    <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
 
 INSERT {
   GRAPH ?vendorGraph {
@@ -18,15 +19,16 @@ INSERT {
   }
 }
 WHERE {
+  GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+    <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
+      account:canActOnBehalfOf ?organisation ;
+      a ext:Vendor ;
+      core:uuid ?vendorUUID .
+  }
   GRAPH <http://mu.semte.ch/graphs/public> {
     ?organisation
       a besluit:Bestuurseenheid ;
       core:uuid ?organisationUUID .
-  }
-  GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
-    <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
-      account:canActOnBehalfOf ?organisation ;
-      core:uuid ?vendorUUID .
   }
   BIND (IRI(CONCAT("http://mu.semte.ch/graphs/vendors/", STR(?vendorUUID), "/", STR(?organisationUUID))) AS ?vendorGraph)
   BIND (IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", STR(?organisationUUID), "/LoketLB-berichtenGebruiker")) AS ?organisationGraph)

--- a/config/migrations/2023/berichten-melding/20231024160202-berichten-centrum-data-in-vendor-graph_attachments.sparql
+++ b/config/migrations/2023/berichten-melding/20231024160202-berichten-centrum-data-in-vendor-graph_attachments.sparql
@@ -24,7 +24,7 @@ WHERE {
       core:uuid ?organisationUUID .
   }
   GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
-    ?vendor
+    <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
       account:canActOnBehalfOf ?organisation ;
       core:uuid ?vendorUUID .
   }

--- a/config/migrations/2023/berichten-melding/20231024160203-berichten-centrum-data-in-vendor-graph_physical-attachments.sparql
+++ b/config/migrations/2023/berichten-melding/20231024160203-berichten-centrum-data-in-vendor-graph_physical-attachments.sparql
@@ -11,6 +11,7 @@ PREFIX dct:     <http://purl.org/dc/terms/>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 PREFIX account: <http://mu.semte.ch/vocabularies/account/>
 PREFIX core:    <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
 
 INSERT {
   GRAPH ?vendorGraph {
@@ -18,15 +19,16 @@ INSERT {
   }
 }
 WHERE {
+  GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+    <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
+      account:canActOnBehalfOf ?organisation ;
+      a ext:Vendor ;
+      core:uuid ?vendorUUID .
+  }
   GRAPH <http://mu.semte.ch/graphs/public> {
     ?organisation
       a besluit:Bestuurseenheid ;
       core:uuid ?organisationUUID .
-  }
-  GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
-    <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
-      account:canActOnBehalfOf ?organisation ;
-      core:uuid ?vendorUUID .
   }
   BIND (IRI(CONCAT("http://mu.semte.ch/graphs/vendors/", STR(?vendorUUID), "/", STR(?organisationUUID))) AS ?vendorGraph)
   BIND (IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", STR(?organisationUUID), "/LoketLB-berichtenGebruiker")) AS ?organisationGraph)

--- a/config/migrations/2023/berichten-melding/20231024160203-berichten-centrum-data-in-vendor-graph_physical-attachments.sparql
+++ b/config/migrations/2023/berichten-melding/20231024160203-berichten-centrum-data-in-vendor-graph_physical-attachments.sparql
@@ -24,7 +24,7 @@ WHERE {
       core:uuid ?organisationUUID .
   }
   GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
-    ?vendor
+    <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
       account:canActOnBehalfOf ?organisation ;
       core:uuid ?vendorUUID .
   }

--- a/config/migrations/2023/berichten-melding/20231024160204-berichten-centrum-data-in-vendor-graph_jobs.sparql
+++ b/config/migrations/2023/berichten-melding/20231024160204-berichten-centrum-data-in-vendor-graph_jobs.sparql
@@ -20,16 +20,16 @@ INSERT {
   }
 }
 WHERE {
-  GRAPH <http://mu.semte.ch/graphs/public> {
-    ?organisation
-      a besluit:Bestuurseenheid ;
-      core:uuid ?organisationUUID .
-  }
   GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
     <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
       account:canActOnBehalfOf ?organisation ;
       a ext:Vendor ;
       core:uuid ?vendorUUID .
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?organisation
+      a besluit:Bestuurseenheid ;
+      core:uuid ?organisationUUID .
   }
   BIND (IRI(CONCAT("http://mu.semte.ch/graphs/vendors/", STR(?vendorUUID), "/", STR(?organisationUUID))) AS ?vendorGraph)
   BIND (IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", STR(?organisationUUID), "/LoketLB-berichtenGebruiker")) AS ?organisationGraph)

--- a/config/migrations/2023/berichten-melding/20231024160204-berichten-centrum-data-in-vendor-graph_jobs.sparql
+++ b/config/migrations/2023/berichten-melding/20231024160204-berichten-centrum-data-in-vendor-graph_jobs.sparql
@@ -26,7 +26,7 @@ WHERE {
       core:uuid ?organisationUUID .
   }
   GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
-    ?vendor
+    <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
       account:canActOnBehalfOf ?organisation ;
       a ext:Vendor ;
       core:uuid ?vendorUUID .

--- a/config/vendor-data/subjectsAndPaths.js
+++ b/config/vendor-data/subjectsAndPaths.js
@@ -121,6 +121,8 @@ export const subjects = [
           <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url>
             ?bijlageDownloadLink .
       `,
+      //NOTE: the UNION/FILTER are deliberate query optimisations, with complicated explanation.
+      // So please be careful with them.
       where: `
         GRAPH ?g {
           ?subject
@@ -198,6 +200,8 @@ export const subjects = [
           <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url>
             ?bijlageDownloadLink .
       `,
+      //NOTE: the UNION/FILTER are deliberate query optimisations, with complicated explanation.
+      // So please be careful with them.
       where: `
         GRAPH ?g {
           ?conversatie
@@ -271,6 +275,8 @@ export const subjects = [
           <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url>
             ?bijlageDownloadLink .
       `,
+      //NOTE: the UNION/FILTER are deliberate query optimisations, with complicated explanation.
+      // So please be careful with them.
       where: `
         GRAPH ?g {
           ?conversatie

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,7 @@ services:
     restart: always
     logging: *default-logging
   berichtencentrum-sync-with-kalliope:
-    image: lblod/berichtencentrum-sync-with-kalliope-service:0.16.0
+    image: lblod/berichtencentrum-sync-with-kalliope-service:0.17.0
     environment:
       MU_SPARQL_ENDPOINT: "http://database:8890/sparql"
       MU_SPARQL_UPDATEPOINT: "http://database:8890/sparql"


### PR DESCRIPTION
Extra performance fixes:
 - sync with K: less taxing query for sending confirmations out
 - scoped migration per vendor; else it won't work on prod data.
 - -> this means that we'll have to run a migration if a vendor wants historical data when integration is needed.