### PR TITLE
Bump adressenregister-fuzzy-search-service to v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Fixes
  - Bump berichtencentrum-email-notification-service, which fixes the general problem where no emails about messages get sent. (DL-5775)
    Note: It will already be deployed on production (`docker-compose.override.yml`) before this release gets deployed
+ - Bump `adressenregister-fuzzy-search-service` to `v0.8.0`(DL-5822)
 #### New Organizations
  - Add a new politiezone: `PZ Aalter/Maldegem: Aalter en Maldegem` (DL-5730)
  - Add a new OCMW vereniging: `Ter Lembeek` (DL-5739)
@@ -12,6 +13,7 @@
 #### Docker Commands
  - `drc restart migrations`
  - `drc restart resource cache`
+ - `drc up -d adressenregister`
 ## 1.96.0 (2024-03-25)
 ### Reports
  - Changed Report on Berichten: increased history to 12 months, changed column order and attachments are formatted with their filename. (DL-5696)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,7 +247,7 @@ services:
     restart: always
     logging: *default-logging
   adressenregister:
-    image: lblod/adressenregister-fuzzy-search-service:0.6.3
+    image: lblod/adressenregister-fuzzy-search-service:0.8.0
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
# Description
DL-5822

This PR bumps adressenregister-fuzzy-search-service to v0.8.0 to use the api v2 instead of the decommissioned v1.

This affects multiple modules 

leidinggevenden
![Screenshot 2024-04-05 at 16-30-14 Loket voor lokale besturen](https://github.com/lblod/app-digitaal-loket/assets/38471754/db98bc82-e1a6-43ac-ac84-163d281e8b85)

Eredienst mandatarissen
![Screenshot 2024-04-05 at 16-28-22 Bewerk Mandataris David Test Mandatenbeheer Loket voor lokale besturen](https://github.com/lblod/app-digitaal-loket/assets/38471754/312c4507-0a60-4cf4-b2f3-27cc9fb83540)

Eredienst bedienaren
![Screenshot 2024-04-05 at 16-26-06 Voeg bedienaar toe Bedienarenbeheer Loket voor lokale besturen](https://github.com/lblod/app-digitaal-loket/assets/38471754/378562b0-e3cf-4d16-b869-fec8fe07e6ba)


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

# Related services

- https://github.com/lblod/adressenregister-fuzzy-search-service

# How to test 
 
Already tested

# What to check

- N/A

# Links to other PR's

- N/A

# Notes
