### PR TITLE
Reports with too many double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Fixes
  - Bump berichtencentrum-email-notification-service, which fixes the general problem where no emails about messages get sent. (DL-5775)
    Note: It will already be deployed on production (`docker-compose.override.yml`) before this release gets deployed
+ - Fix reports with too many quotes around fields in the data. (DL-5811)
 #### New Organizations
  - Add a new politiezone: `PZ Aalter/Maldegem: Aalter en Maldegem` (DL-5730)
  - Add a new OCMW vereniging: `Ter Lembeek` (DL-5739)

--- a/config/reports/climateSubsidie2PactsReport.js
+++ b/config/reports/climateSubsidie2PactsReport.js
@@ -68,15 +68,15 @@ export default {
     const queryResponse = await query(queryString);
     const data = queryResponse.results.bindings.map((subsidie) => {
       return {
-        subsidie: getSafeValue(subsidie, 'subsidie'),
-        modified: getSafeValue(subsidie, 'modified'),
-        status: getSafeValue(subsidie, 'status'),
-        contactFirstName: getSafeValue(subsidie, 'contactFirstName'),
-        contactLastName: getSafeValue(subsidie, 'contactLastName'),
-        contactEmail: getSafeValue(subsidie, 'contactEmail'),
-        contactTelephone: getSafeValue(subsidie, 'contactTelephone'),
-        bestuurseenheid: getSafeValue(subsidie, 'bestuurseenheid'),
-        classificatie: getSafeValue(subsidie, 'classificatie')
+        subsidie: subsidie?.subsidie?.value,
+        modified: subsidie?.modified?.value,
+        status: subsidie?.status?.value,
+        contactFirstName: subsidie?.contactFirstName?.value,
+        contactLastName: subsidie?.contactLastName?.value,
+        contactEmail: subsidie?.contactEmail?.value,
+        contactTelephone: subsidie?.contactTelephone?.value,
+        bestuurseenheid: subsidie?.bestuurseenheid?.value,
+        classificatie: subsidie?.classificatie?.value
       };
     });
 
@@ -93,12 +93,3 @@ export default {
     ], reportData);
   }
 };
-
-function getSafeValue(entry, property){
-  return entry[property] ? wrapInQuote(entry[property].value) : null;
-}
-
-// Some values might contain comas, wrapping them in escapes quotes doesn't disturb the colomns
-function wrapInQuote(value) {
-  return `\"${value}\"`;
-}

--- a/config/reports/climateSubsidieOproep2PactsReport.js
+++ b/config/reports/climateSubsidieOproep2PactsReport.js
@@ -68,15 +68,15 @@ export default {
     const queryResponse = await query(queryString);
     const data = queryResponse.results.bindings.map((subsidie) => {
       return {
-        subsidie: getSafeValue(subsidie, 'subsidie'),
-        modified: getSafeValue(subsidie, 'modified'),
-        status: getSafeValue(subsidie, 'status'),
-        contactFirstName: getSafeValue(subsidie, 'contactFirstName'),
-        contactLastName: getSafeValue(subsidie, 'contactLastName'),
-        contactEmail: getSafeValue(subsidie, 'contactEmail'),
-        contactTelephone: getSafeValue(subsidie, 'contactTelephone'),
-        bestuurseenheid: getSafeValue(subsidie, 'bestuurseenheid'),
-        classificatie: getSafeValue(subsidie, 'classificatie')
+        subsidie: subsidie?.subsidie?.value,
+        modified: subsidie?.modified?.value,
+        status: subsidie?.status?.value,
+        contactFirstName: subsidie?.contactFirstName?.value,
+        contactLastName: subsidie?.contactLastName?.value,
+        contactEmail: subsidie?.contactEmail?.value,
+        contactTelephone: subsidie?.contactTelephone?.value,
+        bestuurseenheid: subsidie?.bestuurseenheid?.value,
+        classificatie: subsidie?.classificatie?.value
       };
     });
 
@@ -93,12 +93,3 @@ export default {
     ], reportData);
   }
 };
-
-function getSafeValue(entry, property){
-  return entry[property] ? wrapInQuote(entry[property].value) : null;
-}
-
-// Some values might contain comas, wrapping them in escapes quotes doesn't disturb the colomns
-function wrapInQuote(value) {
-  return `\"${value}\"`;
-}

