### PR TITLE
Feature: subsidy attachments + meta ttl files sync

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -515,9 +515,10 @@ services:
     restart: always
     logging: *default-logging
   delta-files-share:
-    image: redpencil/file-share-sync:0.0.5
+    image: redpencil/file-share-sync:0.0.6
     volumes:
       - ./data/files:/share
+      - ./data/files/subsidies:/data # used to access meta ttl files
     environment:
       ALLOW_SUPER_CONSUMER: "true"
       ALLOWED_ACCOUNTS: "http://services.lblod.info/diff-consumer/account,http://data.lblod.info/foaf/account/id/dd85f516-ee7c-406b-8245-91ce7f9545b7,http://data.lblod.info/foaf/account/id/4171b7a5-a4d6-42d0-bf37-f97b135fb885"


### PR DESCRIPTION
 ## Description

Use latest file-share-sync-service once released. This allows us to sync over subsidy attachments, as well as meta ttl files to subsidiedatabank.

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## Related services

 - subsidiedatabank

 ## How to test

In Loket, use a local producer consumer setup. Create subsidies in loket and wait until they are synced over to subsidiedatabank. The subsidies should have downloaded over the attachments as well as the meta ttl files.

 ## Links to other PR's

 - https://github.com/redpencilio/file-share-sync-service/pull/4