### PR TITLE
[DL-5618] Add a new "Virus scan" report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
    - Adds `vendor-management` as a new delta-stream
  - Add server-specific configurations for `delta-producer-background-jobs-initiator` and `delta-producer-publication-graph-maintainer` (DL-5752)
    - Resolves merge conflict issues when adding a new delta stream or editing an existing one
- - Add `restart: always` for the `virus-scanner` service
+ - Add a new "Virus scan" report (DL-5618)
 ### Deploy Notes
  - Remove the frontend `v0.90.3` image override from `docker-compose.override.yml`
  - Update the controle image to `v0.91.1-controle` in the `docker-compose.override.yml` file
@@ -38,7 +38,7 @@
  - Add `"key": "<producer_key>"` for the new `vendor-management` delta stream.
 #### Docker Commands
  - `drc up -d loket controle migrations mocklogin vendor-data-distribution enrich-submission prepare-submissions-for-export virus-scanner berichtencentrum-sync-with-kalliope`
- - `drc restart subsidy-applications-management dispatcher deltanotifier delta-producer-background-jobs-initiator delta-producer-publication-graph-maintainer delta-producer-dump-file-publisher jobs-controller delta-producer-publication-graph-maintainer-subsidies migrations resource cache`
+ - `drc restart subsidy-applications-management dispatcher deltanotifier delta-producer-background-jobs-initiator delta-producer-publication-graph-maintainer delta-producer-dump-file-publisher jobs-controller delta-producer-publication-graph-maintainer-subsidies migrations resource cache report-generation`
 ## 1.94.0 (2024-02-19)
 ### Subsidies
  - Add new stadsvernieuwing - conceptsubsidie || Oproep 2024 reeks (DGS-154)

--- a/config/reports/index.js
+++ b/config/reports/index.js
@@ -24,6 +24,7 @@ import toezichtSubmissionsReport from './toezicht-submissions-report';
 import toezichtTaxRegulationSubmissionReport from './toezicht-tax-regulation-submissions-report';
 import ukraineSubsidyOproepOneReport from './ukraineSubsidyOproep1Report';
 import linksBetweenWorshipServicesAndAdminUnitsReport from './links-between-worship-services-and-admin-units-report';
+import virusScanReport from './virusScanReport';
 
 //Worship reports
 import bedienaren from './worship/bedienaren';
@@ -63,6 +64,7 @@ export default [
   toezichtTaxRegulationSubmissionReport,
   ukraineSubsidyOproepOneReport,
   linksBetweenWorshipServicesAndAdminUnitsReport,
+  virusScanReport,
 
   //Worship reports
   bedienaren,

--- a/config/reports/virusScanReport.js
+++ b/config/reports/virusScanReport.js
@@ -1,0 +1,48 @@
+import { generateReportFromData } from '../helpers.js';
+import { querySudo as query } from '@lblod/mu-auth-sudo';
+
+export default {
+  cronPattern: '4 2 * * *',
+  name: 'virusScanReport',
+  execute: async () => {
+    const reportData = {
+      title: 'Virus Scan Report',
+      description:
+        'A list of files that are considered malicious, or where the status is unknown',
+      filePrefix: 'virus-scan-report',
+    };
+
+    const queryString = `
+      PREFIX stix: <http://docs.oasis-open.org/cti/ns/stix#>
+      PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+      PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+      SELECT DISTINCT ?file ?fileName ?scanResult ?scanDate WHERE {
+        GRAPH ?g {
+          ?analysis a stix:MalwareAnalysis ;
+            stix:analysis_started ?scanDate ;
+            stix:sample_ref ?file ;
+            stix:result ?scanResult .
+            FILTER (?scanResult IN ("malicious", "unknown"))
+
+            ?file nfo:fileName ?fileName .
+        }
+      }
+      ORDER BY ?scanResult DESC(?scanDate)
+    `;
+
+    const queryResponse = await query(queryString);
+    const data = queryResponse.results.bindings.map((data) => ({
+      file: data.file.value,
+      fileName: data.fileName.value,
+      scanResult: data.scanResult.value,
+      scanDate: data.scanDate.value,
+    }));
+
+    await generateReportFromData(
+      data,
+      ['file', 'fileName', 'scanResult', 'scanDate'],
+      reportData,
+    );
+  },
+};


### PR DESCRIPTION
This report will generate a list of all the files which are considered "malicious" or where the status of the scan is unknown.

**Test instructions**
- check out the branch and start the stack
- add a port mapping to the report generation service so you can make direct API calls to it:
```yml
  report-generation:
    ports:
      - "8080:80"
```
- restart the `report-generation` service if the stack was already running (`drc restart report-generation` / `drc up -d report-generation` in case of the port mapping)
- Upload a [malicious test file](https://www.eicar.org/download-anti-malware-testfile/) in one of the file upload fields in Loket. The easiest is to go to the `Toezicht` module, create a new submission and upload it there.
- (optional) check the virus scan service logs to see if the file was scanned
- trigger the report generation with an [API call](https://github.com/lblod/loket-report-generation-service?tab=readme-ov-file#manually-trigger-reports) using `virusScanReport` as the name
- verify that a file is generated starting with the following name `virus-scan-report-[uuid].csv` and that it includes an entry for the malicious test file 
