### PR TITLE
Allowing besluitTypes "Niet-bindend advies op (statuten and oprichting)" to flow in Kalliope

### DIFF
--- a/config/berichtencentrum-sync-with-kalliope/config.json
+++ b/config/berichtencentrum-sync-with-kalliope/config.json
@@ -40,6 +40,8 @@
     "<https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c>",
     "<https://data.vlaanderen.be/id/concept/BesluitDocumentType/cc831628-95a0-4874-bad5-cdf563896032>",
     "<https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a>",
-    "<https://data.vlaanderen.be/id/concept/BesluitType/df483116-be05-4a2b-a68a-baf355c9bd81>"
+    "<https://data.vlaanderen.be/id/concept/BesluitType/df483116-be05-4a2b-a68a-baf355c9bd81>",
+    "<https://data.vlaanderen.be/id/concept/BesluitType/a2836d2f-1fee-4549-bd85-b9c13698b757>",
+    "<https://data.vlaanderen.be/id/concept/BesluitType/afdb7387-da47-4dc4-bbbe-e86ea5c3df28>"
   ]
 }


### PR DESCRIPTION
# Description

DL-5592

This PR enables the Kalliope flowthrough for two new forms `Niet-bindend advies op oprichting` & `Niet-bindend advies op statuten`


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- Berichtencentrum-sync-with-kalliope

# How to test 

- N/A

# What to check

- Typos, and form structure  

# Links to other PR's

- https://github.com/lblod/app-public-decisions-database/pull/22
- https://github.com/lblod/app-meldingsplichtige-api/pull/39
- https://github.com/lblod/app-toezicht-abb/pull/36
- https://github.com/lblod/app-digitaal-loket/pull/505
- https://github.com/lblod/manage-submission-form-tooling/pull/41

# Notes

- drc restart berichtencentrum-sync-with-kalliope