### PR TITLE
LEKP 1.0 - 2021 - Delete unneeded concept-schemes & form properties

### DIFF
--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
@@ -48,19 +48,5 @@
         ]
       }
     ]
-  },
-  "meta": {
-    "schemes": [
-      "http://lblod.data.gift/concept-schemes/33e233eb-6a9b-4141-b607-2ff72fe2ded2",
-      "http://lblod.data.gift/concepts/1df4b56a-3ccd-450d-93dc-317fda1ada38",
-      "http://lblod.data.gift/concepts/2697fbe1-4226-4325-807b-5dfa58e40a95",
-      "http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2",
-      "http://lblod.data.gift/concepts/5e52660c-9067-4d6f-b82c-c73ffd043401",
-      "http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2",
-      "http://lblod.data.gift/concept-schemes/dcfb437e-1219-4d1e-891d-057f262da9d6",
-      "http://lblod.data.gift/concept-schemes/dd44f316-7a30-45ab-b0f3-5dd642e0b6c7",
-      "http://lblod.data.gift/concept-schemes/2c0ec673-a430-4cd3-861d-8666991b790f",
-      "http://lblod.data.gift/concept-schemes/9a3f018b-6528-4abb-82d5-b7920d05a3da"
-    ]
   }
 }

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.json
@@ -37,19 +37,5 @@
         ]
       }
     ]
-  },
-  "meta": {
-    "schemes": [
-      "http://lblod.data.gift/concept-schemes/33e233eb-6a9b-4141-b607-2ff72fe2ded2",
-      "http://lblod.data.gift/concepts/1df4b56a-3ccd-450d-93dc-317fda1ada38",
-      "http://lblod.data.gift/concepts/2697fbe1-4226-4325-807b-5dfa58e40a95",
-      "http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2",
-      "http://lblod.data.gift/concepts/5e52660c-9067-4d6f-b82c-c73ffd043401",
-      "http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2",
-      "http://lblod.data.gift/concept-schemes/dcfb437e-1219-4d1e-891d-057f262da9d6",
-      "http://lblod.data.gift/concept-schemes/dd44f316-7a30-45ab-b0f3-5dd642e0b6c7",
-      "http://lblod.data.gift/concept-schemes/2c0ec673-a430-4cd3-861d-8666991b790f",
-      "http://lblod.data.gift/concept-schemes/9a3f018b-6528-4abb-82d5-b7920d05a3da"
-    ]
   }
 }

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
@@ -16,14 +16,15 @@
       "PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>"
     ],
     "properties": [
-      "dct:created",
-      "dct:modified",
-      "adms:status",
-      "ext:lastModifiedBy",
-      "dct:creator",
-      "pav:createdBy",
-      "lblodSubsidie:populationCount",
-      "lblodSubsidie:totaleDrawingRights",
+      {
+        "s-prefix": "schema:contactPoint",
+        "properties": [
+          "foaf:firstName",
+          "foaf:familyName",
+          "schema:telephone",
+          "schema:email"
+        ]
+      },
       {
         "s-prefix": "lblodSubsidie:signedPact",
         "properties": [
@@ -34,30 +35,7 @@
             ]
           }
         ]
-      },
-      {
-        "s-prefix": "schema:contactPoint",
-        "properties": [
-          "foaf:firstName",
-          "foaf:familyName",
-          "schema:telephone",
-          "schema:email"
-        ]
       }
-    ]
-  },
-  "meta": {
-    "schemes": [
-      "http://lblod.data.gift/concept-schemes/33e233eb-6a9b-4141-b607-2ff72fe2ded2",
-      "http://lblod.data.gift/concepts/1df4b56a-3ccd-450d-93dc-317fda1ada38",
-      "http://lblod.data.gift/concepts/2697fbe1-4226-4325-807b-5dfa58e40a95",
-      "http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2",
-      "http://lblod.data.gift/concepts/5e52660c-9067-4d6f-b82c-c73ffd043401",
-      "http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2",
-      "http://lblod.data.gift/concept-schemes/dcfb437e-1219-4d1e-891d-057f262da9d6",
-      "http://lblod.data.gift/concept-schemes/dd44f316-7a30-45ab-b0f3-5dd642e0b6c7",
-      "http://lblod.data.gift/concept-schemes/2c0ec673-a430-4cd3-861d-8666991b790f",
-      "http://lblod.data.gift/concept-schemes/9a3f018b-6528-4abb-82d5-b7920d05a3da"
     ]
   }
 }

--- a/config/subsidy-application-management/forms/climate/step-submit-proposal/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-proposal/versions/20210420172044/form.json
@@ -17,12 +17,6 @@
       "PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>"
     ],
     "properties": [
-      "dct:created",
-      "dct:modified",
-      "adms:status",
-      "ext:lastModifiedBy",
-      "dct:creator",
-      "pav:createdBy",
       "lblodSubsidie:populationCount",
       "lblodSubsidie:totaleDrawingRights",
       {
@@ -41,20 +35,6 @@
           }
          ]
        }
-    ]
-  },
-  "meta": {
-    "schemes": [
-      "http://lblod.data.gift/concept-schemes/33e233eb-6a9b-4141-b607-2ff72fe2ded2",
-      "http://lblod.data.gift/concepts/1df4b56a-3ccd-450d-93dc-317fda1ada38",
-      "http://lblod.data.gift/concepts/2697fbe1-4226-4325-807b-5dfa58e40a95",
-      "http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2",
-      "http://lblod.data.gift/concepts/5e52660c-9067-4d6f-b82c-c73ffd043401",
-      "http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2",
-      "http://lblod.data.gift/concept-schemes/dcfb437e-1219-4d1e-891d-057f262da9d6",
-      "http://lblod.data.gift/concept-schemes/dd44f316-7a30-45ab-b0f3-5dd642e0b6c7",
-      "http://lblod.data.gift/concept-schemes/2c0ec673-a430-4cd3-861d-8666991b790f",
-      "http://lblod.data.gift/concept-schemes/9a3f018b-6528-4abb-82d5-b7920d05a3da"
     ]
   }
 }


### PR DESCRIPTION
## ID
 DGS-144

 ## Description

While updating extractor I stumbled across some issues because too many properties where defined in the form its json file. 

- too many properties cause unstable extractor behaviour (specifically adms:status)
- concept-schemes defined in meta get fetched but are never used

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Other

 ## How to test

Best to test both with local and with remote data. 
- setup the app
- create a LEKP 1.0 - 2021 subsidy
- fill in the form and all its values
- save, reload and navigate around a bit 
- check if all data is loading in correctly and nothing odd is happening
