### PR TITLE
Add LEKP 1.0 (2021) types via extractor

### DIFF
--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -24,6 +24,25 @@
       "properties": [
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
         "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName",
+        "http://purl.org/dc/terms/format",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize",
+        "http://dbpedia.org/ontology/fileExtension",
+        "http://purl.org/dc/terms/created",
+        "http://purl.org/dc/terms/modified",
+        "http://purl.org/dc/terms/type",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
         "http://purl.org/dc/terms/description",
         "http://data.europa.eu/m8g/role"
       ],
@@ -114,7 +133,89 @@
         "http://www.w3.org/ns/adms#status",
         "http://schema.org/bankAccount",
         "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/unresolvedSocialProblems",
-        "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/usesSocialImpactBound"
+        "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/usesSocialImpactBound",
+        "http://lblod.data.gift/vocabularies/subsidie/projectName",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#identifier",
+        "http://lblod.data.gift/vocabularies/subsidie/picturesUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#estimatedCostTable",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveTable",
+        "http://lblod.data.gift/vocabularies/subsidie/timeBlock",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidyMeasure",
+        "http://lblod.data.gift/vocabularies/subsidie/decisionUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/accountabilityNoteUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/reportUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/justificationExpropriationsUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/justificationCostsUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/invoiceUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/awardReportUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/attachment",
+        "http://lblod.data.gift/vocabularies/subsidie/signedPact",
+        "http://lblod.data.gift/vocabularies/subsidie/climateTable",
+        "http://purl.org/pav/createdBy",
+        "http://lblod.data.gift/vocabularies/subsidie/isCollaboration",
+        "http://lblod.data.gift/vocabularies/subsidie/collaborator",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresNovember",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresDecember",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresJanuary",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresFebruary",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresMarch",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresApril",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresMay",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresJune",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresJuly",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresAugust",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresSeptember",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresOctober",
+        "http://lblod.data.gift/vocabularies/subsidie/estimatedExtraCosts",
+        "http://lblod.data.gift/vocabularies/subsidie/focusedPopulation",
+        "http://lblod.data.gift/vocabularies/subsidie/focusedPopulationAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/typesOfContacts",
+        "http://lblod.data.gift/vocabularies/subsidie/typesOfContactsAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/preventionMethods",
+        "http://lblod.data.gift/vocabularies/subsidie/preventionMethodsAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/sourceDetectionActions",
+        "http://lblod.data.gift/vocabularies/subsidie/sourceDetectionActionsAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/quarantaineCoachingMethods",
+        "http://lblod.data.gift/vocabularies/subsidie/quarantaineCoachingMethodsAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/vulnerableGroupsHelp",
+        "http://lblod.data.gift/vocabularies/subsidie/vulnerableGroupsHelpAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveOne",
+        "http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveTwo",
+        "http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveThree",
+        "http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveFour",
+        "http://lblod.data.gift/vocabularies/subsidie/EngagementTable",
+        "http://lblod.data.gift/vocabularies/subsidie/amount",
+        "http://lblod.data.gift/vocabularies/subsidie/currentEInclusionActions",
+        "http://lblod.data.gift/vocabularies/subsidie/actionShortDescription",
+        "http://lblod.data.gift/vocabularies/subsidie/actionFullDescription",
+        "http://lblod.data.gift/vocabularies/subsidie/targetedAudience",
+        "http://lblod.data.gift/vocabularies/subsidie/targetedAudienceOther",
+        "http://lblod.data.gift/vocabularies/subsidie/hasAdditionalAction",
+        "http://lblod.data.gift/vocabularies/subsidie/usedParentalContribution",
+        "http://lblod.data.gift/vocabularies/subsidie/uniqueChildrenNumberForWholePeriod",
+        "http://lblod.data.gift/vocabularies/subsidie/daysOfChildcareForWholePeriod",
+        "http://lblod.data.gift/vocabularies/subsidie/userDeclaresDataIsExact",
+        "http://lblod.data.gift/vocabularies/subsidie/userCompliesWithEmergencyChildcareConditions",
+        "http://lblod.data.gift/vocabularies/subsidie/ApplicationFormTable",
+        "http://lblod.data.gift/vocabularies/subsidie/projectStartDate",
+        "http://lblod.data.gift/vocabularies/subsidie/projectEndDate",
+        "http://lblod.data.gift/vocabularies/subsidie/totalAmount",
+        "http://lblod.data.gift/vocabularies/subsidie/projectType",
+        "http://lblod.data.gift/vocabularies/subsidie/accountabilitySummary",
+        "http://lblod.data.gift/vocabularies/subsidie/accountabilityProof",
+        "http://lblod.data.gift/vocabularies/subsidie/urbanRenewalApplicationForm",
+        "http://lblod.data.gift/vocabularies/subsidie/urbanRenewalAttachments",
+        "http://mu.semte.ch/vocabularies/ext/samenvattingSummaryDescription",
+        "http://mu.semte.ch/vocabularies/ext/schetsDeKwaliteitDescription",
+        "http://mu.semte.ch/vocabularies/ext/ProjectorganisatieEnRegiefunctieDescription",
+        "http://mu.semte.ch/vocabularies/ext/BeschrijfParticipatieCommunicatieInteractieDescription",
+        "http://mu.semte.ch/vocabularies/ext/ProjectfaseringMetProjectverloopTimingEnRisicobeheerDescription",
+        "http://mu.semte.ch/vocabularies/ext/AanvraagSubsidieEnBetekenisVoorStadsvernieuwingsprojectDescription",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragAanvraag",
+        "http://mu.semte.ch/vocabularies/ext/politicalReferenceContactPoint",
+        "http://mu.semte.ch/vocabularies/ext/FinancingPartner",
+        "http://lblod.data.gift/vocabularies/projectOnderdeelUnit",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragListingUnit"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
@@ -146,8 +247,7 @@
         "http://www.w3.org/2004/02/skos/core#related"
       ],
       "graphsFilter": [
-        "http://mu.semte.ch/graphs/public",
-        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+        "http://mu.semte.ch/graphs/public"
       ],
       "type": "http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelAanbod"
     },
