### PR TITLE
Add Nooddorpen subsidy types via extractor

### DIFF
--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -24,6 +24,25 @@
       "properties": [
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
         "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName",
+        "http://purl.org/dc/terms/format",
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize",
+        "http://dbpedia.org/ontology/fileExtension",
+        "http://purl.org/dc/terms/created",
+        "http://purl.org/dc/terms/modified",
+        "http://purl.org/dc/terms/type",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
         "http://purl.org/dc/terms/description",
         "http://data.europa.eu/m8g/role"
       ],
@@ -114,7 +133,89 @@
         "http://www.w3.org/ns/adms#status",
         "http://schema.org/bankAccount",
         "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/unresolvedSocialProblems",
-        "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/usesSocialImpactBound"
+        "http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/usesSocialImpactBound",
+        "http://lblod.data.gift/vocabularies/subsidie/projectName",
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#identifier",
+        "http://lblod.data.gift/vocabularies/subsidie/picturesUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#estimatedCostTable",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveTable",
+        "http://lblod.data.gift/vocabularies/subsidie/timeBlock",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidyMeasure",
+        "http://lblod.data.gift/vocabularies/subsidie/decisionUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/accountabilityNoteUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/reportUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/justificationExpropriationsUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/justificationCostsUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/invoiceUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/awardReportUpload",
+        "http://lblod.data.gift/vocabularies/subsidie/attachment",
+        "http://lblod.data.gift/vocabularies/subsidie/signedPact",
+        "http://lblod.data.gift/vocabularies/subsidie/climateTable",
+        "http://purl.org/pav/createdBy",
+        "http://lblod.data.gift/vocabularies/subsidie/isCollaboration",
+        "http://lblod.data.gift/vocabularies/subsidie/collaborator",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresNovember",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresDecember",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresJanuary",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresFebruary",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresMarch",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresApril",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresMay",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresJune",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresJuly",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresAugust",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresSeptember",
+        "http://lblod.data.gift/vocabularies/subsidie/extraContactTracingMeasuresOctober",
+        "http://lblod.data.gift/vocabularies/subsidie/estimatedExtraCosts",
+        "http://lblod.data.gift/vocabularies/subsidie/focusedPopulation",
+        "http://lblod.data.gift/vocabularies/subsidie/focusedPopulationAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/typesOfContacts",
+        "http://lblod.data.gift/vocabularies/subsidie/typesOfContactsAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/preventionMethods",
+        "http://lblod.data.gift/vocabularies/subsidie/preventionMethodsAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/sourceDetectionActions",
+        "http://lblod.data.gift/vocabularies/subsidie/sourceDetectionActionsAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/quarantaineCoachingMethods",
+        "http://lblod.data.gift/vocabularies/subsidie/quarantaineCoachingMethodsAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/vulnerableGroupsHelp",
+        "http://lblod.data.gift/vocabularies/subsidie/vulnerableGroupsHelpAndereOption",
+        "http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveOne",
+        "http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveTwo",
+        "http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveThree",
+        "http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveFour",
+        "http://lblod.data.gift/vocabularies/subsidie/EngagementTable",
+        "http://lblod.data.gift/vocabularies/subsidie/amount",
+        "http://lblod.data.gift/vocabularies/subsidie/currentEInclusionActions",
+        "http://lblod.data.gift/vocabularies/subsidie/actionShortDescription",
+        "http://lblod.data.gift/vocabularies/subsidie/actionFullDescription",
+        "http://lblod.data.gift/vocabularies/subsidie/targetedAudience",
+        "http://lblod.data.gift/vocabularies/subsidie/targetedAudienceOther",
+        "http://lblod.data.gift/vocabularies/subsidie/hasAdditionalAction",
+        "http://lblod.data.gift/vocabularies/subsidie/usedParentalContribution",
+        "http://lblod.data.gift/vocabularies/subsidie/uniqueChildrenNumberForWholePeriod",
+        "http://lblod.data.gift/vocabularies/subsidie/daysOfChildcareForWholePeriod",
+        "http://lblod.data.gift/vocabularies/subsidie/userDeclaresDataIsExact",
+        "http://lblod.data.gift/vocabularies/subsidie/userCompliesWithEmergencyChildcareConditions",
+        "http://lblod.data.gift/vocabularies/subsidie/ApplicationFormTable",
+        "http://lblod.data.gift/vocabularies/subsidie/projectStartDate",
+        "http://lblod.data.gift/vocabularies/subsidie/projectEndDate",
+        "http://lblod.data.gift/vocabularies/subsidie/totalAmount",
+        "http://lblod.data.gift/vocabularies/subsidie/projectType",
+        "http://lblod.data.gift/vocabularies/subsidie/accountabilitySummary",
+        "http://lblod.data.gift/vocabularies/subsidie/accountabilityProof",
+        "http://lblod.data.gift/vocabularies/subsidie/urbanRenewalApplicationForm",
+        "http://lblod.data.gift/vocabularies/subsidie/urbanRenewalAttachments",
+        "http://mu.semte.ch/vocabularies/ext/samenvattingSummaryDescription",
+        "http://mu.semte.ch/vocabularies/ext/schetsDeKwaliteitDescription",
+        "http://mu.semte.ch/vocabularies/ext/ProjectorganisatieEnRegiefunctieDescription",
+        "http://mu.semte.ch/vocabularies/ext/BeschrijfParticipatieCommunicatieInteractieDescription",
+        "http://mu.semte.ch/vocabularies/ext/ProjectfaseringMetProjectverloopTimingEnRisicobeheerDescription",
+        "http://mu.semte.ch/vocabularies/ext/AanvraagSubsidieEnBetekenisVoorStadsvernieuwingsprojectDescription",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragAanvraag",
+        "http://mu.semte.ch/vocabularies/ext/politicalReferenceContactPoint",
+        "http://mu.semte.ch/vocabularies/ext/FinancingPartner",
+        "http://lblod.data.gift/vocabularies/projectOnderdeelUnit",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragListingUnit"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
@@ -146,8 +247,7 @@
         "http://www.w3.org/2004/02/skos/core#related"
       ],
       "graphsFilter": [
-        "http://mu.semte.ch/graphs/public",
-        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+        "http://mu.semte.ch/graphs/public"
       ],
       "type": "http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelAanbod"
     },
