### PR TITLE
Bump mock-login service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,16 @@
  - Add Nooddorpen subsidy types via extractor (DGS-166)
 ### General
 #### Frontend
- - Bump frontend to `v0.90.3` (DL-5709): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0903-2024-02-28
+ - Bump frontend to `v0.90.3` (DL-5708): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0903-2024-02-28
 #### Backend
  - Bump `migrations` to `v0.9.0`
+ - Bump `mock-login` to `v0.4.0` (DL-5709)
 ### Deploy Notes
- - remove the loket v0.90.3 image override from the docker-compose.override.yml
-#### Docker commands
+ - Remove the frontend `v0.90.3` image override from `docker-compose.override.yml`
+#### Docker Commands
  - `drc up -d migrations`
  - `drc restart subsidy-applications-management`
+ - `drc up -d mocklogin`
 ## 1.94.0 (2024-02-19)
 ### Subsidies
  - Add new stadsvernieuwing - conceptsubsidie || Oproep 2024 reeks (DGS-154)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,8 @@
 ### Deploy Notes
  - Remove the frontend `v0.90.3` image override from `docker-compose.override.yml`
 #### Docker Commands
- - `drc up -d migrations`
+ - `drc up -d migrations mocklogin`
  - `drc restart subsidy-applications-management`
- - `drc up -d mocklogin`
 ## 1.94.0 (2024-02-19)
 ### Subsidies
  - Add new stadsvernieuwing - conceptsubsidie || Oproep 2024 reeks (DGS-154)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "443:443"
   mocklogin:
-    image: lblod/mock-login-service:0.3.1
+    image: lblod/mock-login-service:0.4.0
   loket:
     restart: "no"
     environment:


### PR DESCRIPTION
## Ticket Number

DL-5709

## Ticket Description

Bump the `mocklogin` service from `v0.3.1` to `v0.4.0`.

## How to Test

Try logging in with different types of organizations using the `/mock-login` route.