### PR TITLE
Adjust report `messages with provenance`

### DIFF
--- a/config/reports/berichten/messages-with-provenance.js
+++ b/config/reports/berichten/messages-with-provenance.js
@@ -119,7 +119,7 @@ async function generate() {
     {
       title: 'Message report with provenance',
       description: 'Report about the Conversations and Messages with where they came from in the past 12 months.',
-      filePrefix: 'messages-with-provenance-6-months',
+      filePrefix: 'messages-with-provenance-12-months',
     },
   );
 }

--- a/config/reports/berichten/messages-with-provenance.js
+++ b/config/reports/berichten/messages-with-provenance.js
@@ -42,6 +42,8 @@ async function generate() {
     const recipient = detailsStore.getObjects(message, ns.sch`recipient`)[0];
     const recipientV = recipient?.value;
     const recipientnameV = detailsStore.getObjects(recipient, ns.skos`prefLabel`)[0]?.value;
+    const recipientClassificatieCode = detailsStore.getObjects(recipientV, ns.besluit`classificatie`)[0]?.value;
+    const recipientTypeBestuur = detailsStore.getObjects(recipientClassificatieCode, ns.skos`prefLabel`)[0]?.value;
     const confirmedStatus = detailsStore.getObjects(message, ns.adms`status`)[0];
     let job = detailsStore.getSubjects(ns.dct`subject`, message)[0];
     job = detailsStore.has(job, ns.rdf`type`, ns.cogs`Job`) ? job : undefined;
@@ -66,6 +68,7 @@ async function generate() {
         recipient: recipientV,
         sendername: sendernameV,
         recipientname: recipientnameV,
+        recipientTypeBestuur,
         provenance: provenanceV,
         attachmentSequence: '0/0',
         filename: '',
@@ -89,6 +92,7 @@ async function generate() {
         recipient: recipientV,
         sendername: sendernameV,
         recipientname: recipientnameV,
+        recipientTypeBestuur,
         provenance: provenanceV,
         attachmentSequence: attachmentSeqV,
         filename: filenameV,
@@ -108,6 +112,7 @@ async function generate() {
       'sendername',
       'recipient',
       'recipientname',
+      'recipientTypeBestuur',
       'type',
       'dateSent',
       'dateReceived',

--- a/config/reports/berichten/messages-with-provenance.js
+++ b/config/reports/berichten/messages-with-provenance.js
@@ -39,11 +39,21 @@ async function generate() {
     const sender = detailsStore.getObjects(message, ns.sch`sender`)[0];
     const senderV = sender?.value;
     const sendernameV = detailsStore.getObjects(sender, ns.skos`prefLabel`)[0]?.value;
+    const senderClassificatieCode = detailsStore.getObjects(sender, ns.besluit`classificatie`)[0];
+    let senderTypeBestuurV;
+    if (senderClassificatieCode) {
+      const senderTypeBestuur = detailsStore.getObjects(senderClassificatieCode, ns.skos`prefLabel`)[0];
+      senderTypeBestuurV = senderTypeBestuur?.value;
+    }
     const recipient = detailsStore.getObjects(message, ns.sch`recipient`)[0];
     const recipientV = recipient?.value;
     const recipientnameV = detailsStore.getObjects(recipient, ns.skos`prefLabel`)[0]?.value;
-    const recipientClassificatieCode = detailsStore.getObjects(recipientV, ns.besluit`classificatie`)[0]?.value;
-    const recipientTypeBestuur = detailsStore.getObjects(recipientClassificatieCode, ns.skos`prefLabel`)[0]?.value;
+    const recipientClassificatieCode = detailsStore.getObjects(recipient, ns.besluit`classificatie`)[0];
+    let recipientTypeBestuurV;
+    if (recipientClassificatieCode) {
+      const recipientTypeBestuur = detailsStore.getObjects(recipientClassificatieCode, ns.skos`prefLabel`)[0];
+      recipientTypeBestuurV = recipientTypeBestuur?.value;
+    }
     const confirmedStatus = detailsStore.getObjects(message, ns.adms`status`)[0];
     let job = detailsStore.getSubjects(ns.dct`subject`, message)[0];
     job = detailsStore.has(job, ns.rdf`type`, ns.cogs`Job`) ? job : undefined;
@@ -67,8 +77,9 @@ async function generate() {
         sender: senderV,
         recipient: recipientV,
         sendername: sendernameV,
+        senderTypeBestuur: senderTypeBestuurV,
         recipientname: recipientnameV,
-        recipientTypeBestuur,
+        recipientTypeBestuur: recipientTypeBestuurV,
         provenance: provenanceV,
         attachmentSequence: '0/0',
         filename: '',
@@ -91,8 +102,9 @@ async function generate() {
         sender: senderV,
         recipient: recipientV,
         sendername: sendernameV,
+        senderTypeBestuur: senderTypeBestuurV,
         recipientname: recipientnameV,
-        recipientTypeBestuur,
+        recipientTypeBestuur: recipientTypeBestuurV,
         provenance: provenanceV,
         attachmentSequence: attachmentSeqV,
         filename: filenameV,
@@ -110,6 +122,7 @@ async function generate() {
       'message',
       'sender',
       'sendername',
+      'senderTypeBestuur',
       'recipient',
       'recipientname',
       'recipientTypeBestuur',

--- a/config/reports/berichten/queries.js
+++ b/config/reports/berichten/queries.js
@@ -90,6 +90,8 @@ CONSTRUCT {
     a cogs:Job .
   ?sender skos:prefLabel ?sendername .
   ?recipient skos:prefLabel ?recipientname .
+  ?senderClassificatieCode skos:prefLabel ?senderTypeBestuur .
+  ?recipientClassificatieCode skos:prefLabel ?recipientTypeBestuur .
 }
 WHERE {
   VALUES ?message { ${rst.termToString(message)} }
@@ -128,10 +130,18 @@ WHERE {
   OPTIONAL {
     ?message sch:sender ?sender .
     ?sender skos:prefLabel ?sendername .
+    OPTIONAL {
+      ?sender besluit:classificatie ?senderClassificatieCode .
+      ?senderClassificatieCode skos:prefLabel ?senderTypeBestuur .
+    }
   }
   OPTIONAL {
     ?message sch:recipient ?recipient .
     ?recipient skos:prefLabel ?recipientname .
+    OPTIONAL {
+      ?recipient besluit:classificatie ?recipientClassificatieCode .
+      ?recipientClassificatieCode skos:prefLabel ?recipientTypeBestuur .
+    }
   }
 }`;
 }

--- a/config/reports/berichten/queries.js
+++ b/config/reports/berichten/queries.js
@@ -88,8 +88,12 @@ CONSTRUCT {
     task:operation jo:harvestBericht ;
     dct:creator ?creator ;
     a cogs:Job .
-  ?sender skos:prefLabel ?sendername .
-  ?recipient skos:prefLabel ?recipientname .
+  ?sender 
+    skos:prefLabel ?sendername ;
+    besluit:classificatie ?senderClassificatieCode .
+  ?recipient
+    skos:prefLabel ?recipientname ;
+    besluit:classificatie ?recipientClassificatieCode .
   ?senderClassificatieCode skos:prefLabel ?senderTypeBestuur .
   ?recipientClassificatieCode skos:prefLabel ?recipientTypeBestuur .
 }


### PR DESCRIPTION
# Description
DL-5836

This PR adds two extra columns `senderTypeBestuur` and `recipientTypeBestuur` for `messages with provenance` report, it also adjusts the file prefix `messages-with-provenance-12-months` where it's 12 instead of 6.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

# Related services

- report-generation

# How to test 

1. Add in `docker-compose.override.yml` 
```yml
  report-generation:
    links:
      - virtuoso:database  # we need to because performance
    ports:
      - 9999:80
```
3. `drc up -d`
4. Toezicht module: Meldingen → 
```bash 
curl -X POST -H "Content-Type: application/vnd.api+json"  -d '{  "data": { "attributes": { "reportName": "messages-with-provenance" }  }  }'  http://localhost:9999/reports
```
5. Generated report = `{"data":{"type":"report-generation-tasks","attributes":{"status":"success"}}}` and should be visible in `/data/files/`

# What to check

- N/A

# Links to other PR's

- N/A

# Notes

- Update changelog