### PR TITLE
Use the ACM/IDM admin role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 #### Frontend
+ - `v0.92.1` (DL-5790): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0921-2024-04-08
  - `v0.92.0` (DL-5790): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0920-2024-04-04
 ### General
 #### Fixes

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -558,7 +558,7 @@ defmodule Acl.UserGroups.Config do
        %GroupSpec{
          name: "o-admin-sessions-rwf",
          useage: [:read, :write, :read_for_write],
-         access: access_by_role_for_single_graph( "LoketAdmin" ),
+         access: access_by_role_for_single_graph( "LoketLB-admin" ),
          graphs: [
            %GraphSpec{
              graph: "http://mu.semte.ch/graphs/sessions",
@@ -572,6 +572,7 @@ defmodule Acl.UserGroups.Config do
        %GroupSpec{
           name: "o-admin-rwf",
           useage: [:read, :write, :read_for_write],
+          # we're currently transitioning from a local admin role to an acm provided admin role. This will be fixed soon.
           access: access_by_role( "LoketAdmin" ),
           graphs: [ %GraphSpec{
                       graph: "http://mu.semte.ch/graphs/organizations/",
@@ -589,7 +590,8 @@ defmodule Acl.UserGroups.Config do
        %GroupSpec{
           name: "o-admin-rwf",
           useage: [:read, :write, :read_for_write],
-          access: access_by_role_for_single_graph( "LoketAdmin" ), #access_by_role_for_single_graph( "LoketAdmin" ),
+          # we're currently transitioning from a local admin role to an ACM/IDM provided admin role. This will be fixed soon.
+          access: access_by_role_for_single_graph( "LoketAdmin" ),
           graphs: [ %GraphSpec{
                       graph: "http://mu.semte.ch/graphs/harvesting",
                       constraint: %ResourceConstraint{

--- a/config/migrations/2024/20240408142300-mock-admin-correct-role.sparql
+++ b/config/migrations/2024/20240408142300-mock-admin-correct-role.sparql
@@ -1,0 +1,14 @@
+INSERT {
+  GRAPH ?g {
+    ?mock <http://mu.semte.ch/vocabularies/ext/sessionRole> "LoketLB-admin" .
+  }
+}
+WHERE {
+  VALUES ?mock {
+    <http://data.lblod.info/id/account/3a91ff60-07c1-4136-ac5e-55cf401e0956>
+  }
+
+  GRAPH ?g {
+    ?mock <http://mu.semte.ch/vocabularies/ext/sessionRole> ?role .
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   loket:
-    image: lblod/frontend-loket:0.92.0
+    image: lblod/frontend-loket:0.92.1
     links:
       - identifier:backend
     labels:


### PR DESCRIPTION
This updates the setup so it uses the `LoketLB-admin` role, (which is the one that ACM/IDM returns according to the login service logs on QA), for the impersonation feature.

There is already existing code that also uses the `LoketAdmin` role, but those are still required until ACM/IDM is enabled everywhere.