@@ -157,7 +257,6 @@
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://lblod.data.gift/vocabularies/subsidie/heeftSubsidieprocedurestap",
         "http://www.w3.org/2007/uwa/context/common.owl#active",
-        "http://www.w3.org/2004/02/skos/core#prefLabel",
         "http://purl.org/dc/terms/description",
         "http://purl.org/dc/terms/title",
         "http://data.europa.eu/m8g/startTime",
@@ -165,8 +264,7 @@
         "http://purl.org/vocab/cpsv#follows"
       ],
       "graphsFilter": [
-        "http://mu.semte.ch/graphs/public",
-        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+        "http://mu.semte.ch/graphs/public"
       ],
       "type": "http://lblod.data.gift/vocabularies/subsidie/SubsidiemaatregelAanbodReeks"
     },
@@ -191,7 +289,8 @@
         "http://rdf-vocabulary.ddialliance.org/xkos#previous",
         "http://purl.org/dc/terms/isPartOf",
         "http://purl.org/dc/terms/source",
-        "http://purl.org/linked-data/cube#order"
+        "http://purl.org/linked-data/cube#order",
+        "http://purl.org/dc/terms/isReplacedBy"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/public"
@@ -214,7 +313,6 @@
     {
       "properties": [
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-        "http://mu.semte.ch/vocabularies/core/uuid",
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://data.europa.eu/m8g/endTime",
         "http://data.europa.eu/m8g/startTime"
@@ -288,40 +386,476 @@
       "properties": [
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
         "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName",
-        "http://purl.org/dc/terms/format",
-        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize",
-        "http://dbpedia.org/ontology/fileExtension",
-        "http://purl.org/dc/terms/created",
-        "http://purl.org/dc/terms/modified",
-        "http://purl.org/dc/terms/type",
-        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
-        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url"
+        "http://schema.org/email",
+        "http://schema.org/telephone",
+        "http://schema.org/url",
+        "http://schema.org/openingHours",
+        "http://schema.org/jobTitle",
+        "http://www.w3.org/ns/locn#address",
+        "http://www.w3.org/ns/shacl#order",
+        "http://xmlns.com/foaf/0.1/firstName",
+        "http://xmlns.com/foaf/0.1/familyName"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
       ],
-      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject"
+      "type": "http://schema.org/ContactPoint"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/decision-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/pictures-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/report-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/award-report-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/accountability-note-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-costs-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-expropriations-upload/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/invoice-upload/FormData"
     },
     {
       "properties": [
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
         "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url",
-        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName",
-        "http://purl.org/dc/terms/format",
-        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize",
-        "http://dbpedia.org/ontology/fileExtension",
-        "http://purl.org/dc/terms/created",
-        "http://purl.org/dc/terms/modified",
-        "http://purl.org/dc/terms/type",
-        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
-        "http://www.w3.org/ns/adms#status"
+        "http://schema.org/identifier",
+        "http://purl.org/dc/terms/hasPart"
       ],
       "graphsFilter": [
         "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
       ],
-      "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject"
+      "type": "http://schema.org/BankAccount"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#validEstimatedCostTable",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#estimatedCostEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#EstimatedCostTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://mu.semte.ch/vocabularies/ext/index",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#costEstimationType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#cost",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#share"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#EstimatedCostEntry"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#validObjectiveTable",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#objectiveEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#ObjectiveTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#approachType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#directionType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#bikeLaneType",
+        "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#kilometers"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#ObjectiveEntry"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/climate/attachment/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/climate/signed-pact/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/validClimateTable",
+        "http://lblod.data.gift/vocabularies/subsidie/totalBudgettedAmount",
+        "http://data.lblod.info/vocabularies/subsidie/climate/climateEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/ClimateTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://data.lblod.info/vocabularies/subsidie/climate/actionDescription",
+        "http://data.lblod.info/vocabularies/subsidie/climate/toRealiseUnits",
+        "http://data.lblod.info/vocabularies/subsidie/climate/costPerUnit",
+        "http://data.lblod.info/vocabularies/subsidie/climate/restitution",
+        "http://data.lblod.info/vocabularies/subsidie/climate/amountPerAction",
+        "http://data.lblod.info/vocabularies/subsidie/climate/customAction",
+        "http://data.lblod.info/vocabularies/subsidie/climate/customDescription",
+        "http://purl.org/linked-data/cube#order"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://data.lblod.info/vocabularies/subsidie/climate/ClimateEntry"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://lblod.data.gift/vocabularies/subsidie/priority",
+        "http://purl.org/dc/terms/description"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-one/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://lblod.data.gift/vocabularies/subsidie/priority",
+        "http://purl.org/dc/terms/description"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-two/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://lblod.data.gift/vocabularies/subsidie/priority",
+        "http://purl.org/dc/terms/description"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-three/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://lblod.data.gift/vocabularies/subsidie/priority",
+        "http://purl.org/dc/terms/description"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-four/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://mu.semte.ch/vocabularies/ext/engagementEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/EngagementTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://mu.semte.ch/vocabularies/ext/existingStaff",
+        "http://mu.semte.ch/vocabularies/ext/additionalStaff",
+        "http://mu.semte.ch/vocabularies/ext/volunteers"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://mu.semte.ch/vocabularies/ext/EngagementEntry"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://lblod.data.gift/vocabularies/subsidie/additionalActionType",
+        "http://lblod.data.gift/vocabularies/subsidie/additionalActionShortDescription",
+        "http://lblod.data.gift/vocabularies/subsidie/additionalActionFullDescription",
+        "http://lblod.data.gift/vocabularies/subsidie/additionalActionTargetedAudience",
+        "http://lblod.data.gift/vocabularies/subsidie/additionalActionTargetedAudienceOther"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/additonalAction"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://mu.semte.ch/vocabularies/ext/applicationFormEntry"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/ApplicationFormTable"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://mu.semte.ch/vocabularies/ext/actorName",
+        "http://mu.semte.ch/vocabularies/ext/numberChildrenPerInfrastructure",
+        "http://mu.semte.ch/vocabularies/ext/numberChildrenForFullDay",
+        "http://mu.semte.ch/vocabularies/ext/numberChildrenForHalfDay",
+        "http://purl.org/dc/terms/created"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://mu.semte.ch/vocabularies/ext/ApplicationFormEntry"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/ukraine-nooddorpen/accountability-summary/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/ukraine-nooddorpen/accountability-proof/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/urban-renewal/urban-renewal-application-form/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://purl.org/dc/terms/hasPart"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/urban-renewal/urban-renewal-attachments/FormData"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://xmlns.com/foaf/0.1/firstName",
+        "http://xmlns.com/foaf/0.1/familyName",
+        "http://schema.org/telephone",
+        "http://schema.org/email",
+        "http://schema.org/jobTitle"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://mu.semte.ch/vocabularies/ext/PoliticalReferenceContactPoint"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://mu.semte.ch/vocabularies/ext/partnerTitle",
+        "http://mu.semte.ch/vocabularies/ext/partnerType",
+        "http://mu.semte.ch/vocabularies/ext/financingAmount"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://mu.semte.ch/vocabularies/ext/FinancingPartner"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelNaam",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelBeschrijving",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelTimingUnit",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelStadUnit",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPubliekePartnerListingUnit",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPrivatePartnerListingUnit"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelUnit"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelTimingListingUnitBeschrijving",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelTimingListingUnitStartDatum",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelTimingListingUnitEindDatum"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelTimingUnit"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelStadListingUnitAandeel",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelStadListingUnitBedrag"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelStadUnit"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPubliekePartnerListingUnitNaam",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPubliekePartnerListingUnitBedrag"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPubliekePartnerListingUnit"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPrivatePartnerListingNaam",
+        "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPrivatePartnerListingBedrag"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/projectOnderdeelPrivatePartnerListingUnit"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/shacl#order",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragListingUnitNaam",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragListingUnitMotivering",
+        "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragListingUnitBedrag"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/organizations/.*/LoketLB-subsidies"
+      ],
+      "type": "http://lblod.data.gift/vocabularies/subsidie/subsidieBedragListingUnit"
     }
   ]
 }