@@ -157,7 +257,6 @@
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://lblod.data.gift/vocabularies/subsidie/heeftSubsidieprocedurestap",
         "http://www.w3.org/2007/uwa/context/common.owl#active",
-        "http://www.w3.org/2004/02/skos/core#prefLabel",
         "http://purl.org/dc/terms/description",
         "http://purl.org/dc/terms/title",
         "http://data.europa.eu/m8g/startTime",
@@ -165,8 +264,7 @@
         "http://purl.org/vocab/cpsv#follows"
       ],
       "graphsFilter": [
-        "http://mu.semte.ch/graphs/public",
-        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+        "http://mu.semte.ch/graphs/public"
       ],
       "type": "http://lblod.data.gift/vocabularies/subsidie/SubsidiemaatregelAanbodReeks"
     },
@@ -191,7 +289,8 @@
         "http://rdf-vocabulary.ddialliance.org/xkos#previous",
         "http://purl.org/dc/terms/isPartOf",
         "http://purl.org/dc/terms/source",
-        "http://purl.org/linked-data/cube#order"
+        "http://purl.org/linked-data/cube#order",
+        "http://purl.org/dc/terms/isReplacedBy"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/public"
@@ -214,7 +313,6 @@
     {
       "properties": [
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-        "http://mu.semte.ch/vocabularies/core/uuid",
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://data.europa.eu/m8g/endTime",
         "http://data.europa.eu/m8g/startTime"
@@ -288,40 +386,476 @@
       "properties": [
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
         "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName",
-        "http://purl.org/dc/terms/format",
-        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize",
-        "http://dbpedia.org/ontology/fileExtension",
-        "http://purl.org/dc/terms/created",
-        "http://purl.org/dc/terms/modified",
-        "http://purl.org/dc/terms/type",
-        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
-        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url"
+        "http://schema.org/email",
+        "http://schema.org/telephone",
+        "http://schema.org/url",
+        "http://schema.org/openingHours",
+        "http://schema.org/jobTitle",
+        "http://www.w3.org/ns/locn#address",
+        "http://www.w3.org/ns/shacl#order",
+        "http://xmlns.com/foaf/0.1/firstName",
+        "http://xmlns.com/foaf/0.1/familyName"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
       ],
-      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject"
+      "type": "http://schema.org/ContactPoint"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/decision-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/pictures-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/report-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/award-report-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/accountability-note-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-costs-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-expropriations-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/invoice-upload/FormData"
     },
     {
       "properties": [
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
         "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url",
-        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName",
-        "http://purl.org/dc/terms/format",
-        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize",
-        "http://dbpedia.org/ontology/fileExtension",
-        "http://purl.org/dc/terms/created",
-        "http://purl.org/dc/terms/modified",
-        "http://purl.org/dc/terms/type",
-        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
-        "http://www.w3.org/ns/adms#status"
+        "http://schema.org/identifier",
+        "http://purl.org/dc/terms/hasPart"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
       ],
-      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject"
+      "type": "http://schema.org/BankAccount"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#validEstimatedCostTable",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#estimatedCostEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#EstimatedCostTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://mu.semte.ch/vocabularies/ext/index",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#costEstimationType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#cost",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#share"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#EstimatedCostEntry"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#validObjectiveTable",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#ObjectiveTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#approachType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#directionType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#bikeLaneType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#kilometers"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#ObjectiveEntry"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/climate/attachment/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/climate/signed-pact/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/validClimateTable",
+        "http://lblod.data.gift/vocabularies/subsidie/totalBudgettedAmount",
+        "http://data.lblod.info/vocabularies/subsidie/climate/climateEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/ClimateTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://data.lblod.info/vocabularies/subsidie/climate/actionDescription",
+        "http://data.lblod.info/vocabularies/subsidie/climate/toRealiseUnits",
+        "http://data.lblod.info/vocabularies/subsidie/climate/costPerUnit",
+        "http://data.lblod.info/vocabularies/subsidie/climate/restitution",
+        "http://data.lblod.info/vocabularies/subsidie/climate/amountPerAction",
+        "http://data.lblod.info/vocabularies/subsidie/climate/customAction",
+        "http://data.lblod.info/vocabularies/subsidie/climate/customDescription",
+        "http://purl.org/linked-data/cube#order"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://data.lblod.info/vocabularies/subsidie/climate/ClimateEntry"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://lblod.data.gift/vocabularies/subsidie/priority",
+        "http://purl.org/dc/terms/description"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-one/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://lblod.data.gift/vocabularies/subsidie/priority",
+        "http://purl.org/dc/terms/description"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-two/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://lblod.data.gift/vocabularies/subsidie/priority",
+        "http://purl.org/dc/terms/description"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-three/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://lblod.data.gift/vocabularies/subsidie/priority",
+        "http://purl.org/dc/terms/description"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-four/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://mu.semte.ch/vocabularies/ext/engagementEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/EngagementTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://mu.semte.ch/vocabularies/ext/existingStaff",
+        "http://mu.semte.ch/vocabularies/ext/additionalStaff",
+        "http://mu.semte.ch/vocabularies/ext/volunteers"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://mu.semte.ch/vocabularies/ext/EngagementEntry"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/additionalActionType",
+        "http://lblod.data.gift/vocabularies/subsidie/additionalActionShortDescription",
+        "http://lblod.data.gift/vocabularies/subsidie/additionalActionFullDescription",
+        "http://lblod.data.gift/vocabularies/subsidie/additionalActionTargetedAudience",
+        "http://lblod.data.gift/vocabularies/subsidie/additionalActionTargetedAudienceOther"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/additonalAction"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://mu.semte.ch/vocabularies/ext/applicationFormEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/ApplicationFormTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://mu.semte.ch/vocabularies/ext/actorName",
+        "http://mu.semte.ch/vocabularies/ext/numberChildrenPerInfrastructure",
+        "http://mu.semte.ch/vocabularies/ext/numberChildrenForFullDay",
+        "http://mu.semte.ch/vocabularies/ext/numberChildrenForHalfDay",
+        "http://purl.org/dc/terms/created"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://mu.semte.ch/vocabularies/ext/ApplicationFormEntry"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/ukraine-nooddorpen/accountability-summary/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/ukraine-nooddorpen/accountability-proof/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/urban-renewal/urban-renewal-application-form/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/urban-renewal/urban-renewal-attachments/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://xmlns.com/foaf/0.1/firstName",
+        "http://xmlns.com/foaf/0.1/familyName",
+        "http://schema.org/telephone",
+        "http://schema.org/email",
+        "http://schema.org/jobTitle"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://mu.semte.ch/vocabularies/ext/PoliticalReferenceContactPoint"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://mu.semte.ch/vocabularies/ext/partnerTitle",
+        "http://mu.semte.ch/vocabularies/ext/partnerType",
+        "http://mu.semte.ch/vocabularies/ext/financingAmount"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://mu.semte.ch/vocabularies/ext/FinancingPartner"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelNaam",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelBeschrijving",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelTimingUnit",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelStadUnit",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPubliekePartnerListingUnit",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPrivatePartnerListingUnit"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelUnit"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelTimingListingUnitBeschrijving",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelTimingListingUnitStartDatum",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelTimingListingUnitEindDatum"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelTimingUnit"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelStadListingUnitAandeel",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelStadListingUnitBedrag"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelStadUnit"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPubliekePartnerListingUnitNaam",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPubliekePartnerListingUnitBedrag"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPubliekePartnerListingUnit"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPrivatePartnerListingNaam",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPrivatePartnerListingBedrag"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPrivatePartnerListingUnit"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragListingUnitNaam",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragListingUnitMotivering",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragListingUnitBedrag"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragListingUnit"
     }
   ]
 }

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -149,6 +149,7 @@
         "http://lblod.data.gift/vocabularies/subsidie/invoiceUpload",
         "http://lblod.data.gift/vocabularies/subsidie/awardReportUpload",
         "http://lblod.data.gift/vocabularies/subsidie/attachment",
