### PR TITLE
Update LEKP 2.0 deadlines

### DIFF
--- a/config/migrations/2024/subsidies/20240313125823-update-lekp-2-deadlines.sparql
+++ b/config/migrations/2024/subsidies/20240313125823-update-lekp-2-deadlines.sparql
@@ -1,0 +1,62 @@
+PREFIX m8g: <http://data.europa.eu/m8g/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+# Update LEKP 2.0 - 2022 deadline: remove subsidy period -> 'N.V.T'
+DELETE {
+  GRAPH ?g {
+    ?s m8g:startTime ?startTimeSubsidy .
+    ?s m8g:endTime ?endTimeSubsidy .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?s {
+      <http://data.lblod.info/id/periodes/180927bf-5bf3-4b5e-8b1c-bbadc19042b2> # LEKP 2.0 subsidy deadline
+    }
+    ?s m8g:startTime ?startTimeSubsidy .
+    ?s m8g:endTime ?endTimeSubsidy .
+  }
+};
+
+# Update LEKP 2.0 series to show '2022 – 2024' and 'N.V.T'
+DELETE {
+  GRAPH ?g {
+    ?s dct:title ?title .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s dct:title "2022 – 2024" .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?s {
+      <http://lblod.data.info/id/subsidy-measure-offer-series/811ea781-c0dc-4647-ad8f-ea090bafc61d> # LEKP 2.0 series
+    }
+    ?s dct:title ?title .
+  }
+};
+
+
+# Update LEKP 2.0 - 2022, Indienen Pact deadline
+DELETE {
+  GRAPH ?g {
+    ?s m8g:endTime ?endTimeStep .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    # Time is set to 22:59:00 because Belgium time is UTC+1
+    ?s m8g:endTime "2024-12-05T22:59:00Z"^^xsd:dateTime .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?s {
+      <http://data.lblod.info/id/periodes/18374b39-b34b-43d1-b135-5e14007ca512> # LEKP 2.0 Indienen Pact step deadline
+    }
+    ?s m8g:endTime ?endTimeStep .
+  }
+}


### PR DESCRIPTION
## ID
DGS-168

## Description

The subsidy LEKP 2.0 is updated with the following:
 - `indienen pact` has a new deadline of 05 december 2024 23:59 and so is available to create again
 - The period of the subsidy is changed to show `2022 - 2024` with `N.V.T` underneath

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How to test

Visit subsidy module and verify the changes are made to `indienen pact` and `Periode`. 