--- a/config/reports/climateSubsidieOpvolgmomentReport.js
+++ b/config/reports/climateSubsidieOpvolgmomentReport.js
@@ -68,15 +68,15 @@ export default {
     const queryResponse = await query(queryString);
     const data = queryResponse.results.bindings.map((subsidie) => {
       return {
-        subsidie: getSafeValue(subsidie, 'subsidie'),
-        modified: getSafeValue(subsidie, 'modified'),
-        status: getSafeValue(subsidie, 'status'),
-        contactFirstName: getSafeValue(subsidie, 'contactFirstName'),
-        contactLastName: getSafeValue(subsidie, 'contactLastName'),
-        contactEmail: getSafeValue(subsidie, 'contactEmail'),
-        contactTelephone: getSafeValue(subsidie, 'contactTelephone'),
-        bestuurseenheid: getSafeValue(subsidie, 'bestuurseenheid'),
-        classificatie: getSafeValue(subsidie, 'classificatie')
+        subsidie: subsidie?.subsidie?.value,
+        modified: subsidie?.modified?.value,
+        status: subsidie?.status?.value,
+        contactFirstName: subsidie?.contactFirstName?.value,
+        contactLastName: subsidie?.contactLastName?.value,
+        contactEmail: subsidie?.contactEmail?.value,
+        contactTelephone: subsidie?.contactTelephone?.value,
+        bestuurseenheid: subsidie?.bestuurseenheid?.value,
+        classificatie: subsidie?.classificatie?.value
       };
     });
 
@@ -93,12 +93,3 @@ export default {
     ], reportData);
   }
 };
-
-function getSafeValue(entry, property){
-  return entry[property] ? wrapInQuote(entry[property].value) : null;
-}
-
-// Some values might contain comas, wrapping them in escapes quotes doesn't disturb the colomns
-function wrapInQuote(value) {
-  return `\"${value}\"`;
-}

--- a/config/reports/fietsSubsidieBalanceRequestsReport.js
+++ b/config/reports/fietsSubsidieBalanceRequestsReport.js
@@ -61,13 +61,13 @@ export default {
     const queryResponse = await query(queryString);
     const data = queryResponse.results.bindings.map((subsidie) => {
       return {
-        submissionDate: getSafeValue(subsidie, 'submissionDate'),
-        bestuurseenheid: getSafeValue(subsidie, 'bestuurseenheid'),
-        subsidie: getSafeValue(subsidie, 'subsidie'),
-        subsidieStatus: getSafeValue(subsidie, 'subsidieStatus'),
-        formStatus: getSafeValue(subsidie, 'formStatusLabel'),
-        iban: getSafeValue(subsidie, 'iban'),
-        dossierNummer: getSafeValue(subsidie, 'dossierNummer')
+        submissionDate: subsidie?.submissionDate?.value,
+        bestuurseenheid: subsidie?.bestuurseenheid?.value,
+        subsidie: subsidie?.subsidie?.value,
+        subsidieStatus: subsidie?.subsidieStatus?.value,
+        formStatus: subsidie?.formStatusLabel?.value,
+        iban: subsidie?.iban?.value,
+        dossierNummer: subsidie?.dossierNummer?.value
       };
     });
 
@@ -82,12 +82,3 @@ export default {
     ], reportData);
   }
 };
-
-function getSafeValue(entry, property){
-  return entry[property] ? wrapInQuote(entry[property].value) : null;
-}
-
-// Some values might contain comas, wrapping them in escapes quotes doesn't disturb the colomns
-function wrapInQuote(value) {
-  return `\"${value}\"`;
-}

--- a/config/reports/fietsSubsidieRequestsReport.js
+++ b/config/reports/fietsSubsidieRequestsReport.js
@@ -61,13 +61,13 @@ export default {
     const queryResponse = await query(queryString);
     const data = queryResponse.results.bindings.map((subsidie) => {
       return {
-        submissionDate: getSafeValue(subsidie, 'submissionDate'),
-        bestuurseenheid: getSafeValue(subsidie, 'bestuurseenheid'),
-        subsidie: getSafeValue(subsidie, 'subsidie'),
-        subsidieStatus: getSafeValue(subsidie, 'subsidieStatus'),
-        formStatus: getSafeValue(subsidie, 'formStatusLabel'),
-        iban: getSafeValue(subsidie, 'iban'),
-        dossierNummer: getSafeValue(subsidie, 'dossierNummer')
+        submissionDate: subsidie?.submissionDate?.value,
+        bestuurseenheid: subsidie?.bestuurseenheid?.value,
+        subsidie: subsidie?.subsidie?.value,
+        subsidieStatus: subsidie?.subsidieStatus?.value,
+        formStatus: subsidie?.formStatusLabel?.value,
+        iban: subsidie?.iban?.value,
+        dossierNummer: subsidie?.dossierNummer?.value
       };
     });
 
@@ -82,12 +82,3 @@ export default {
     ], reportData);
   }
 };