--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -149,6 +149,7 @@
         "http://lblod.data.gift/vocabularies/subsidie/invoiceUpload",
         "http://lblod.data.gift/vocabularies/subsidie/awardReportUpload",
         "http://lblod.data.gift/vocabularies/subsidie/attachment",
+        "http://lblod.data.gift/vocabularies/subsidie/attachmentLEKPReport",
         "http://lblod.data.gift/vocabularies/subsidie/signedPact",
         "http://lblod.data.gift/vocabularies/subsidie/climateTable",
         "http://purl.org/pav/createdBy",

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/proposal/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/proposal/tailored/source/extractors/missing-types-extractor.js
@@ -1,0 +1,27 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate/bicycle-infrastructure/proposal/missing-types-extractor',
+  execute: async (store, graphs, lib, source) => {
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SCHEMA = new $rdf.Namespace('http://schema.org/');
+    const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
+    const DECISION_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/decision-upload/');
+    const PICTURES_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/pictures-upload/');
+
+    const contactPoint = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const decisionUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const picturesUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+    store.add($rdf.sym(source.uri), SCHEMA('contactPoint'), $rdf.sym(contactPoint), graphs.additions);
+    store.add($rdf.sym(contactPoint), RDF_TYPE, SCHEMA('ContactPoint'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('decisionUpload'), $rdf.sym(decisionUpload), graphs.additions);
+    store.add($rdf.sym(decisionUpload), RDF_TYPE, DECISION_UPLOAD('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('picturesUpload'), $rdf.sym(picturesUpload), graphs.additions);
+    store.add($rdf.sym(picturesUpload), RDF_TYPE, PICTURES_UPLOAD('FormData'), graphs.additions);
+  }
+}

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/proposal/tailored/source/index.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/proposal/tailored/source/index.js
@@ -1,0 +1,3 @@
+const missingTypesExtractor = require('./extractors/missing-types-extractor');
+
+module.exports = [ missingTypesExtractor ];

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/proposal/versions/20210420163405-initial-version/form.json
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/proposal/versions/20210420163405-initial-version/form.json
@@ -17,6 +17,7 @@
       {
         "s-prefix": "lblodSubsidie:decisionUpload",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -28,6 +29,7 @@
       {
         "s-prefix": "lblodSubsidie:picturesUpload",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -39,6 +41,7 @@
       {
         "s-prefix": "schema:contactPoint",
         "properties": [
+          "rdf:type",
           "foaf:firstName",
           "foaf:familyName",
           "schema:telephone",
@@ -48,10 +51,12 @@
       {
         "s-prefix": "bicycleInfrastructure:estimatedCostTable",
         "properties": [
+          "rdf:type",
           "bicycleInfrastructure:validEstimatedCostTable",
           {
             "s-prefix": "bicycleInfrastructure:estimatedCostEntry",
             "properties": [
+              "rdf:type",
               "bicycleInfrastructure:costEstimationType",
               "bicycleInfrastructure:cost",
               "bicycleInfrastructure:share",
@@ -63,6 +68,7 @@
       {
         "s-prefix": "bicycleInfrastructure:objectiveTable",
         "properties": [
+          "rdf:type",
           "bicycleInfrastructure:validObjectiveTable",
           {
             "s-prefix": "bicycleInfrastructure:objectiveEntry",

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/proposal/versions/20210420163405-initial-version/form.ttl
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/proposal/versions/20210420163405-initial-version/form.ttl
@@ -188,7 +188,7 @@ fields:eea274cf-b422-4b8e-bb83-b066edbff8b1 a form:Field ;
     [ a form:RequiredConstraint ;
       form:grouping form:Bag ;
       sh:resultMessage "Dit veld is verplicht."@nl;
-      sh:path lblodSubsidie:decisionUpload
+      sh:path ( lblodSubsidie:decisionUpload dct:hasPart )
     ] ;
     form:displayType displayTypes:files ;
     sh:group fields:c1ba7dcf-2e7c-4f70-b61d-88f6b339771e .
@@ -206,7 +206,7 @@ fields:d7c19de5-1012-4d9d-a611-af26038c788a a form:Field ;
     [ a form:RequiredConstraint ;
       form:grouping form:Bag ;
       sh:resultMessage "Dit veld is verplicht."@nl;
-      sh:path lblodSubsidie:picturesUpload
+      sh:path ( lblodSubsidie:picturesUpload dct:hasPart )
     ] ;
     form:displayType displayTypes:files ;
     sh:group fields:c1ba7dcf-2e7c-4f70-b61d-88f6b339771e .

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/request-balance/tailored/source/extractors/bank-info-extractor.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/request-balance/tailored/source/extractors/bank-info-extractor.js
@@ -9,6 +9,7 @@ module.exports = {
 
     const {$rdf, mu, sudo} = lib;
 
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
     const SCHEMA =
         new $rdf.Namespace('http://schema.org/');
     const DCT =
@@ -22,6 +23,12 @@ module.exports = {
         $rdf.sym(target.uri),
         SCHEMA('bankAccount'),
         $rdf.sym(bankAccount),
+        graphs.additions);
+
+    store.add(
+        $rdf.sym(bankAccount),
+        RDF_TYPE,
+        SCHEMA('BankAccount'),
         graphs.additions);
 
     const {iban} = await getGenericInfo(source.uri, mu, sudo);

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/request-balance/tailored/source/extractors/contact-info-extractor.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/request-balance/tailored/source/extractors/contact-info-extractor.js
@@ -9,6 +9,7 @@ module.exports = {
 
     const {$rdf, mu, sudo} = lib;
 
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
     const SCHEMA = new $rdf.Namespace('http://schema.org/');
     const FOAF = new $rdf.Namespace('http://xmlns.com/foaf/0.1/');
 
@@ -19,6 +20,13 @@ module.exports = {
         SCHEMA('contactPoint'),
         $rdf.sym(contactPoint),
         graphs.additions);
+
+    store.add(
+        $rdf.sym(contactPoint),
+        RDF_TYPE,
+        SCHEMA('ContactPoint'),
+        graphs.additions);
+  
 
     const {firstName, familyName, email, telephone} =
         await getGenericInfo(source.uri, mu, sudo);

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/request-balance/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/request-balance/tailored/source/extractors/missing-types-extractor.js
@@ -1,0 +1,28 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate/bicycle-infrastructure/proposal/missing-types-extractor',
+  execute: async (store, graphs, lib, source) => {
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
+    const PICTURE_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/pictures-upload/');
+    const INVOICE_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/invoice-upload/');
+    const REPORT_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/report-upload/');
+
+    const pictureUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const invoiceUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const reportUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('picturesUpload'), $rdf.sym(pictureUpload), graphs.additions);
+    store.add($rdf.sym(pictureUpload), RDF_TYPE, PICTURE_UPLOAD('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('invoiceUpload'), $rdf.sym(invoiceUpload), graphs.additions);
+    store.add($rdf.sym(invoiceUpload), RDF_TYPE, INVOICE_UPLOAD('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('reportUpload'), $rdf.sym(reportUpload), graphs.additions);
+    store.add($rdf.sym(reportUpload), RDF_TYPE, REPORT_UPLOAD('FormData'), graphs.additions);
+
+  }
+}

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/request-balance/tailored/source/index.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/request-balance/tailored/source/index.js
@@ -4,6 +4,7 @@ const contactInfo = require(
     './extractors/contact-info-extractor');
 const bankInfo = require(
     './extractors/bank-info-extractor');
+const missingTypesExtractor = require('./extractors/missing-types-extractor');
 
 precedingFormExtractor = (extractors) =>
     Object.assign(
@@ -50,5 +51,5 @@ SELECT DISTINCT ?previousForm where {
  * NOTE: order of execution bound to position in the array
  */
 module.exports = [
-  precedingFormExtractor([genericInfo, contactInfo, bankInfo]),
+  precedingFormExtractor([genericInfo, contactInfo, bankInfo]), missingTypesExtractor,
 ];

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/request-balance/versions/20220110162327-initial-version/form.json
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/request-balance/versions/20220110162327-initial-version/form.json
@@ -17,6 +17,7 @@
       {
         "s-prefix": "lblodSubsidie:picturesUpload",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -28,6 +29,7 @@
       {
         "s-prefix": "lblodSubsidie:invoiceUpload",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -39,6 +41,7 @@
       {
         "s-prefix": "lblodSubsidie:reportUpload",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -50,6 +53,7 @@
       {
         "s-prefix": "schema:contactPoint",
         "properties": [
+          "rdf:type",
           "foaf:firstName",
           "foaf:familyName",
           "schema:telephone",
@@ -59,6 +63,7 @@
       {
         "s-prefix": "schema:bankAccount",
         "properties": [
+          "rdf:type",
           "schema:identifier",
           {
             "s-prefix": "dct:hasPart",
@@ -71,10 +76,12 @@
       {
         "s-prefix": "bicycleInfrastructure:estimatedCostTable",
         "properties": [
+          "rdf:type",
           "bicycleInfrastructure:validEstimatedCostTable",
           {
             "s-prefix": "bicycleInfrastructure:estimatedCostEntry",
             "properties": [
+              "rdf:type",
               "bicycleInfrastructure:costEstimationType",
               "bicycleInfrastructure:cost",
               "bicycleInfrastructure:share",
@@ -86,6 +93,7 @@
       {
         "s-prefix": "bicycleInfrastructure:objectiveTable",
         "properties": [
+          "rdf:type",
           "bicycleInfrastructure:validObjectiveTable",
           {
             "s-prefix": "bicycleInfrastructure:objectiveEntry",

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/request/tailored/source/extractors/bike-subsidy-request-extractor.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/request/tailored/source/extractors/bike-subsidy-request-extractor.js
@@ -3,6 +3,8 @@ module.exports = {
   execute: async (store, graphs, lib, form) => {
     try {
       const { $rdf, mu, sudo } = lib;
+
+      const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
       const SCHEMA = new $rdf.Namespace('http://schema.org/');
       const FOAF = new $rdf.Namespace('http://xmlns.com/foaf/0.1/');
       const LBLOD_SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
@@ -19,6 +21,7 @@ module.exports = {
         store.add($rdf.sym(form.uri), LBLOD_SUBSIDIE('projectName'), info.projectName, graphs.additions);
         store.add($rdf.sym(form.uri), NIE('identifier'), info.dossiernummer, graphs.additions);
         store.add($rdf.sym(form.uri), SCHEMA('contactPoint'), $rdf.sym(contactPointUri), graphs.additions);
+        store.add($rdf.sym(contactPointUri), RDF_TYPE, SCHEMA('ContactPoint'), graphs.additions);
         store.add($rdf.sym(contactPointUri), FOAF('firstName'), info.firstName, graphs.additions);
         store.add($rdf.sym(contactPointUri), FOAF('familyName'), info.familyName, graphs.additions);
         store.add($rdf.sym(contactPointUri), SCHEMA('email'), info.email, graphs.additions);

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/request/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/request/tailored/source/extractors/missing-types-extractor.js
@@ -1,0 +1,47 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate/bicycle-infrastructure/request/missing-types-extractor',
+  execute: async (store, graphs, lib, source) => {
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
+    const SCHEMA = new $rdf.Namespace('http://schema.org/');
+    const DECISION_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/decision-upload/');
+    const REPORT_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/report-upload/');
+    const AWARD_REPORT_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/award-report-upload/');
+    const ACCOUNTABILITY_NOTE_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/accountability-note-upload/');
+    const JUSTIFICATION_COSTS_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-costs-upload/');
+    const JUSTIFICATION_EXPROPRIATIONS_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-expropriations-upload/');
+
+    const bankAccount = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const decisionUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const reportUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const awardReportUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const accountabilityNoteUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const justificationCostsUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const justificationExpropriationsUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+    store.add($rdf.sym(source.uri), SCHEMA('bankAccount'), $rdf.sym(bankAccount), graphs.additions);
+    store.add($rdf.sym(bankAccount), RDF_TYPE, SCHEMA('BankAccount'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('decisionUpload'), $rdf.sym(decisionUpload), graphs.additions);
+    store.add($rdf.sym(decisionUpload), RDF_TYPE, DECISION_UPLOAD('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('reportUpload'), $rdf.sym(reportUpload), graphs.additions);
+    store.add($rdf.sym(reportUpload), RDF_TYPE, REPORT_UPLOAD('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('awardReportUpload'), $rdf.sym(awardReportUpload), graphs.additions);
+    store.add($rdf.sym(awardReportUpload), RDF_TYPE, AWARD_REPORT_UPLOAD('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('accountabilityNoteUpload'), $rdf.sym(accountabilityNoteUpload), graphs.additions);
+    store.add($rdf.sym(accountabilityNoteUpload), RDF_TYPE, ACCOUNTABILITY_NOTE_UPLOAD('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('justificationCostsUpload'), $rdf.sym(justificationCostsUpload), graphs.additions);
+    store.add($rdf.sym(justificationCostsUpload), RDF_TYPE, JUSTIFICATION_COSTS_UPLOAD('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('justificationExpropriationsUpload'), $rdf.sym(justificationExpropriationsUpload), graphs.additions);
+    store.add($rdf.sym(justificationExpropriationsUpload), RDF_TYPE, JUSTIFICATION_EXPROPRIATIONS_UPLOAD('FormData'), graphs.additions);
+  }
+}

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/request/tailored/source/index.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/request/tailored/source/index.js
@@ -1,8 +1,9 @@
 const bikeSubsidyRequestExtractor = require('./extractors/bike-subsidy-request-extractor');
+const missingTypesExtractor = require('./extractors/missing-types-extractor');
 
 /**
  * NOTE: order of execution bound to position in the array
  */
 module.exports = [
-    bikeSubsidyRequestExtractor
+    bikeSubsidyRequestExtractor, missingTypesExtractor
 ]

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/request/versions/20220228164354-additional-fields/form.json
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/request/versions/20220228164354-additional-fields/form.json
@@ -17,6 +17,7 @@
       {
         "s-prefix": "lblodSubsidie:decisionUpload",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -28,6 +29,7 @@
       {
         "s-prefix": "lblodSubsidie:reportUpload",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -39,6 +41,7 @@
       {
         "s-prefix": "lblodSubsidie:awardReportUpload",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -50,6 +53,7 @@
       {
         "s-prefix": "lblodSubsidie:accountabilityNoteUpload",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -61,6 +65,7 @@
       {
         "s-prefix": "lblodSubsidie:justificationCostsUpload",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -72,6 +77,7 @@
       {
         "s-prefix": "lblodSubsidie:justificationExpropriationsUpload",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -83,6 +89,7 @@
       {
         "s-prefix": "schema:contactPoint",
         "properties": [
+          "rdf:type",
           "foaf:firstName",
           "foaf:familyName",
           "schema:telephone",
@@ -92,6 +99,7 @@
       {
         "s-prefix": "schema:bankAccount",
         "properties": [
+          "rdf:type",
           "schema:identifier",
           {
             "s-prefix": "dct:hasPart",
@@ -104,10 +112,12 @@
       {
         "s-prefix": "bicycleInfrastructure:estimatedCostTable",
         "properties": [
+          "rdf:type",
           "bicycleInfrastructure:validEstimatedCostTable",
           {
             "s-prefix": "bicycleInfrastructure:estimatedCostEntry",
             "properties": [
+              "rdf:type",
               "bicycleInfrastructure:costEstimationType",
               "bicycleInfrastructure:cost",
               "bicycleInfrastructure:share",
@@ -119,6 +129,7 @@
       {
         "s-prefix": "bicycleInfrastructure:objectiveTable",
         "properties": [
+          "rdf:type",
           "bicycleInfrastructure:validObjectiveTable",
           {
             "s-prefix": "bicycleInfrastructure:objectiveEntry",

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/extractors/contact-info-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/extractors/contact-info-extractor.js
@@ -9,6 +9,7 @@ module.exports = {
 
     const {$rdf, mu, sudo} = lib;
 
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
     const SCHEMA = new $rdf.Namespace('http://schema.org/');
     const FOAF = new $rdf.Namespace('http://xmlns.com/foaf/0.1/');
 
@@ -18,6 +19,12 @@ module.exports = {
         $rdf.sym(target.uri),
         SCHEMA('contactPoint'),
         $rdf.sym(contactPoint),
+        graphs.additions);
+
+    store.add(
+        $rdf.sym(contactPoint), 
+        RDF_TYPE, 
+        SCHEMA('ContactPoint'), 
         graphs.additions);
 
     const {firstName, familyName, email, telephone} =

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/extractors/missing-types-extractor.js
@@ -1,0 +1,21 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate/step-submit-opvolgmoment-2024/missing-types-extractor',
+  execute: async (store, graphs, lib, source) => {
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
+    const ATTACHMENT = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/climate/attachment/');
+
+    const attachment = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const attachmentLEKPReport = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('attachment'), $rdf.sym(attachment), graphs.additions);
+    store.add($rdf.sym(attachment), RDF_TYPE, ATTACHMENT('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('attachmentLEKPReport'), $rdf.sym(attachmentLEKPReport), graphs.additions);
+    store.add($rdf.sym(attachmentLEKPReport), RDF_TYPE, ATTACHMENT('FormData'), graphs.additions);
+  }
+}

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/index.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/tailored/source/index.js
@@ -1,4 +1,5 @@
 const contactInfoExtractor = require('./extractors/contact-info-extractor');
+const missingTypesExtractor = require('./extractors/missing-types-extractor');
 
 const extractor = {
   name: 'climate-subsidy/opvolgmoment/first-step-as-source',
@@ -46,4 +47,4 @@ async function findFormFromStep1( { mu, sudo }, form ) {
   return results.bindings[0].firstForm.value;
 }
 
-module.exports = [ extractor ];
+module.exports = [ extractor, missingTypesExtractor ];

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.json
@@ -19,6 +19,7 @@
       {
         "s-prefix": "schema:contactPoint",
         "properties": [
+          "rdf:type",
           "foaf:firstName",
           "foaf:familyName",
           "schema:telephone",
@@ -28,6 +29,7 @@
       {
         "s-prefix": "lblodSubsidie:attachment",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [
@@ -39,6 +41,7 @@
       {
         "s-prefix": "lblodSubsidie:attachmentLEKPReport",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.ttl
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment-2024/versions/20231116154454/form.ttl
@@ -134,7 +134,7 @@ fields:f6f972c0-e796-42e8-87c1-c689dab0a690 a form:Field ;
         [ a form:RequiredConstraint ;
             form:grouping form:Bag ;
             sh:resultMessage "Dit veld is verplicht."@nl ;
-            sh:path lblodSubsidie:attachment
+            sh:path ( lblodSubsidie:attachment dct:hasPart )
         ] ;
     form:displayType displayTypes:files ;
     sh:group fields:70f45080-8a18-473f-bb3f-abf6ce9c678e .

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/extractors/contact-info-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/extractors/contact-info-extractor.js
@@ -9,6 +9,7 @@ module.exports = {
 
     const {$rdf, mu, sudo} = lib;
 
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
     const SCHEMA = new $rdf.Namespace('http://schema.org/');
     const FOAF = new $rdf.Namespace('http://xmlns.com/foaf/0.1/');
 
@@ -18,6 +19,12 @@ module.exports = {
         $rdf.sym(target.uri),
         SCHEMA('contactPoint'),
         $rdf.sym(contactPoint),
+        graphs.additions);
+
+    store.add(
+        $rdf.sym(contactPoint), 
+        RDF_TYPE, 
+        SCHEMA('ContactPoint'), 
         graphs.additions);
 
     const {firstName, familyName, email, telephone} =

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/extractors/missing-types-extractor.js
@@ -1,0 +1,17 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate/step-submit-opvolgmoment/missing-types-extractor',
+  execute: async (store, graphs, lib, source) => {
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
+    const ATTACHMENT = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/climate/attachment/');
+
+    const attachment = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('attachment'), $rdf.sym(attachment), graphs.additions);
+    store.add($rdf.sym(attachment), RDF_TYPE, ATTACHMENT('FormData'), graphs.additions);
+  }
+}

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/index.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/tailored/source/index.js
@@ -1,4 +1,5 @@
 const contactInfoExtractor = require('./extractors/contact-info-extractor');
+const missingTypesExtractor = require('./extractors/missing-types-extractor');
 
 const extractor = {
   name: 'climate-subsidy/opvolgmoment/first-step-as-source',
@@ -45,4 +46,4 @@ async function findFormFromStep1( { mu, sudo }, form ) {
   return results.bindings[0].firstForm.value;
 }
 
-module.exports = [ extractor ];
+module.exports = [ extractor, missingTypesExtractor  ];

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.json
@@ -19,6 +19,7 @@
       {
         "s-prefix": "schema:contactPoint",
         "properties": [
+          "rdf:type",
           "foaf:firstName",
           "foaf:familyName",
           "schema:telephone",
@@ -28,6 +29,7 @@
       {
         "s-prefix": "lblodSubsidie:attachment",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [

--- a/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.ttl
+++ b/config/subsidy-application-management/forms/climate/step-submit-opvolgmoment/versions/20210420172044/form.ttl
@@ -134,7 +134,7 @@ fields:f6f972c0-e796-42e8-87c1-c689dab0a690 a form:Field ;
         [ a form:RequiredConstraint ;
             form:grouping form:Bag ;
             sh:resultMessage "Dit veld is verplicht."@nl ;
-            sh:path lblodSubsidie:attachment
+            sh:path ( lblodSubsidie:attachment dct:hasPart )
         ] ;
     form:displayType displayTypes:files ;
     sh:group fields:70f45080-8a18-473f-bb3f-abf6ce9c678e .

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/extractors/missing-types-extractor.js
@@ -8,7 +8,7 @@ module.exports = {
     const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
     const SCHEMA = new $rdf.Namespace('http://schema.org/');
     const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
-    const PACT = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/climate/signed-pact/');
+    const SIGNED_PACT = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/climate/signed-pact/');
 
 
     const contactPoint = new $rdf.NamedNode(URI_BASE + mu.uuid());
@@ -19,6 +19,6 @@ module.exports = {
     store.add($rdf.sym(contactPoint), RDF_TYPE, SCHEMA('ContactPoint'), graphs.additions);
 
     store.add($rdf.sym(source.uri), SUBSIDIE('signedPact'), $rdf.sym(signedPact), graphs.additions);
-    store.add($rdf.sym(signedPact), RDF_TYPE, PACT('FormData'), graphs.additions);
+    store.add($rdf.sym(signedPact), RDF_TYPE, SIGNED_PACT('FormData'), graphs.additions);
   }
 }

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/extractors/missing-types-extractor.js
@@ -1,0 +1,24 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate/step-submit-pact/missing-types-extractor',
+  execute: async (store, graphs, lib, source) => {
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SCHEMA = new $rdf.Namespace('http://schema.org/');
+    const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
+    const PACT = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/climate/signed-pact/');
+
+
+    const contactPoint = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const signedPact = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+
+    store.add($rdf.sym(source.uri), SCHEMA('contactPoint'), $rdf.sym(contactPoint), graphs.additions);
+    store.add($rdf.sym(contactPoint), RDF_TYPE, SCHEMA('ContactPoint'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('signedPact'), $rdf.sym(signedPact), graphs.additions);
+    store.add($rdf.sym(signedPact), RDF_TYPE, PACT('FormData'), graphs.additions);
+  }
+}

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/index.js
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/tailored/source/index.js
@@ -1,0 +1,3 @@
+const missingTypesExtractor = require('./extractors/missing-types-extractor');
+
+module.exports = [ missingTypesExtractor ];

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
@@ -16,6 +16,11 @@
       "PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>"
     ],
     "properties": [
+      "dct:created",
+      "dct:modified",
+      "ext:lastModifiedBy",
+      "dct:isPartOf",
+      "dct:creator",
       {
         "s-prefix": "schema:contactPoint",
         "properties": [

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.json
@@ -19,6 +19,7 @@
       {
         "s-prefix": "schema:contactPoint",
         "properties": [
+          "rdf:type",
           "foaf:firstName",
           "foaf:familyName",
           "schema:telephone",
@@ -28,6 +29,7 @@
       {
         "s-prefix": "lblodSubsidie:signedPact",
         "properties": [
+          "rdf:type",
           {
             "s-prefix": "dct:hasPart",
             "properties": [

--- a/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.ttl
+++ b/config/subsidy-application-management/forms/climate/step-submit-pact/versions/20210420172044/form.ttl
@@ -135,7 +135,8 @@ fields:fbd15091-9155-4c73-a12a-0df4e4eda7b9 a form:Field ;
     [ a form:RequiredConstraint ;
       form:grouping form:Bag ;
       sh:resultMessage "Dit veld is verplicht." ;
-      sh:path lblodSubsidie:signedPact ] ;
+      sh:path ( lblodSubsidie:signedPact dct:hasPart ) 
+    ] ;
     sh:group fields:07372422-b306-4157-9970-60fdd79ac57f .
 
 ##########################################################

--- a/config/subsidy-application-management/forms/ukraine-nooddorpen/proposal/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/ukraine-nooddorpen/proposal/tailored/source/extractors/missing-types-extractor.js
@@ -1,0 +1,28 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate/bicycle-infrastructure/proposal/missing-types-extractor',
+  execute: async (store, graphs, lib, source) => {
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SCHEMA = new $rdf.Namespace('http://schema.org/');
+    const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
+    const ACCOUNTABILITY_SUMMARY= new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/ukraine-nooddorpen/accountability-summary/');
+    const ACCOUNTABILITY_PROOF= new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/ukraine-nooddorpen/accountability-proof/');
+
+    const contactPoint = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const accountabilitySummary = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const accountabilityProof = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    
+    store.add($rdf.sym(source.uri), SCHEMA('contactPoint'), $rdf.sym(contactPoint), graphs.additions);
+    store.add($rdf.sym(contactPoint), RDF_TYPE, SCHEMA('ContactPoint'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('accountabilitySummary'), $rdf.sym(accountabilitySummary), graphs.additions);
+    store.add($rdf.sym(accountabilitySummary), RDF_TYPE, ACCOUNTABILITY_SUMMARY('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('accountabilityProof'), $rdf.sym(accountabilityProof), graphs.additions);
+    store.add($rdf.sym(accountabilityProof), RDF_TYPE, ACCOUNTABILITY_PROOF('FormData'), graphs.additions);
+
+  }
+}

--- a/config/subsidy-application-management/forms/ukraine-nooddorpen/proposal/tailored/source/index.js
+++ b/config/subsidy-application-management/forms/ukraine-nooddorpen/proposal/tailored/source/index.js
@@ -1,0 +1,3 @@
+const missingTypesExtractor = require('./extractors/missing-types-extractor');
+
+module.exports = [ missingTypesExtractor ];

--- a/config/subsidy-application-management/forms/ukraine-nooddorpen/proposal/versions/20220801110000/form.json
+++ b/config/subsidy-application-management/forms/ukraine-nooddorpen/proposal/versions/20220801110000/form.json
@@ -20,6 +20,7 @@
         {
           "s-prefix": "schema:contactPoint",
           "properties": [
+            "rdf:type",
             "foaf:firstName",
             "foaf:familyName",
             "schema:telephone",
@@ -29,6 +30,7 @@
         {
           "s-prefix": "lblodSubsidie:accountabilitySummary",
           "properties": [
+            "rdf:type",
             {
               "s-prefix": "dct:hasPart",
               "properties": [
@@ -40,18 +42,7 @@
         {
           "s-prefix": "lblodSubsidie:accountabilityProof",
           "properties": [
-            {
-              "s-prefix": "dct:hasPart",
-              "properties": [
-                "rdf:type"
-              ]
-            }
-          ]
-        },
-        {
-          "s-prefix": "schema:bankAccount",
-          "properties": [
-            "schema:identifier",
+            "rdf:type",
             {
               "s-prefix": "dct:hasPart",
               "properties": [


### PR DESCRIPTION
## ID
 DGS-166

 ## Description
! ONLY TO BE REVIEWED/MERGED AFTER THIS ONE: https://github.com/lblod/app-digitaal-loket/pull/523

Similar to LEKP 1.0 (2021), this PR adds missing rdf:type to nooddorpen fields so they can get exported corrrectly by the delta-producer.   

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## How to test

See "How to test" -> https://github.com/lblod/app-digitaal-loket/pull/523

 ## Links to other PR's

 - https://github.com/lblod/app-digitaal-loket/pull/523