+        "http://lblod.data.gift/vocabularies/subsidie/attachmentLEKPReport",
         "http://lblod.data.gift/vocabularies/subsidie/signedPact",
         "http://lblod.data.gift/vocabularies/subsidie/climateTable",
         "http://purl.org/pav/createdBy",

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/extractors/contact-info-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/extractors/contact-info-extractor.js
@@ -9,6 +9,7 @@ module.exports = {
 
     const {$rdf, mu, sudo} = lib;
 
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
     const SCHEMA = new $rdf.Namespace('http://schema.org/');
     const FOAF = new $rdf.Namespace('http://xmlns.com/foaf/0.1/');
 
@@ -18,6 +19,12 @@ module.exports = {
         $rdf.sym(target.uri),
         SCHEMA('contactPoint'),
         $rdf.sym(contactPoint),
+        graphs.additions);
+
+    store.add(
+        $rdf.sym(contactPoint), 
+        RDF_TYPE, 
+        SCHEMA('ContactPoint'), 
         graphs.additions);
 
     const {firstName, familyName, email, telephone} =

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/extractors/missing-types-extractor.js
@@ -1,0 +1,21 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate/step-submit-opvolgmoment-2024/missing-types-extractor',
+  execute: async (store, graphs, lib, source) => {
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
+    const ATTACHMENT = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/climate/attachment/');
+
+    const attachment = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const attachmentLEKPReport = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('attachment'), $rdf.sym(attachment), graphs.additions);
+    store.add($rdf.sym(attachment), RDF_TYPE, ATTACHMENT('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('attachmentLEKPReport'), $rdf.sym(attachmentLEKPReport), graphs.additions);
+    store.add($rdf.sym(attachmentLEKPReport), RDF_TYPE, ATTACHMENT('FormData'), graphs.additions);
+  }
+}

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/index.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/index.js
@@ -1,4 +1,5 @@
 const contactInfoExtractor = require('./extractors/contact-info-extractor');
+const missingTypesExtractor = require('./extractors/missing-types-extractor');
 
 const extractor = {
   name: 'climate-subsidy/opvolgmoment/first-step-as-source',
@@ -46,4 +47,4 @@ async function findFormFromStep1( { mu, sudo }, form ) {
   return results.bindings[0].firstForm.value;
 }
 
-module.exports = [ extractor ];
+module.exports = [ extractor, missingTypesExtractor ];

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
@@ -19,6 +19,7 @@
       {
         "s-prefix": "schema:contactPoint",
         "properties": [
+          "rdf:type",
           "foaf:firstName",
           "foaf:familyName",
           "schema:telephone",
@@ -28,6 +29,7 @@
       {
         "s-prefix": "lblodSubsidie:attachment",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -39,6 +41,7 @@
       {
         "s-prefix": "lblodSubsidie:attachmentLEKPReport",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
@@ -48,19 +48,5 @@
         ]
       }
     ]
-  },
-  "meta": {
-    "schemes": [
-      "http://lblod.data.gift/concept-schemes/33e233eb-6a9b-4141-b607-2ff72fe2ded2",
-      "http://lblod.data.gift/concepts/1df4b56a-3ccd-450d-93dc-317fda1ada38",
-      "http://lblod.data.gift/concepts/2697fbe1-4226-4325-807b-5dfa58e40a95",
-      "http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2",
-      "http://lblod.data.gift/concepts/5e52660c-9067-4d6f-b82c-c73ffd043401",
-      "http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2",
-      "http://lblod.data.gift/concept-schemes/dcfb437e-1219-4d1e-891d-057f262da9d6",
-      "http://lblod.data.gift/concept-schemes/dd44f316-7a30-45ab-b0f3-5dd642e0b6c7",
-      "http://lblod.data.gift/concept-schemes/2c0ec673-a430-4cd3-861d-8666991b790f",
-      "http://lblod.data.gift/concept-schemes/9a3f018b-6528-4abb-82d5-b7920d05a3da"
-    ]
   }
 }

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.ttl
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.ttl
@@ -134,7 +134,7 @@ fields:f6f972c0-e796-42e8-87c1-c689dab0a690 a form:Field ;
         [ a form:RequiredConstraint ;
             form:grouping form:Bag ;
             sh:resultMessage "Dit veld is verplicht."@nl ;
-            sh:path lblodSubsidie:attachment
+            sh:path ( lblodSubsidie:attachment dct:hasPart )
         ] ;
     form:displayType displayTypes:files ;
     sh:group fields:70f45080-8a18-473f-bb3f-abf6ce9c678e .

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/extractors/contact-info-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/extractors/contact-info-extractor.js
@@ -9,6 +9,7 @@ module.exports = {
 
     const {$rdf, mu, sudo} = lib;
 
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
     const SCHEMA = new $rdf.Namespace('http://schema.org/');
     const FOAF = new $rdf.Namespace('http://xmlns.com/foaf/0.1/');
 
@@ -18,6 +19,12 @@ module.exports = {
         $rdf.sym(target.uri),
         SCHEMA('contactPoint'),
         $rdf.sym(contactPoint),
+        graphs.additions);
+
+    store.add(
+        $rdf.sym(contactPoint), 
+        RDF_TYPE, 
+        SCHEMA('ContactPoint'), 
         graphs.additions);
 
     const {firstName, familyName, email, telephone} =

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/extractors/missing-types-extractor.js
@@ -1,0 +1,17 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate/step-submit-opvolgmoment/missing-types-extractor',
+  execute: async (store, graphs, lib, source) => {
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
+    const ATTACHMENT = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/climate/attachment/');
+
+    const attachment = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('attachment'), $rdf.sym(attachment), graphs.additions);
+    store.add($rdf.sym(attachment), RDF_TYPE, ATTACHMENT('FormData'), graphs.additions);
+  }
+}

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/index.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/index.js
@@ -1,4 +1,5 @@
 const contactInfoExtractor = require('./extractors/contact-info-extractor');