-
-function getSafeValue(entry, property){
-  return entry[property] ? wrapInQuote(entry[property].value) : null;
-}
-
-// Some values might contain comas, wrapping them in escapes quotes doesn't disturb the colomns
-function wrapInQuote(value) {
-  return `\"${value}\"`;
-}

--- a/config/reports/gemeentewegenReport.js
+++ b/config/reports/gemeentewegenReport.js
@@ -42,8 +42,8 @@ export default {
 
     const queryResponsePart1 = await batchedQuery(queryStringPart1);
     const dataToEnrich = queryResponsePart1.results.bindings.map((row) => ({
-        s: getSafeValue(row, 's'),
-        file: getSafeValue(row, 'file')
+        s: row?.s?.value,
+        file: row?.file?.value
     }));
 
     // Group the files in a field
@@ -71,6 +71,7 @@ export default {
       PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
       PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
       PREFIX lblodBesluit: <http://lblod.data.gift/vocabularies/besluit/> 
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
       SELECT ?s ?verstuurd ?bestuurseenheidLabel ?typeBestuur ?datumZitting ?statusLabel
             ?angemaaktDoor ?gewijzigdDoor ?link ?typeVaststelling ?typeGemeenteweg
@@ -137,17 +138,18 @@ export default {
     const queryResponsePart2 = await batchedQuery(queryStringPart2);
     const dataPart2 = queryResponsePart2.results.bindings.reduce( (acc, row) => {
       let dataPart = {
-        verstuurd: getSafeValue(row, 'verstuurd'),
-        bestuurseenheidLabel: getSafeValue(row, 'bestuurseenheidLabel'),
-        typeBestuur: getSafeValue(row, 'typeBestuur'),
-        angemaaktDoor: getSafeValue(row, 'angemaaktDoor'),
-        gewijzigdDoor: getSafeValue(row, 'gewijzigdDoor'),
-        statusLabel: getSafeValue(row, 'statusLabel'),
-        datumZitting: getSafeValue(row, 'datumZitting'),
-        typeVaststelling: getSafeValue(row, 'typeVaststelling'),
-        typeGemeenteweg: getSafeValue(row, 'typeGemeenteweg'),
-        link: getSafeValue(row, 'link')      };
-      acc[getSafeValue(row, 's')] = Object.assign(dataPart, dataPart1[getSafeValue(row, 's')]);
+        verstuurd: row?.verstuurd?.value,
+        bestuurseenheidLabel: row?.bestuurseenheidLabel?.value,
+        typeBestuur: row?.typeBestuur?.value,
+        angemaaktDoor: row?.angemaaktDoor?.value,
+        gewijzigdDoor: row?.gewijzigdDoor?.value,
+        statusLabel: row?.statusLabel?.value,
+        datumZitting: row?.datumZitting?.value,
+        typeVaststelling: row?.typeVaststelling?.value,
+        typeGemeenteweg: row?.typeGemeenteweg?.value,
+        link: row?.link?.value,
+      };
+      acc[row?.s?.value] = Object.assign(dataPart, dataPart1[row?.s?.value]);
       return acc;
     }, {});
 
@@ -174,13 +176,4 @@ function groupFilesBySubmission(data) {
       o.files = filesFromSameSubmission.map(f => f.file).join(",");
     }
   })
-}
-
-function getSafeValue(entry, property){
-  return entry[property] ? wrapInQuote(entry[property].value) : null;
-}
-
-// Some values might contain comas, wrapping them in escapes quotes doesn't disturb the colomns
-function wrapInQuote(value) {
-  return `\"${value}\"`;
 }

