### PR TITLE
Task: update lekp 2.0 and 2.1 'opvolgmoment' step title

### DIFF
--- a/config/migrations/2023/subsidies/20231215101434-update-lekp-2.1-and-2-opvolgmoment-title-temporary.sparql
+++ b/config/migrations/2023/subsidies/20231215101434-update-lekp-2.1-and-2-opvolgmoment-title-temporary.sparql
@@ -1,0 +1,19 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+
+# Change opvolgmoment step title of LEKP 2.1 and 2.0 (temporary)
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    #2.1
+    <http://data.lblod.info/id/subsidy-procedural-steps/be1168a8-5131-4adb-a913-a4147bd8c6f5> dct:description ?description1 .
+    #2.0
+    <http://data.lblod.info/id/subsidy-procedural-steps/0567d95f-f5ce-4e7f-afda-02921386b5a8> dct:description ?description2 .
+  }
+};
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Update step description
+    <http://data.lblod.info/id/subsidy-procedural-steps/be1168a8-5131-4adb-a913-a4147bd8c6f5> dct:description "Opvolgmoment - gelieve in LEKP 1.0 in te dienen" .
+    <http://data.lblod.info/id/subsidy-procedural-steps/0567d95f-f5ce-4e7f-afda-02921386b5a8> dct:description "Opvolgmoment - gelieve in LEKP 1.0 in te dienen" .
+  }
+}

--- a/config/migrations/2023/subsidies/20231215101434-update-lekp-2.1-and-2-opvolgmoment-title-temporary.sparql
+++ b/config/migrations/2023/subsidies/20231215101434-update-lekp-2.1-and-2-opvolgmoment-title-temporary.sparql
@@ -13,7 +13,7 @@ DELETE WHERE {
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
     # Update step description
-    <http://data.lblod.info/id/subsidy-procedural-steps/be1168a8-5131-4adb-a913-a4147bd8c6f5> dct:description "Opvolgmoment - gelieve in LEKP 1.0 in te dienen" .
-    <http://data.lblod.info/id/subsidy-procedural-steps/0567d95f-f5ce-4e7f-afda-02921386b5a8> dct:description "Opvolgmoment - gelieve in LEKP 1.0 in te dienen" .
+    <http://data.lblod.info/id/subsidy-procedural-steps/be1168a8-5131-4adb-a913-a4147bd8c6f5> dct:description "Opvolgmoment (gelieve in LEKP 1.0 in te dienen)" .
+    <http://data.lblod.info/id/subsidy-procedural-steps/0567d95f-f5ce-4e7f-afda-02921386b5a8> dct:description "Opvolgmoment (gelieve in LEKP 1.0 in te dienen)" .
   }
 }


### PR DESCRIPTION
## ID
DGS-95

## Description

Since the opvolgmoment of LEKP 2.0 and 2.1 step have to be filled in in LEKP 1.0 and we don't have a solution to show this custom message (yet), we ended up changing the title of the step with this message temporarily.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How to test

Run the migration, visit the subsidies of LEKP 2.1 and 2.0. Their third step 'opvolgmoment' should now be called `Opvolgmoment - gelieve in LEKP 1.0 in te dienen`
