### PR TITLE
Move publicationGraphEndpoint for mandatarissen and leidinggevenden to publication-triplestore

### DIFF
--- a/config/delta-producer/dump-file-publisher/config.json
+++ b/config/delta-producer/dump-file-publisher/config.json
@@ -3,28 +3,28 @@
     "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/LeidinggevendenCacheGraphDump",
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer",
     "fileBaseName": "dump-leidinggevenden",
-    "publicationGraphEndpoint": "http://virtuoso:8890/sparql",
+    "publicationGraphEndpoint": "http://publication-triplestore:8890/sparql",
     "cleanupOldDumps": true
   },
   "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/leidinggevenden": {
     "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/LeidinggevendenCacheGraphDump",
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer",
     "fileBaseName": "dump-leidinggevenden",
-    "publicationGraphEndpoint": "http://virtuoso:8890/sparql",
+    "publicationGraphEndpoint": "http://publication-triplestore:8890/sparql",
     "cleanupOldDumps": true
   },
   "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/mandatarissen": {
     "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/MandatarissenCacheGraphDump",
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/loket-mandatarissen-producer",
     "fileBaseName": "dump-mandatarissen",
-    "publicationGraphEndpoint": "http://virtuoso:8890/sparql",
+    "publicationGraphEndpoint": "http://publication-triplestore:8890/sparql",
     "cleanupOldDumps": true
   },
   "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/mandatarissen": {
     "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/MandatarissenCacheGraphDump",
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/loket-mandatarissen-producer",
     "fileBaseName": "dump-mandatarissen",
-    "publicationGraphEndpoint": "http://virtuoso:8890/sparql",
+    "publicationGraphEndpoint": "http://publication-triplestore:8890/sparql",
     "cleanupOldDumps": true
   },
   "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/submissions": {


### PR DESCRIPTION
## Ticket Number

DL-5584

## Ticket Description

After consolidating the `mandatarissen` and `leidinggevenden` delta streams in DL-5585 and DL-5582 respectively, the goal now is to complete the picture by moving the publication graph endpoint inside the dump file publisher configs for both streams into the `publication-triplestore`.