### PR TITLE
Task: extend deadline oekraine slaapplekken

### DIFF
--- a/config/migrations/2023/subsidies/20231211111351-update-ukarine-opknapwerken-slaapplekken-deadline.sparql
+++ b/config/migrations/2023/subsidies/20231211111351-update-ukarine-opknapwerken-slaapplekken-deadline.sparql
@@ -1,0 +1,29 @@
+PREFIX m8g: <http://data.europa.eu/m8g/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+# Extend Deadline opknapwerken slaapplekken oekraine
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.info/id/subsidy-measure-offer-series/fecdeba8-cabb-43b0-a0a1-3ab7a1d4a773> dct:description ?description .
+
+    # End time for the Aanvraag step to be deleted
+    <http://data.lblod.info/id/periodes/cbc00fd0-0d0e-4c99-8dfc-691db7dde72d> m8g:endTime ?endTimeStep .
+
+    # End time for the SubsidiemaatregelAanbod to be deleted
+    <http://data.lblod.info/id/periodes/9e11f337-8575-4c8f-a9e5-34d7d91988da> m8g:endTime ?endTimeSubsidy .
+  }
+};
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Update period description
+    <http://lblod.data.info/id/subsidy-measure-offer-series/fecdeba8-cabb-43b0-a0a1-3ab7a1d4a773> dct:description "14/03/2022 — 31/05/2025"@nl .
+
+    # Time is set to 21:59:00 because Belgium time is UTC+2 instead of UTC+1 in May.
+    # End time for the Aanvraag step to be added is "31 May, 2025"
+    <http://data.lblod.info/id/periodes/cbc00fd0-0d0e-4c99-8dfc-691db7dde72d> m8g:endTime "2025-05-31T21:59:59Z"^^xsd:dateTime .
+    # End time for the SubsidiemaatregelAanbod to be added is "31 May, 2025"
+    <http://data.lblod.info/id/periodes/9e11f337-8575-4c8f-a9e5-34d7d91988da> m8g:endTime "2025-05-31T21:59:59Z"^^xsd:dateTime .
+  }
+}


### PR DESCRIPTION
## ID
 DGS-109

 ## Description

Change the deadline of Opknapwerken Slaapplekken Oekraïne to 31 mei 2025 (currently 31 mei 2024).

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Other


 ## How to test

 Run the migration and verify that the 'Opknapwerken Slaapplekken Oekraïne' subsidy now has a deadline of 31 mei 2025.