### PR TITLE
Removing dossierbehandelaar from omzendbrief

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
     restart: always
     logging: *default-logging
   berichtencentrum-sync-with-kalliope:
-    image: lblod/berichtencentrum-sync-with-kalliope-service:0.18.0
+    image: lblod/berichtencentrum-sync-with-kalliope-service:0.19.0-rc.1
     environment:
       MU_SPARQL_ENDPOINT: "http://database:8890/sparql"
       MU_SPARQL_UPDATEPOINT: "http://database:8890/sparql"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
     restart: always
     logging: *default-logging
   berichtencentrum-sync-with-kalliope:
-    image: lblod/berichtencentrum-sync-with-kalliope-service:0.19.0-rc.1
+    image: lblod/berichtencentrum-sync-with-kalliope-service:0.19.0
     environment:
       MU_SPARQL_ENDPOINT: "http://database:8890/sparql"
       MU_SPARQL_UPDATEPOINT: "http://database:8890/sparql"


### PR DESCRIPTION
# Description

DL-5629

This PR removes "dossierbehandelaar" only when "omzendbriven" (mass mailings)

- Bumping berichtencentrum-sync-with-kalliope to v0.19.0-rc.1 (Tested on QA)
- Bumping berichtencentrum-sync-with-kalliope to v0.19.0

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

- N/A

# What to check

- N/A

# Links to other PR's

- N/A

# Notes

- Tested on QA; Bump service to release version