### PR TITLE
Fix: Messages via Controle from ABB not correctly saved and distributed

### DIFF
--- a/config/vendor-data/subjectsAndPaths.js
+++ b/config/vendor-data/subjectsAndPaths.js
@@ -149,6 +149,8 @@ export const subjects = [
            } UNION {
              ?conversatie ?pc ?co .
            } UNION {
+             ?bericht ?pa ?ca .
+           } UNION {
              ?bijlage ?pb ?ob .
            } UNION {
              ?physicalBijlage ?pp ?op .
@@ -236,7 +238,6 @@ export const subjects = [
     }
   },
   //For Berichten saved in Loket
-  //TODO: Trigger is not yet working like this
   {
     type: 'http://schema.org/Message',
     trigger: `

--- a/config/vendor-data/subjectsAndPaths.js
+++ b/config/vendor-data/subjectsAndPaths.js
@@ -310,4 +310,80 @@ export const subjects = [
       `,
     }
   },
+  //For Berichten saved in Loket, but via Controle as if you were ABB
+  {
+    type: 'http://schema.org/Message',
+    trigger: `
+      ?subject
+        <http://mu.semte.ch/vocabularies/ext/creator>
+          <https://github.com/lblod/frontend-loket> ;
+        <http://schema.org/sender>
+          <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> .
+    `,
+    path: `
+      ?subject <http://schema.org/recipient> ?organisation.
+      ?organisation a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>.
+
+      ?vendor <http://mu.semte.ch/vocabularies/account/canActOnBehalfOf> ?organisation;
+        a <http://xmlns.com/foaf/0.1/Agent>.
+    `,
+    remove: {
+      delete: `
+        ?conversatie ?pc ?oc .
+      `,
+      where: `
+        GRAPH ?g {
+          ?conversatie
+            <http://schema.org/hasPart> ?subject ;
+            a <http://schema.org/Conversation> .
+        }
+        ?conversatie ?pc ?oc .
+      `,
+    },
+    copy: {
+      insert: `
+        ?subject ?p ?o .
+        ?conversatie ?pc ?co .
+        ?bijlage ?pb ?ob .
+        ?physicalBijlage ?pp ?op .
+
+        ?bijlage
+          <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url>
+            ?bijlageDownloadLink .
+      `,
+      //NOTE: the UNION/FILTER are deliberate query optimisations, with complicated explanation.
+      // So please be careful with them.
+      where: `
+        GRAPH ?g {
+          ?conversatie
+            <http://schema.org/hasPart> ?subject ;
+            a <http://schema.org/Conversation> .
+          ?subject
+            a <http://schema.org/Message> ;
+            <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart>
+              ?bijlage .
+          ?bijlage
+            a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject> ;
+            <http://mu.semte.ch/vocabularies/core/uuid> ?bijlageUUID .
+          ?physicalBijlage
+            a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject> ;
+            <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource>
+              ?bijlage .
+
+          BIND (CONCAT("${HOSTNAME}files/", STR(?bijlageUUID), "/download") AS ?bijlageDownloadLink)
+
+           {
+             ?subject ?p ?o .
+           } UNION {
+             ?conversatie ?pc ?co .
+           } UNION {
+             ?bijlage ?pb ?ob .
+           } UNION {
+             ?physicalBijlage ?pp ?op .
+           }
+        }
+        FILTER( REGEX(STR(?g), "LoketLB-berichtenGebruiker"))
+      `,
+    }
+  },
 ];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -469,7 +469,7 @@ services:
     restart: always
     logging: *default-logging
   berichtencentrum-melding:
-    image: lblod/berichten-melding-service:1.0.1
+    image: lblod/berichten-melding-service:1.0.2
     volumes:
       - ./data/files:/share
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   loket:
-    image: lblod/frontend-loket:0.87.6
+    image: lblod/frontend-loket:0.88.0
     links:
       - identifier:backend
     labels:


### PR DESCRIPTION
Saving a message in Loket from ABB (via Controle) was not done correctly. Sender and recipient were not always correct. In combination, the VDDS was not triggering correctly on those messages either. This meant that vendors did not see those messages in their vendor graph.

Fixed by adding config to the VDDS to also trigger on those messages from ABB and created by the Loket frontend. A new version of the frontend also fixes the sender and recipients for messages.

**TODO:**

* Review and release:

  - https://github.com/lblod/frontend-loket/pull/349
  - https://github.com/lblod/frontend-loket/pull/350

* Bump Loket frontend in this PR