+const missingTypesExtractor = require('./extractors/missing-types-extractor');
 
 const extractor = {
   name: 'climate-subsidy/opvolgmoment/first-step-as-source',
@@ -45,4 +46,4 @@ async function findFormFromStep1( { mu, sudo }, form ) {
   return results.bindings[0].firstForm.value;
 }
 
-module.exports = [ extractor ];
+module.exports = [ extractor, missingTypesExtractor  ];

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.json
@@ -19,6 +19,7 @@
       {
         "s-prefix": "schema:contactPoint",
         "properties": [
+          "rdf:type",
           "foaf:firstName",
           "foaf:familyName",
           "schema:telephone",
@@ -28,6 +29,7 @@
       {
         "s-prefix": "lblodSubsidie:attachment",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.json
@@ -37,19 +37,5 @@
         ]
       }
     ]
-  },
-  "meta": {
-    "schemes": [
-      "http://lblod.data.gift/concept-schemes/33e233eb-6a9b-4141-b607-2ff72fe2ded2",
-      "http://lblod.data.gift/concepts/1df4b56a-3ccd-450d-93dc-317fda1ada38",
-      "http://lblod.data.gift/concepts/2697fbe1-4226-4325-807b-5dfa58e40a95",
-      "http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2",
-      "http://lblod.data.gift/concepts/5e52660c-9067-4d6f-b82c-c73ffd043401",
-      "http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2",
-      "http://lblod.data.gift/concept-schemes/dcfb437e-1219-4d1e-891d-057f262da9d6",
-      "http://lblod.data.gift/concept-schemes/dd44f316-7a30-45ab-b0f3-5dd642e0b6c7",
-      "http://lblod.data.gift/concept-schemes/2c0ec673-a430-4cd3-861d-8666991b790f",
-      "http://lblod.data.gift/concept-schemes/9a3f018b-6528-4abb-82d5-b7920d05a3da"
-    ]
   }
 }

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.ttl
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.ttl
@@ -134,7 +134,7 @@ fields:f6f972c0-e796-42e8-87c1-c689dab0a690 a form:Field ;
         [ a form:RequiredConstraint ;
             form:grouping form:Bag ;
             sh:resultMessage "Dit veld is verplicht."@nl ;
-            sh:path lblodSubsidie:attachment
+            sh:path ( lblodSubsidie:attachment dct:hasPart )
         ] ;
     form:displayType displayTypes:files ;
     sh:group fields:70f45080-8a18-473f-bb3f-abf6ce9c678e .

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/extractors/missing-types-extractor.js
@@ -8,7 +8,7 @@ module.exports = {
     const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
     const SCHEMA = new $rdf.Namespace('http://schema.org/');
     const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
-    const PACT = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/climate/signed-pact/');
+    const SIGNED_PACT = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/climate/signed-pact/');
 
 
     const contactPoint = new $rdf.NamedNode(URI_BASE + mu.uuid());
@@ -19,6 +19,6 @@ module.exports = {
     store.add($rdf.sym(contactPoint), RDF_TYPE, SCHEMA('ContactPoint'), graphs.additions);
 
     store.add($rdf.sym(source.uri), SUBSIDIE('signedPact'), $rdf.sym(signedPact), graphs.additions);
-    store.add($rdf.sym(signedPact), RDF_TYPE, PACT('FormData'), graphs.additions);
+    store.add($rdf.sym(signedPact), RDF_TYPE, SIGNED_PACT('FormData'), graphs.additions);
   }
 }

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/extractors/missing-types-extractor.js
@@ -1,0 +1,24 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate/step-submit-pact/missing-types-extractor',
+  execute: async (store, graphs, lib, source) => {
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SCHEMA = new $rdf.Namespace('http://schema.org/');
+    const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
+    const PACT = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/climate/signed-pact/');
+
+
+    const contactPoint = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const signedPact = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+
+    store.add($rdf.sym(source.uri), SCHEMA('contactPoint'), $rdf.sym(contactPoint), graphs.additions);
+    store.add($rdf.sym(contactPoint), RDF_TYPE, SCHEMA('ContactPoint'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('signedPact'), $rdf.sym(signedPact), graphs.additions);
+    store.add($rdf.sym(signedPact), RDF_TYPE, PACT('FormData'), graphs.additions);
+  }
+}

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/index.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/index.js
@@ -1,0 +1,3 @@
+const missingTypesExtractor = require('./extractors/missing-types-extractor');
+
+module.exports = [ missingTypesExtractor ];

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
@@ -16,14 +16,15 @@
       "PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>"
     ],
     "properties": [
-      "dct:created",
-      "dct:modified",
-      "adms:status",
-      "ext:lastModifiedBy",
-      "dct:creator",
-      "pav:createdBy",
-      "lblodSubsidie:populationCount",
-      "lblodSubsidie:totaleDrawingRights",
+      {
+        "s-prefix": "schema:contactPoint",
+        "properties": [
+          "foaf:firstName",
+          "foaf:familyName",
+          "schema:telephone",
+          "schema:email"
+        ]
+      },
       {
         "s-prefix": "lblodSubsidie:signedPact",
         "properties": [
@@ -34,30 +35,7 @@
             ]
           }
         ]
