### PR TITLE
Bump berichtencentrum-sync-with-kalliope to v0.18.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,7 @@ services:
     restart: always
     logging: *default-logging
   berichtencentrum-sync-with-kalliope:
-    image: lblod/berichtencentrum-sync-with-kalliope-service:0.17.2
+    image: lblod/berichtencentrum-sync-with-kalliope-service:0.18.0
     environment:
       MU_SPARQL_ENDPOINT: "http://database:8890/sparql"
       MU_SPARQL_UPDATEPOINT: "http://database:8890/sparql"


### PR DESCRIPTION
# Description
DL-5560
Sub stories -> DL-5561 - DL-5562 - DL-5563

This PR bumps berichtencentrum-sync-with-kalliope to v0.18.0 and add exclusion rules for worship submissions, see full change here : https://github.com/lblod/berichtencentrum-sync-with-kalliope-service/pull/12 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

- N/A

# What to check

- N/A

# Links to other PR's

- https://github.com/lblod/berichtencentrum-sync-with-kalliope-service/pull/12

# Notes

drc up -d berichtencentrum-sync-with-kalliope
