### PR TITLE
Add mock user rights for contact and verenigingen apps

### DIFF
--- a/config/migrations/2024/contact/20240116200259-add-contact-session-role-to-all-types-of-organizations.sparql
+++ b/config/migrations/2024/contact/20240116200259-add-contact-session-role-to-all-types-of-organizations.sparql
@@ -21,5 +21,5 @@ WHERE {
     foaf:account ?account .
 
   ?account a foaf:OnlineAccount ;
-    ext:sessionRole ?sessionRole .
+    foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service> .
 }

--- a/config/migrations/2024/contact/20240116200259-add-contact-session-role-to-all-types-of-organizations.sparql
+++ b/config/migrations/2024/contact/20240116200259-add-contact-session-role-to-all-types-of-organizations.sparql
@@ -1,0 +1,25 @@
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+
+#
+# Insert contact app session role for all types of
+# organizations. 
+#
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?account ext:sessionRole "abb_organisatieportaal_rol_3d" .
+  }
+}
+WHERE {
+  ?bestuurseenheid a besluit:Bestuurseenheid .
+
+  ?persoon a foaf:Person ;
+    foaf:member ?bestuurseenheid ;
+    foaf:account ?account .
+
+  ?account a foaf:OnlineAccount ;
+    ext:sessionRole ?sessionRole .
+}

--- a/config/migrations/2024/verenigingen/20240116200212-add-verenigingen-session-role-to-gemeenten.sparql
+++ b/config/migrations/2024/verenigingen/20240116200212-add-verenigingen-session-role-to-gemeenten.sparql
@@ -1,0 +1,26 @@
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+
+#
+# Insert verenigingen app session role only for
+# Gemeenten.
+#
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?account ext:sessionRole "abb_loketverenigingenapp" .
+  }
+}
+WHERE {
+  ?bestuurseenheid a besluit:Bestuurseenheid ;
+    besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> . # Gemeente
+
+  ?persoon a foaf:Person ;
+    foaf:member ?bestuurseenheid ;
+    foaf:account ?account .
+
+  ?account a foaf:OnlineAccount ;
+    ext:sessionRole ?sessionRole .
+}

--- a/config/migrations/2024/verenigingen/20240116200212-add-verenigingen-session-role-to-gemeenten.sparql
+++ b/config/migrations/2024/verenigingen/20240116200212-add-verenigingen-session-role-to-gemeenten.sparql
@@ -22,5 +22,5 @@ WHERE {
     foaf:account ?account .
 
   ?account a foaf:OnlineAccount ;
-    ext:sessionRole ?sessionRole .
+    foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service> .
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   loket:
-    image: lblod/frontend-loket:0.88.3
+    image: lblod/frontend-loket:0.89.0
     links:
       - identifier:backend
     labels:


### PR DESCRIPTION
## Ticket Number

DL-5599

## Ticket Description

The **Contact** and **Verenigingen** apps have been added to the frontend's development branch:
* [Contact PR](https://github.com/lblod/frontend-loket/pull/355)
* [Verenigingen PR](https://github.com/lblod/frontend-loket/pull/353)

This PR adds the `mock-login` session roles for these two apps.

## How to Test

You need to first run the development branch of the frontend (through `eds --proxy http://host:90` or `./node_modules/ember-cli/bin/ember --proxy http://host:90`) and apply the following diff:
```diff
diff --git a/config/environment.js b/config/environment.js
index a23357eb..390ba55c 100644
--- a/config/environment.js
+++ b/config/environment.js
@@ -34,11 +34,11 @@ module.exports = function (environment) {
     features: {
       // 'feature-name': '{{FEATURE_ENV_VAR_NAME}}',
     },
-    lpdcUrl: '{{LPDC_URL}}',
+    lpdcUrl: "https://test.lpdc.lokaalbestuur.lblod.info/",
     worshipDecisionsDatabaseUrl: '{{WORSHIP_DECISIONS_DATABASE_URL}}',
     worshipOrganisationsDatabaseUrl: '{{WORSHIP_ORGANISATIONS_DATABASE_URL}}',
-    verenigingenUrl: '{{VERENIGINGEN_URL}}',
-    contactUrl: '{{CONTACT_URL}}',
+    verenigingenUrl: "https://verenigingen-loket.lblod.info/",
+    contactUrl: "https://contactgegevens-loket.lblod.info/",
     'ember-plausible': {
       enabled: false,
     },
```

The diff above replaces the `{{URL}}` entries with the relevant QA URL of the external apps (The LPDC app was included to confirm that adding a URL will allow the card to display).

Once this is done, log in using different types of organizations:
* Only **Gemeenten** can see the **Verenigingen** app.
* **All types** of organizations can see the **Contact** app. 

## Note

If you run the frontend development branch, sign in to an organization, run the migrations + restarted resource/cache, and do not see the **Verenigingen** and **Contact** module cards, you have to sign out and back in for the changes to kick in.