### PR TITLE
Task: update opvolgmoment 2024 lekp 1.0 deadline

### DIFF
--- a/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
+++ b/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
@@ -1,0 +1,20 @@
+PREFIX m8g: <http://data.europa.eu/m8g/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+# Update LEKP 1.0 Opvolgmoment 2024 deadline
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> m8g:endTime ?endTimeSubsidy .
+    <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> m8g:endTime ?endTimeStep .
+  }
+};
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Time is set to 21:59:00 because Belgium time is UTC+2 instead of UTC+1 in May.
+    # Update endtime of subsidy
+    <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime.
+    #Update endtime of the only step
+    <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime.
+  }
+}

--- a/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
+++ b/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
@@ -12,7 +12,7 @@ DELETE WHERE {
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
     # Time is set to 21:59:00 because Belgium time is UTC+2 instead of UTC+1 in May.
-    # Update endtime of subsidy
+    # Update endTime of subsidy
     <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime.
     # Update endTime of the only step
     <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime.

--- a/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
+++ b/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
@@ -2,19 +2,25 @@ PREFIX m8g: <http://data.europa.eu/m8g/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 # Update LEKP 1.0 Opvolgmoment 2024 deadline
-DELETE WHERE {
-  GRAPH <http://mu.semte.ch/graphs/public> {
-    <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> m8g:endTime ?endTimeSubsidy .
-    <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> m8g:endTime ?endTimeStep .
+DELETE {
+  GRAPH ?g {
+    ?s m8g:endTime ?endTimeSubsidy .
+    ?s m8g:endTime ?endTimeStep .
   }
-};
-
-INSERT DATA {
-  GRAPH <http://mu.semte.ch/graphs/public> {
+}
+INSERT {
+  GRAPH ?g {
     # Time is set to 21:59:00 because Belgium time is UTC+2 instead of UTC+1 in May.
-    # Update endTime of subsidy
-    <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime .
-    # Update endTime of the only step
-    <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime .
+    ?s m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?s {
+      <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> # LEKP 1.0 subsidy deadline
+      <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> # LEKP 1.0 Opvolgmoment 2024 step deadline
+    }
+    ?s m8g:endTime ?endTimeSubsidy.
+    ?s m8g:endTime ?endTimeStep .
   }
 }

--- a/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
+++ b/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
@@ -13,7 +13,7 @@ INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
     # Time is set to 21:59:00 because Belgium time is UTC+2 instead of UTC+1 in May.
     # Update endTime of subsidy
-    <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime.
+    <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime .
     # Update endTime of the only step
     <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime.
   }

--- a/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
+++ b/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
@@ -15,6 +15,6 @@ INSERT DATA {
     # Update endTime of subsidy
     <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime .
     # Update endTime of the only step
-    <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime.
+    <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime .
   }
 }

--- a/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
+++ b/config/migrations/2024/subsidies/20240109152003-update-opvolgmoment-2024-deadline.sparql
@@ -14,7 +14,7 @@ INSERT DATA {
     # Time is set to 21:59:00 because Belgium time is UTC+2 instead of UTC+1 in May.
     # Update endtime of subsidy
     <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime.
-    #Update endtime of the only step
+    # Update endTime of the only step
     <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> m8g:endTime "2024-05-01T21:59:00Z"^^xsd:dateTime.
   }
 }


### PR DESCRIPTION
## ID
DGS-122

## Description

Change deadline Opvolgmoment 2024 LEKP 1.0 from 1 maart 2024 to 1 mei 2024.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How to test

The opvolgmoment 2024 step in LEKP 1.0 is updated to 1 mei 2024.
