### PR TITLE
Adjust report `Toezicht module: Meldingen` and `Eredienst mandatarissen`

### DIFF
--- a/config/reports/toezicht-submissions/submissions.js
+++ b/config/reports/toezicht-submissions/submissions.js
@@ -53,7 +53,8 @@ PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 SELECT DISTINCT 
 (?submission AS ?melding) 
 (?labelBestuurseenheidClassification AS ?typeBestuur) 
-(?labelBestuurseenheid AS ?bestuurseenheid)
+?labelBestuurseenheid
+?bestuurseenheid
 (?labelBestuursorgaanClassificatie AS ?typeBestuursorgaan)
 ?bestuursorgaanInTijd
 ?aangemaaktDoor

--- a/config/reports/worship/mandatarissen.js
+++ b/config/reports/worship/mandatarissen.js
@@ -186,6 +186,21 @@ async function generate() {
       .parseJsonResults(eenhedenResponse)
       .map((i) => i.range);
 
+    // //TypeEredienst
+    const typeEredienstQuery = queries.domainToRange(
+      eenheden,
+      ns.ere`typeEredienst`,
+      ns.organ`TypeEredienst`
+    );
+    const typeEredienstResponse = await mas.querySudo(
+      typeEredienstQuery,
+      undefined,
+      connectionOptions
+    );
+    const typeEredienst = sparqlJsonParser
+      .parseJsonResults(typeEredienstResponse)
+      .map((i) => i.range);
+
     const allSubjects = uti.dedup(
       [
         ...mandatarissenSlice,
@@ -199,6 +214,7 @@ async function generate() {
         ...besturenInTijd,
         ...besturen,
         ...eenheden,
+        ...typeEredienst,
       ],
       'value'
     );
@@ -226,6 +242,7 @@ async function generate() {
     [
       'eenheid',
       'eenheidnaam',
+      'typeEredienstLabel',
       'bestuurnaam',
       'bestuurInTijd',
       'bestuurInTijdStart',
@@ -418,6 +435,15 @@ function combineMandatarissenData(store) {
           )[0];
         const eenheidnaam = store.readQuads(eenheid, ns.skos`prefLabel`).next()
           .value?.object?.value;
+        const typeEredienstLabel = store
+          .getObjects(eenheid, ns.ere`typeEredienst`)
+          .filter((p) =>
+            store.has(p, ns.rdf`type`, ns.organ`TypeEredienst`)
+          )
+          .map(
+            (f) =>
+              store.readQuads(f, ns.skos`prefLabel`).next().value?.object?.value
+          )[0];
 
         const collectBestuurInTijd = {
           bestuurInTijd: bestuurInTijd?.value,
@@ -426,6 +452,7 @@ function combineMandatarissenData(store) {
           bestuurnaam,
           eenheid: eenheid?.value,
           eenheidnaam,
+          typeEredienstLabel,
         };
 
         data.push({ ...collect, ...collectBestuurInTijd });


### PR DESCRIPTION
# Description
DL-5815

This PR adds bestuurseenheid URI in report `Toezicht module: Meldingen` and typeEredienstLabel in report `Eredienst mandatarissen`.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- report-generation

# How to test 

1. Add in `docker-compose.override.yml` 
```yml
  report-generation:
    links:
      - virtuoso:database  # we need to because performance
    ports:
      - 9999:80
```
3. `drc up -d`
4. Toezicht module: Meldingen → 
```bash 
curl -X POST -H "Content-Type: application/vnd.api+json"  -d '{  "data": { "attributes": { "reportName": "toezicht-submissions" }  }  }'  http://localhost:9999/reports
```
5. Eredienst mandatarissen → 
```bash 
curl -X POST -H "Content-Type: application/vnd.api+json"  -d '{  "data": { "attributes": { "reportName": "eredienst-mandatarissen" }  }  }'  http://localhost:9999/reports
```
6. Generated report = `{"data":{"type":"report-generation-tasks","attributes":{"status":"success"}}}` and should be visible in `/data/files/`

# What to check

- N/A

# Links to other PR's

- N/A

# Notes

- Update changelog