### PR TITLE
update lekp 1.0 2021 deadlines

### DIFF
--- a/config/migrations/2024/subsidies/20240311143903-update-lekp-1-deadlines.sparql
+++ b/config/migrations/2024/subsidies/20240311143903-update-lekp-1-deadlines.sparql
@@ -1,10 +1,48 @@
 PREFIX m8g: <http://data.europa.eu/m8g/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+# Update LEKP 1.0 - 2021 deadline: remove subsidy period -> 'N.V.T'
+DELETE {
+  GRAPH ?g {
+    ?s m8g:startTime ?startTimeSubsidy .
+    ?s m8g:endTime ?endTimeSubsidy .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?s {
+      <http://data.lblod.info/id/periodes/d7b3851d-70f7-4929-b226-73d3343c954d> # LEKP 1.0 subsidy deadline
+    }
+    ?s m8g:startTime ?startTimeSubsidy .
+    ?s m8g:endTime ?endTimeSubsidy .
+  }
+};
+
+# Update LEKP 1.0 series to show '2021 – 2024' and 'N.V.T'
+DELETE {
+  GRAPH ?g {
+    ?s dct:title ?title .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s dct:title "2021 – 2024" .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?s {
+      <http://lblod.data.info/id/subsidy-measure-offer-series/87b87f00-6f87-4412-be26-ea531220457c> # LEKP 1.0 series
+    }
+    ?s dct:title ?title .
+  }
+};
+
 
 # Update LEKP 1.0 - 2021, Indienen Pact deadline
 DELETE {
   GRAPH ?g {
-    ?s m8g:endTime ?endTimeSubsidy .
     ?s m8g:endTime ?endTimeStep .
   }
 }
@@ -17,10 +55,8 @@ INSERT {
 WHERE {
   GRAPH ?g {
     VALUES ?s {
-      <http://data.lblod.info/id/periodes/d7b3851d-70f7-4929-b226-73d3343c954d> # LEKP 1.0 subsidy deadline
       <http://data.lblod.info/id/periodes/6123b1b9-b75b-4235-9cc6-58b1d7fa6872> # LEKP 1.0 Indienen Pact step deadline
     }
-    ?s m8g:endTime ?endTimeSubsidy.
     ?s m8g:endTime ?endTimeStep .
   }
 }

--- a/config/migrations/2024/subsidies/20240311143903-update-lekp-1-deadlines.sparql
+++ b/config/migrations/2024/subsidies/20240311143903-update-lekp-1-deadlines.sparql
@@ -39,8 +39,9 @@ WHERE {
     }
     ?s dct:title ?title .
   }
-};
+}
 
+;
 
 # Update LEKP 1.0 - 2021, Indienen Pact deadline
 DELETE {

--- a/config/migrations/2024/subsidies/20240311143903-update-lekp-1-deadlines.sparql
+++ b/config/migrations/2024/subsidies/20240311143903-update-lekp-1-deadlines.sparql
@@ -17,7 +17,9 @@ WHERE {
     ?s m8g:startTime ?startTimeSubsidy .
     ?s m8g:endTime ?endTimeSubsidy .
   }
-};
+}
+
+;
 
 # Update LEKP 1.0 series to show '2021 – 2024' and 'N.V.T'
 DELETE {

--- a/config/migrations/2024/subsidies/20240311143903-update-lekp-1-deadlines.sparql
+++ b/config/migrations/2024/subsidies/20240311143903-update-lekp-1-deadlines.sparql
@@ -1,0 +1,26 @@
+PREFIX m8g: <http://data.europa.eu/m8g/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+# Update LEKP 1.0 - 2021, Indienen Pact deadline
+DELETE {
+  GRAPH ?g {
+    ?s m8g:endTime ?endTimeSubsidy .
+    ?s m8g:endTime ?endTimeStep .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    # Time is set to 22:59:00 because Belgium time is UTC+1
+    ?s m8g:endTime "2024-12-05T22:59:00Z"^^xsd:dateTime .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?s {
+      <http://data.lblod.info/id/periodes/d7b3851d-70f7-4929-b226-73d3343c954d> # LEKP 1.0 subsidy deadline
+      <http://data.lblod.info/id/periodes/6123b1b9-b75b-4235-9cc6-58b1d7fa6872> # LEKP 1.0 Indienen Pact step deadline
+    }
+    ?s m8g:endTime ?endTimeSubsidy.
+    ?s m8g:endTime ?endTimeStep .
+  }
+}

--- a/config/migrations/2024/subsidies/20240311143903-update-lekp-1-deadlines.sparql
+++ b/config/migrations/2024/subsidies/20240311143903-update-lekp-1-deadlines.sparql
@@ -1,6 +1,7 @@
 PREFIX m8g: <http://data.europa.eu/m8g/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX xkos: <http://rdf-vocabulary.ddialliance.org/xkos#>
 
 # Update LEKP 1.0 - 2021 deadline: remove subsidy period -> 'N.V.T'
 DELETE {
@@ -61,5 +62,27 @@ WHERE {
       <http://data.lblod.info/id/periodes/6123b1b9-b75b-4235-9cc6-58b1d7fa6872> # LEKP 1.0 Indienen Pact step deadline
     }
     ?s m8g:endTime ?endTimeStep .
+  }
+}
+
+;
+
+# Update LEKP 1.0 - 2021, indienen pact next step to skip the 2 closed steps in the middle (indienen voorstel and opvolgmoment) and go to opvolgmoment 2024
+DELETE {
+  GRAPH ?g {
+    ?s xkos:next ?nextStep .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s xkos:next <http://lblod.data.info/id/subsidie-application-flow-steps/3514ae35-e18e-48b5-8647-80c06d926c78> . # Opvolgmoment 2024 step
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?s {
+      <http://lblod.data.info/id/subsidie-application-flow-steps/b9034a4b-adf6-4077-8dae-f9bebae4515e> # LEKP 1.0 indienen pact
+    }
+    ?s xkos:next ?nextStep .
   }
 }


### PR DESCRIPTION
## ID
DGS-167

## Description

The subsidy LEKP 1.0 - 2021 is updated with the following:
- indienen pact has a new deadline of 05 december 2024 23:59 and so is available to create again
- The period of the subsidy is changed to show 2021 - 2024 with N.V.T underneath

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How to test

Visit subsidy module and verify the changes are made to `indienen pact` and `Periode`.