--- a/config/reports/internalMandatenReport.js
+++ b/config/reports/internalMandatenReport.js
@@ -37,12 +37,12 @@ export default {
 
     const queryResponsePart1 = await batchedQuery(queryStringPart1);
     const dataPart1 = queryResponsePart1.results.bindings.reduce( (acc, row) => {
-      acc[getSafeValue(row, 'mandataris')] = {
-        mandataris: getSafeValue(row, 'mandataris'),
-        start: getSafeValue(row, 'start'),
-        eind: getSafeValue(row, 'eind'),
-        rangorde: getSafeValue(row, 'rangorde'),
-        status: getSafeValue(row, 'status')
+      acc[row?.mandataris?.value] = {
+        mandataris: row?.mandataris?.value,
+        start: row?.start?.value,
+        eind: row?.eind?.value,
+        rangorde: row?.rangorde?.value,
+        status: row?.status?.value
       };
       return acc;
     }, {});
@@ -77,15 +77,15 @@ export default {
     const queryResponsePart2 = await batchedQuery(queryStringPart2);
     const dataPart2 = queryResponsePart2.results.bindings.reduce( (acc, row) => {
       let dataPart = {
-        mandataris: getSafeValue(row, 'mandataris'),
-        persoon: getSafeValue(row, 'persoon'),
-        voornaam: getSafeValue(row, 'voornaam'),
-        achternaam: getSafeValue(row, 'achternaam'),
-        roepnaam: getSafeValue(row, 'roepnaam'),
-        geslacht: getSafeValue(row, 'geslacht'),
-        geboortedatum: getSafeValue(row, 'geboortedatum')
+        mandataris: row?.mandataris?.value,
+        persoon: row?.persoon?.value,
+        voornaam: row?.voornaam?.value,
+        achternaam: row?.achternaam?.value,
+        roepnaam: row?.roepnaam?.value,
+        geslacht: row?.geslacht?.value,
+        geboortedatum: row?.geboortedatum?.value
       };
-      acc[getSafeValue(row, 'mandataris')] = Object.assign(dataPart, dataPart1[getSafeValue(row, 'mandataris')]);
+      acc[row?.mandataris?.value] = Object.assign(dataPart, dataPart1[row?.mandataris?.value]);
       return acc;
     }, {});
 
@@ -133,17 +133,17 @@ export default {
 
     const dataPart3 = queryResponsePart3.results.bindings.reduce( (acc, row) => {
       let dataPart = {
-        bestuursfunctieLabel: getSafeValue(row, 'bestuursfunctieLabel'),
-        bestuursorgaanLabel: getSafeValue(row, 'bestuursorgaanLabel'),
-        bestuursorgaanClassificatieLabel: getSafeValue( row, 'bestuursorgaanClassificatieLabel'),
-        bestuurseenheidLabel: getSafeValue(row, 'bestuurseenheidLabel'),
-        bestuurseenheidClassificatieLabel: getSafeValue(row, 'bestuurseenheidClassificatieLabel'),
-        werkingsgebiedLabel: getSafeValue(row, 'werkingsgebiedLabel'),
-        werkingsgebiedNiveau: getSafeValue(row, 'werkingsgebiedNiveau'),
-        bestuursPeriodeStart: getSafeValue(row, 'bestuursPeriodeStart'),
-        bestuursPeriodeEinde: getSafeValue(row, 'bestuursPeriodeEinde')
+        bestuursfunctieLabel: row?.bestuursfunctieLabel?.value,
+        bestuursorgaanLabel: row?.bestuursorgaanLabel?.value,
+        bestuursorgaanClassificatieLabel: row?.bestuursorgaanClassificatieLabel?.value,
+        bestuurseenheidLabel: row?.bestuurseenheidLabel?.value,
+        bestuurseenheidClassificatieLabel: row?.bestuurseenheidClassificatieLabel?.value,
+        werkingsgebiedLabel: row?.werkingsgebiedLabel?.value,
+        werkingsgebiedNiveau: row?.werkingsgebiedNiveau?.value,
+        bestuursPeriodeStart: row?.bestuursPeriodeStart?.value,
+        bestuursPeriodeEinde: row?.bestuursPeriodeEinde?.value
       };
-      acc[getSafeValue(row, 'mandataris')] = Object.assign(dataPart, dataPart2[getSafeValue(row, 'mandataris')]);
+      acc[row?.mandataris?.value] = Object.assign(dataPart, dataPart2[row?.mandataris?.value]);
       return acc;
     }, {});
 
@@ -177,9 +177,9 @@ export default {
   const queryResponsePart4 = await batchedQuery(queryStringPart4);
     const dataPart4 = queryResponsePart4.results.bindings.reduce( (acc, row) => {
       let dataPart = {
-        fractieNaam: getSafeValue(row, 'fractieNaam')
+        fractieNaam: row?.fractieNaam?.value
       };
-      acc[getSafeValue(row, 'mandataris')] = Object.assign(dataPart, dataPart3[getSafeValue(row, 'mandataris')]);
+      acc[row?.mandataris?.value] = Object.assign(dataPart, dataPart3[row?.mandataris?.value]);
       return acc;
     }, {});
 
@@ -191,7 +191,3 @@ export default {
     ], reportData);
   }
 };
-
-function getSafeValue(entry, property){
-  return entry[property] ? entry[property].value: null;
-}

--- a/config/reports/mandatarissenWithEmptyPersonReport.js
+++ b/config/reports/mandatarissenWithEmptyPersonReport.js
@@ -32,9 +32,9 @@ export default {
     const data = queryResponse.results.bindings.map((result) => {
       return {
         mandataris: result.mandataris.value,
-        start: getSafeValue(result, 'start'),
-        end: getSafeValue(result, 'end'),
-        role: getSafeValue(result, 'role'),
+        start: result?.start?.value,
+        end: result?.end?.value,
+        role: result?.role?.value,
         person: result.person.value
       };
     });
@@ -42,12 +42,3 @@ export default {
     await generateReportFromData(data, ['mandataris', 'start', 'end', 'role', 'person'], reportData);
   }
 };
-
-function getSafeValue(entry, property){
-  return entry[property] ? wrapInQuote(entry[property].value) : null;
-}
-
-// Some values might contain comas, wrapping them in escapes quotes doesn't disturb the colomns
-function wrapInQuote(value) {
-  return `\"${value}\"`;
-}

--- a/config/reports/personsMissingDataReport.js
+++ b/config/reports/personsMissingDataReport.js
@@ -29,10 +29,10 @@ export default {
     const queryResponsePart1 = await batchedQuery(queryStringPart1);
 
     const dataPart1 = queryResponsePart1.results.bindings.reduce( (acc, row) => {
-      acc[getSafeValue(row, 'person')] = {
-        person: getSafeValue(row, 'person'),
-        firstName: getSafeValue(row, 'firstName'),
-        lastName: getSafeValue(row, 'lastName')
+      acc[row?.person?.value] = {
+        person: row?.person?.value,
+        firstName: row?.firstName?.value,
+        lastName: row?.lastName?.value
       };
       return acc;
     }, {});
@@ -52,15 +52,15 @@ export default {
     const queryResponsePart2 = await batchedQuery(queryStringPart2);
     const dataPart2 = queryResponsePart2.results.bindings.reduce( (acc, row) => {
       let dataPart = {
-        person: getSafeValue(row, 'person'),
-        mandataris: getSafeValue(row, 'mandataris')
+        person: row?.person?.value,
+        mandataris: row?.mandataris?.value
       };
 
-      if(acc[getSafeValue(row, 'person')] && acc[getSafeValue(row, 'person')].mandataris) {
-        dataPart.mandataris = `${acc[getSafeValue(row, 'person')].mandataris} ---and--- ${dataPart.mandataris}`;
+      if(acc[row?.person?.value] && acc[row?.person?.value].mandataris) {
+        dataPart.mandataris = `${acc[row?.person?.value].mandataris} ---and--- ${dataPart.mandataris}`;
       }
 
-      acc[getSafeValue(row, 'person')] = Object.assign(dataPart, dataPart1[getSafeValue(row, 'person')]);
+      acc[row?.person?.value] = Object.assign(dataPart, dataPart1[row?.person?.value]);
       return acc;
     }, {});
 
@@ -90,11 +90,11 @@ export default {
     const queryResponsePart3 = await batchedQuery(queryStringPart3);
     const dataPart3 = queryResponsePart3.results.bindings.reduce( (acc, row) => {
       let dataPart = {
-        person: getSafeValue(row, 'person'),
-        gender: getSafeValue(row, 'gender'),
-        birthDate: getSafeValue(row, 'birthDate')
+        person: row?.person?.value,
+        gender: row?.gender?.value,
+        birthDate: row?.birthDate?.value
       };
-      acc[getSafeValue(row, 'person')] = Object.assign(dataPart, dataPart2[getSafeValue(row, 'person')] || dataPart1[getSafeValue(row, 'person')]); // dataPart2 can be empty if no mandataris found
+      acc[row?.person?.value] = Object.assign(dataPart, dataPart2[row?.person?.value] || dataPart1[row?.person?.value]); // dataPart2 can be empty if no mandataris found
       return acc;
     }, {});
 
@@ -103,7 +103,3 @@ export default {
     ], reportData);
   }
 };
-
-function getSafeValue(entry, property){
-  return entry[property] ? entry[property].value: null;
-}

--- a/config/reports/submissionsReport.js
+++ b/config/reports/submissionsReport.js
@@ -42,8 +42,8 @@ export default {
 
     const queryResponsePart1 = await batchedQuery(queryStringPart1);
     const dataToEnrich = queryResponsePart1.results.bindings.map((row) => ({
-        s: getSafeValue(row, 's'),
-        file: getSafeValue(row, 'file')
+        s: row?.s?.value,
+        file: row?.file?.value
     }));
 
     // Group the files in a field
@@ -172,22 +172,22 @@ export default {
     const queryResponsePart2 = await batchedQuery(queryStringPart2);
     const dataPart2 = queryResponsePart2.results.bindings.reduce( (acc, row) => {
       let dataPart = {
-        verstuurd: getSafeValue(row, 'verstuurd'),
-        typeDossier: getSafeValue(row, 'typeDossier'),
-        typeReglementOfVerordening: getSafeValue(row, 'typeReglementOfVerordening'),
-        soortBelasting: getSafeValue(row, 'soortBelasting'),
-        bestuurseenheidLabel: getSafeValue(row, 'bestuurseenheidLabel'),
-        bestuursorgaanInTijd: getSafeValue(row, 'bot'),
-        bestuursorgaan: getSafeValue(row, 'bestuursorgaan'),
-        bestuursorgaanLabel: getSafeValue(row, 'bestuursorgaanLabel'),
-        bestuursorgaanClassificatie: getSafeValue(row, 'bestuursorgaanClassificatieLabel'),
-        typeBestuur: getSafeValue(row, 'typeBestuur'),
-        angemaaktDoor: getSafeValue(row, 'angemaaktDoor'),
-        gewijzigdDoor: getSafeValue(row, 'gewijzigdDoor'),
-        statusLabel: getSafeValue(row, 'statusLabel'),
-        datumZitting: getSafeValue(row, 'datumZitting'),
-        link: getSafeValue(row, 'link')      };
-      acc[getSafeValue(row, 's')] = Object.assign(dataPart, dataPart1[getSafeValue(row, 's')]);
+        verstuurd: row?.verstuurd?.value,
+        typeDossier: row?.typeDossier?.value,
+        typeReglementOfVerordening: row?.typeReglementOfVerordening?.value,
+        soortBelasting: row?.soortBelasting?.value,
+        bestuurseenheidLabel: row?.bestuurseenheidLabel?.value,
+        bestuursorgaanInTijd: row?.bot?.value,
+        bestuursorgaan: row?.bestuursorgaan?.value,
+        bestuursorgaanLabel: row?.bestuursorgaanLabel?.value,
+        bestuursorgaanClassificatie: row?.bestuursorgaanClassificatieLabel?.value,
+        typeBestuur: row?.typeBestuur?.value,
+        angemaaktDoor: row?.angemaaktDoor?.value,
+        gewijzigdDoor: row?.gewijzigdDoor?.value,
+        statusLabel: row?.statusLabel?.value,
+        datumZitting: row?.datumZitting?.value,
+        link: row?.link?.value      };
+      acc[row?.s?.value] = Object.assign(dataPart, dataPart1[row?.s?.value]);
       return acc;
     }, {});
 
@@ -219,9 +219,9 @@ export default {
     const queryResponsePart3 = await batchedQuery(queryStringPart3);
     const dataPart3 = queryResponsePart3.results.bindings.reduce( (acc, row) => {
       let dataPart = {
-        datumPublicatie: getSafeValue(row, 'datumPublicatie')
+        datumPublicatie: row?.datumPublicatie?.value
       };
-      acc[getSafeValue(row, 's')] = Object.assign(dataPart, dataPart2[getSafeValue(row, 's')]);
+      acc[row?.s?.value] = Object.assign(dataPart, dataPart2[row?.s?.value]);
       return acc;
     }, {});
 
@@ -254,13 +254,4 @@ function groupFilesBySubmission(data) {
       o.files = filesFromSameSubmission.map(f => f.file).join(",");
     }
   })
-}
-
-function getSafeValue(entry, property){
-  return entry[property] ? wrapInQuote(entry[property].value) : null;
-}
-
-// Some values might contain comas, wrapping them in escapes quotes doesn't disturb the colomns
-function wrapInQuote(value) {
-  return `\"${value}\"`;
 }

--- a/config/reports/ukraineSubsidyOproep1Report.js
+++ b/config/reports/ukraineSubsidyOproep1Report.js
@@ -1,5 +1,4 @@
 import { generateReportFromData, batchedQuery } from "../helpers.js";
-import { getSafeValue } from "./util/report-helpers";
 
 export default {
   cronPattern: "0 30 23 * * *",
@@ -87,26 +86,23 @@ export default {
     const queryResponse = await batchedQuery(queryString);
     const data = queryResponse.results.bindings.map((subsidie) => {
       return {
-        subsidieURI: getSafeValue(subsidie, "subsidie"),
-        modified: getSafeValue(subsidie, "modified"),
-        status: getSafeValue(subsidie, "status"),
-        bestuurseenheid: getSafeValue(subsidie, "bestuurseenheid"),
-        kbo: getSafeValue(subsidie, "kbo"),
-        classificatie: getSafeValue(subsidie, "classificatie"),
-        contactFirstName: getSafeValue(subsidie, "contactFirstName"),
-        contactLastName: getSafeValue(subsidie, "contactLastName"),
-        contactTelephone: getSafeValue(subsidie, "contactTelephone"),
-        contactEmail: getSafeValue(subsidie, "contactEmail"),
-        rekeningnummer: getSafeValue(subsidie, "rekeningnummer"),
-        reeks: getSafeValue(subsidie, "reeks"),
-        reeksStart: getSafeValue(subsidie, "reeksStart"),
-        reeksEnd: getSafeValue(subsidie, "reeksEnd"),
-        address: getSafeValue(subsidie, "address"),
-        aantalSlaapkamers: getSafeValue(subsidie, "aantalSlaapkamers"),
-        facturenGemeenschDelen: getSafeValue(
-          subsidie,
-          "facturenGemeenschDelen"
-        ),
+        subsidieURI: subsidie?.subsidie?.value,
+        modified: subsidie?.modified?.value,
+        status: subsidie?.status?.value,
+        bestuurseenheid: subsidie?.bestuurseenheid?.value,
+        kbo: subsidie?.kbo?.value,
+        classificatie: subsidie?.classificatie?.value,
+        contactFirstName: subsidie?.contactFirstName?.value,
+        contactLastName: subsidie?.contactLastName?.value,
+        contactTelephone: subsidie?.contactTelephone?.value,
+        contactEmail: subsidie?.contactEmail?.value,
+        rekeningnummer: subsidie?.rekeningnummer?.value,
+        reeks: subsidie?.reeks?.value,
+        reeksStart: subsidie?.reeksStart?.value,
+        reeksEnd: subsidie?.reeksEnd?.value,
+        address: subsidie?.address?.value,
+        aantalSlaapkamers: subsidie?.aantalSlaapkamers?.value,
+        facturenGemeenschDelen: subsidie?.facturenGemeenschDelen?.value,
       };
     });
 

--- a/config/reports/util/report-helpers.js
+++ b/config/reports/util/report-helpers.js
@@ -16,23 +16,10 @@ export async function generateReportFromQueryResult({results, head}, metadata) {
     const data = bindings.map(row => {
       const obj = {};
       vars.forEach((variable) => {
-        obj[variable] = getSafeValue(row, variable);
+        obj[variable] = row[variable]?.value;
       });
       return obj;
     });
     await generateReportFromData(data, vars, metadata);
   }
-}
-
-/**
- * Translate a query-result row variable to a CSV safe value
- *
- * Some values might contain comas, wrapping them in escapes quotes doesn't disturb the columns
- *
- * @param row
- * @param variable
- * @returns {string|null}
- */
-export function getSafeValue(row, variable) {
-  return row[variable] ? `\"${row[variable].value}\"` : null;
 }


### PR DESCRIPTION
**[DL-5811]**

Some reports used a function called `getSafeValue` which was always redefined in those reports. This function provides safe property access that can more easily be written with the `?.` operation.

In most cases, it also calls a function `wrapInQuote` that wraps the values in the report with an extra double quote, which is no longer needed in newer versions of the `loket-report-generation-service`. In fact it is this function that is causing reports to be printed with too many quotes, making the reports unusable.

This PR removes those functions and relies on the better CSV handling in the service itself.