### PR TITLE
The filesGraph should not be specified or specified to public graph

### DIFF
--- a/config/delta-producer/publication-graph-maintainer/config.json
+++ b/config/delta-producer/publication-graph-maintainer/config.json
@@ -89,7 +89,6 @@
     "healingInitialBatchSizeInsert": 1000,
     "updatePublicationGraphSleep": 200,
     "publicationGraph": "http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer",
-    "filesGraph": "http://redpencil.data.gift/id/deltas/producer/leidinggevenden-deltas",
     "loginPath": "/leidinggevenden/login"
   }
 }


### PR DESCRIPTION
So I think it was an authorization issue. Here the files are public; so should be written to the public graph. Omitting that field will default to the public graph.  (note the same will be for mandatarissen)

For further reference; if you want quick testing from certain timestamp at the consumer; that won't work; it's an old version.
So just do the following update in the database of the consumer
```
    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
    PREFIX dct: <http://purl.org/dc/terms/>

    DELETE {
      GRAPH ?g {
        ?s ext:deltaUntil ?latestDelta .
      }
    }
    INSERT {
      GRAPH ?g {
        ?s ext:deltaUntil "2024-01-30T15:13:56.614Z"^^xsd:dateTime . # your timestamp here
      }
    }
    WHERE {
      GRAPH ?g {
        ?s a ext:SyncTask ;
          dct:creator <http://data.lblod.info/services/id/leidinggevenden-consumer> ;
          ext:deltaUntil ?latestDelta .
      }
    } ORDER BY DESC(?latestDelta) LIMIT 1
```

Also: consumer seemed broken on my machine, had something to do with docker or so; anyway; if the consumer crashes on start try with this image `image: lblod/delta-consumer-single-graph-maintainer:0.5.0` (we'll need maintenance one day of this app but now now)