### PR TITLE
Task: update ukraine Nooddorpen deadline

### DIFF
--- a/config/migrations/2023/subsidies/20231206101224-update-ukraine-nooddorpen-deadline.sparql
+++ b/config/migrations/2023/subsidies/20231206101224-update-ukraine-nooddorpen-deadline.sparql
@@ -1,0 +1,26 @@
+PREFIX m8g: <http://data.europa.eu/m8g/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+# Extend Deadline Nooddorpen Oekraïne
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.info/id/subsidy-measure-offer-series/4a40d903-d77f-49e0-8cf4-daa3ce623439> dct:description ?description .
+
+    <http://data.lblod.info/id/periodes/5ecb1512-e8b3-40bf-a0c4-a4087090c093> m8g:endTime ?endTimeSubsidy .
+    <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c> m8g:endTime ?endTimeStep .
+  }
+};
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Update period
+    <http://lblod.data.info/id/subsidy-measure-offer-series/4a40d903-d77f-49e0-8cf4-daa3ce623439> dct:description "14/03/2022 — 31/05/2025"@nl .
+
+    # Time is set to 21:59:00 because Belgium time is UTC+2 instead of UTC+1 in May.
+    # Update endtime of subsidy
+    <http://data.lblod.info/id/periodes/5ecb1512-e8b3-40bf-a0c4-a4087090c093> m8g:endTime "2025-05-31T21:59:00Z"^^xsd:dateTime.
+    #Update endtime of the only step
+    <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c> m8g:endTime "2025-05-31T21:59:00Z"^^xsd:dateTime.
+  }
+}


### PR DESCRIPTION
## ID
 DGS-108

 ## Description

Change the deadline of Nooddorpen Oekraïne to 31 mei 2025 (currently 31 mei 2024).

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Other


 ## How to test

 Run the migration and verify that the 'Nooddorpen Oekraïne' subsidy now has a deadline of 31 mei 2025.