### PR TITLE
Fixing sync-with-kalliope latest release & updating berichtencentrum-email-notification-service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,7 +185,7 @@ services:
     restart: always
     logging: *default-logging
   berichtencentrum-email-notification:
-    image: lblod/berichtencentrum-email-notification-service:0.3.0
+    image: lblod/berichtencentrum-email-notification-service:0.4.0-rc.1
     labels:
       - "logging=true"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
     restart: always
     logging: *default-logging
   berichtencentrum-sync-with-kalliope:
-    image: lblod/berichtencentrum-sync-with-kalliope-service:0.19.0
+    image: lblod/berichtencentrum-sync-with-kalliope-service:0.20.0-rc.1
     environment:
       MU_SPARQL_ENDPOINT: "http://database:8890/sparql"
       MU_SPARQL_UPDATEPOINT: "http://database:8890/sparql"


### PR DESCRIPTION
# Description

DL-5629
(DL-5748) Bug

This PR reverts the latest changes in the `berichtencentrum-sync-with-kalliope` service and addressing the issue with the mass mailing in `berichtencentrum-email-notification-service`

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

- To be tested

# What to check

- N/A

# Links to other PR's

- https://github.com/lblod/berichtencentrum-email-notification-service/pull/7
- https://github.com/lblod/berichtencentrum-sync-with-kalliope-service/pull/15

Fixes 

https://github.com/lblod/app-digitaal-loket/pull/537

# Notes

- 