-      },
-      {
-        "s-prefix": "schema:contactPoint",
-        "properties": [
-          "foaf:firstName",
-          "foaf:familyName",
-          "schema:telephone",
-          "schema:email"
-        ]
       }
-    ]
-  },
-  "meta": {
-    "schemes": [
-      "http://lblod.data.gift/concept-schemes/33e233eb-6a9b-4141-b607-2ff72fe2ded2",
-      "http://lblod.data.gift/concepts/1df4b56a-3ccd-450d-93dc-317fda1ada38",
-      "http://lblod.data.gift/concepts/2697fbe1-4226-4325-807b-5dfa58e40a95",
-      "http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2",
-      "http://lblod.data.gift/concepts/5e52660c-9067-4d6f-b82c-c73ffd043401",
-      "http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2",
-      "http://lblod.data.gift/concept-schemes/dcfb437e-1219-4d1e-891d-057f262da9d6",
-      "http://lblod.data.gift/concept-schemes/dd44f316-7a30-45ab-b0f3-5dd642e0b6c7",
-      "http://lblod.data.gift/concept-schemes/2c0ec673-a430-4cd3-861d-8666991b790f",
-      "http://lblod.data.gift/concept-schemes/9a3f018b-6528-4abb-82d5-b7920d05a3da"
     ]
   }
 }

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
@@ -16,6 +16,11 @@
       "PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>"
     ],
     "properties": [
+      "dct:created",
+      "dct:modified",
+      "ext:lastModifiedBy",
+      "dct:isPartOf",
+      "dct:creator",
       {
         "s-prefix": "schema:contactPoint",
         "properties": [

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
@@ -19,6 +19,7 @@
       {
         "s-prefix": "schema:contactPoint",
         "properties": [
+          "rdf:type",
           "foaf:firstName",
           "foaf:familyName",
           "schema:telephone",
@@ -28,6 +29,7 @@
       {
         "s-prefix": "lblodSubsidie:signedPact",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.ttl
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.ttl
@@ -135,7 +135,8 @@ fields:fbd15091-9155-4c73-a12a-0df4e4eda7b9 a form:Field ;
     [ a form:RequiredConstraint ;
       form:grouping form:Bag ;
       sh:resultMessage "Dit veld is verplicht." ;
-      sh:path lblodSubsidie:signedPact ] ;
+      sh:path ( lblodSubsidie:signedPact dct:hasPart ) 
+    ] ;
     sh:group fields:07372422-b306-4157-9970-60fdd79ac57f .
 
 ##########################################################

--- a/config/subsidy-application-management/forms/climate/step-submit-proposal/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-proposal/versions/20210420172044/form.json
@@ -17,12 +17,6 @@
       "PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>"
     ],
     "properties": [
-      "dct:created",
-      "dct:modified",
-      "adms:status",
-      "ext:lastModifiedBy",
-      "dct:creator",
-      "pav:createdBy",
       "lblodSubsidie:populationCount",
       "lblodSubsidie:totaleDrawingRights",
       {
@@ -41,20 +35,6 @@
           }
          ]
        }
-    ]
-  },
-  "meta": {
-    "schemes": [
-      "http://lblod.data.gift/concept-schemes/33e233eb-6a9b-4141-b607-2ff72fe2ded2",
-      "http://lblod.data.gift/concepts/1df4b56a-3ccd-450d-93dc-317fda1ada38",
-      "http://lblod.data.gift/concepts/2697fbe1-4226-4325-807b-5dfa58e40a95",
-      "http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2",
-      "http://lblod.data.gift/concepts/5e52660c-9067-4d6f-b82c-c73ffd043401",
-      "http://lblod.data.gift/concept-schemes/af23feb1-a876-4834-9427-947f93b776f2",
-      "http://lblod.data.gift/concept-schemes/dcfb437e-1219-4d1e-891d-057f262da9d6",
-      "http://lblod.data.gift/concept-schemes/dd44f316-7a30-45ab-b0f3-5dd642e0b6c7",
-      "http://lblod.data.gift/concept-schemes/2c0ec673-a430-4cd3-861d-8666991b790f",
-      "http://lblod.data.gift/concept-schemes/9a3f018b-6528-4abb-82d5-b7920d05a3da"
     ]
   }
 }


### PR DESCRIPTION
## ID
 DGS-105

 ## Description

When syncing subsidy data from digitaal-loket to app-subsidiedatabank some data in the forms is missing. The reason is because some subjects to export do not have a rdf:type. Without rdf:type we cannot add them to the delta-producer export config file. 

Note: this also removes meta concept schemes that got loaded for nothing as no concept-scheme selectors get used in the forms. 

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## How to test

- Setup the digitaal-loket <--> subsidiedatabank sync. You can follow this guide: https://github.com/lblod/app-subsidiedatabank/wiki/How-to-setup

- Create multiple LEKP 1.0 (2021 !!!) subsidy in digitaal-loket. Fill in the forms differently (act like a user basically trying to break it)
- go over to subsidiedatabank and make sure that all subsidies are a 1 to 1 copy of the ones in loket. (including files)