### PR TITLE
[DL-5624] Add a warning validation to the "Datum zitting" fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Subsidies
  - Add new stadsvernieuwing - conceptsubsidie || Oproep 2024 reeks (DGS-154)
 ### General
+#### Frontend
+ - Bump frontend to `v0.90.0`: https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0900-2024-02-09
 #### Backend
  - Consolidate `mandatarissen` delta flow (DL-5585, DL-5586)
  - Consolidate `leidinggevenden` delta flow (DL-5582, DL-5583)
@@ -20,6 +22,8 @@
    - `delta-producer-background-jobs-initiator-leidinggevenden`
    - `delta-producer-publication-graph-maintainer-mandatarissen`
    - `delta-producer-publication-graph-maintainer-leidinggevenden`
+#### Controle
+ - Update the version of the controle image in the docker-compose.override.yml file
 #### Docker commands
  - `drc up -d --remove-orphans`
  - `drc restart migrations dispatcher deltanotifier delta-producer-background-jobs-initiator delta-producer-publication-graph-maintainer delta-producer-dump-file-publisher`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
  - Consolidate `leidinggevenden` delta flow (DL-5582, DL-5583)
  - Move `delta-producer-dump-file-publisher` publication graph endpoint from `virtuoso` to `publication-triplestore` (DL-5584)
  - Added virus-scanner service (DL-5553)
+### Toezicht
+ - Add a future date warning validation to the "Datum zitting" fields (DL-5624)
 ### Deploy Notes
 #### Config Delta Mandatarissen & Leidinggevenden
 ##### Edit `config/delta-producer/background-jobs-initiator/config.json`

--- a/config/semantic-forms/20240110093200-forms.ttl
+++ b/config/semantic-forms/20240110093200-forms.ttl
@@ -314,7 +314,12 @@ fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb a form:Field ;
       [ a form:ValidDateTime ;
         form:grouping form:MatchEvery ;
         sh:path ( [ sh:inversePath prov:generated ] dct:subject [ sh:inversePath besluit:behandelt ]  prov:startedAtTime ) ;
-        sh:resultMessage "Geef een geldige datum en tijd op."] ;
+        sh:resultMessage "Geef een geldige datum en tijd op."],
+      [ a form:DateInPast ;
+        form:grouping form:MatchEvery ;
+        sh:path ( [ sh:inversePath prov:generated ] dct:subject [ sh:inversePath besluit:behandelt ]  prov:startedAtTime ) ;
+        sh:resultMessage "Let op: datum ligt in de toekomst. Controleer uw keuze." ;
+        sh:severity sh:Warning ] ;
     form:displayType displayTypes:dateTime ;
     sh:group fields:aDynamicPropertyGroup .
 
@@ -331,7 +336,12 @@ fields:ba965704-5a74-4a77-b283-4f97f3b7ddbc a form:Field ;
       [ a form:ValidDateTime ;
         form:grouping form:MatchEvery ;
         sh:path ( [ sh:inversePath besluit:heeftBesluitenlijst ] prov:startedAtTime ) ;
-        sh:resultMessage "Geef een geldige datum en tijd op."] ;
+        sh:resultMessage "Geef een geldige datum en tijd op."],
+      [ a form:DateInPast ;
+        form:grouping form:MatchEvery ;
+        sh:path ( [ sh:inversePath besluit:heeftBesluitenlijst ] prov:startedAtTime ) ;
+        sh:resultMessage "Let op: datum ligt in de toekomst. Controleer uw keuze." ;
+        sh:severity sh:Warning ] ;
     form:displayType displayTypes:dateTime ;
     sh:group fields:aDynamicPropertyGroup .
 
@@ -348,7 +358,12 @@ fields:857d670f-9a25-4555-bfe5-ecc48c2ffde3 a form:Field ;
       [ a form:ValidDateTime ;
         form:grouping form:MatchEvery ;
         sh:path ( [ sh:inversePath besluit:heeftNotulen ] prov:startedAtTime ) ;
-        sh:resultMessage "Geef een geldige datum en tijd op."] ;
+        sh:resultMessage "Geef een geldige datum en tijd op."],
+      [ a form:DateInPast ;
+        form:grouping form:MatchEvery ;
+        sh:path ( [ sh:inversePath besluit:heeftNotulen ] prov:startedAtTime ) ;
+        sh:resultMessage "Let op: datum ligt in de toekomst. Controleer uw keuze." ;
+        sh:severity sh:Warning ] ;
     form:displayType displayTypes:dateTime ;
     sh:group fields:aDynamicPropertyGroup .
 
@@ -365,7 +380,12 @@ fields:720c86f8-4537-44b0-850b-fb3452d8bb2d a form:Field ;
       [ a form:ValidDateTime ;
         form:grouping form:MatchEvery ;
         sh:path ( [ sh:inversePath besluit:heeftAgenda ] prov:startedAtTime ) ;
-        sh:resultMessage "Geef een geldige datum en tijd op."] ;
+        sh:resultMessage "Geef een geldige datum en tijd op."],
+      [ a form:DateInPast ;
+        form:grouping form:MatchEvery ;
+        sh:path ( [ sh:inversePath besluit:heeftAgenda ] prov:startedAtTime ) ;
+        sh:resultMessage "Let op: datum ligt in de toekomst. Controleer uw keuze." ;
+        sh:severity sh:Warning ] ;
     form:displayType displayTypes:dateTime ;
     sh:group fields:aDynamicPropertyGroup .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   loket:
-    image: lblod/frontend-loket:0.89.0
+    image: lblod/frontend-loket:0.90.0
     links:
       - identifier:backend
     labels:


### PR DESCRIPTION
This adds the `DateInPast` constraint to all "Datum zitting" fields and configures them as warnings.

This is the same change as https://github.com/lblod/manage-submission-form-tooling/pull/43 but directly to the current active form.

~~Needs https://github.com/lblod/frontend-loket/pull/358 to work properly.~~ (Part of the bundled v0.90.0 release now)

**To test:**
- start the stack
- access the bundled frontend and go to the toezicht module 
> The bundled frontend only works if you access it on localhost (or https), because of the [crypto.randomUUID()](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) util that is used by EmberData)
- create a new submission
- select a type of submission that has a `Datum zitting/ *` field. There are multiple versions of this field with a different label
- input a date in the future
- verify that the warning validation is displayed. It should look like this:
![image](https://github.com/lblod/app-digitaal-loket/assets/3533236/45dd29d1-cd6e-4d10-bdab-12d3ff20e16f)

- verify that the form can be submitted, even if the selected date is in the future