### PR TITLE
Add config overrides to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 docker-compose.override.yml
 .htpasswd
 .env
+
+# delta-producer-publication-graph-maintainer and delta-producer-background-jobs-initiator config overrides
+config/delta-producer/background-jobs-initiator/config.override.json
+config/delta-producer/publication-graph-maintainer/config.override.json


### PR DESCRIPTION
## Ticket Number

DL-5580

## Ticket Description

[This](https://github.com/lblod/delta-producer-publication-graph-maintainer/pull/24) and [this PR](https://github.com/lblod/delta-producer-background-jobs-initiator/pull/11) aim to add support for configuration overrides in `delta-producer-publication-graph-maintainer` and `delta-producer-background-jobs-initiator`.

The `config.override.json` files are setup specific and should be ignored by git.