### PR TITLE
Chore/use updated delta publication graph maintainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Fixes
+- Bump delta-producer-publication-graph-maintainer [DL-4527] and related [OP-3151]
+### Deploy Notes
+- `drc up -d delta-producer-publication-graph-maintainer; drc restart deltanotifier`
 ## 1.98.1 (2024-05-27)
 ### Fixes
  - Bump `worship-positions-graph-dispatcher-service-loket` to fix missing data in some organisations (DL-5823). This new version is better at dispatching data with its entire hierarchical model. For this, a migration needs to run to completion and this service then needs to be restarted. You can `drc up -d` it at the end of the deploy. This is included in the commands below.

--- a/config/delta-producer/publication-graph-maintainer/config.json
+++ b/config/delta-producer/publication-graph-maintainer/config.json
@@ -1,7 +1,6 @@
 {
   "submissions": {
     "deltaInterval": 10000,
-    "deltaPath": "/submissions/delta",
     "errorCreatorUri": "http://lblod.data.gift/services/delta-producer-publication-graph-maintainer-submissions",
     "exportConfigPath": "/config/submissions/export.json",
     "filesPath": "/submissions/files",
@@ -22,7 +21,6 @@
   },
   "persons-sensitive": {
     "deltaInterval": 10000,
-    "deltaPath": "/persons-sensitive/delta",
     "errorCreatorUri": "http://lblod.data.gift/services/delta-producer-publication-graph-maintainer-persons-sensitive",
     "exportConfigPath": "/config/persons-sensitive/export.json",
     "filesPath": "/persons-sensitive/files",
@@ -62,14 +60,12 @@
     "updatePublicationGraphSleep": 200,
     "serveDeltaFiles": true,
     "deltaInterval": 10000,
-    "deltaPath": "/worship-submissions/delta",
     "loginPath": "/worship-submissions/login",
     "publisherUri": "http://data.lblod.info/services/delta-producer-publication-graph-maintainer-worship-submissions",
     "filesGraph": "http://redpencil.data.gift/id/deltas/producer/worship-submissions-deltas",
     "account": "http://data.lblod.info/foaf/account/id/dd85f516-ee7c-406b-8245-91ce7f9545b7"
   },
   "mandatarissen": {
-    "deltaPath": "/mandatarissen/delta",
     "errorCreatorUri": "http://lblod.data.gift/services/delta-producer-publication-graph-maintainer-mandatarissen",
     "exportConfigPath": "/config/mandatarissen/export.json",
     "filesPath": "/mandatarissen/files",
@@ -92,7 +88,6 @@
     "loginPath": "/mandatarissen/login"
   },
   "leidinggevenden": {
-    "deltaPath": "/leidinggevenden/delta",
     "errorCreatorUri": "http://lblod.data.gift/services/delta-producer-publication-graph-maintainer-leidinggevenden",
     "exportConfigPath": "/config/leidinggevenden/export.json",
     "filesPath": "/leidinggevenden/files",
@@ -132,7 +127,6 @@
     "updatePublicationGraphSleep": 200,
     "serveDeltaFiles": true,
     "deltaInterval": 10000,
-    "deltaPath": "/vendor-management/delta",
     "loginPath": "/vendor-management/login",
     "publisherUri": "http://data.lblod.info/services/delta-producer-publication-graph-maintainer-vendor-management",
     "filesGraph": "http://redpencil.data.gift/id/deltas/producer/vendor-management-deltas",

--- a/config/delta/delta-producer-publication-graph-maintainer.js
+++ b/config/delta/delta-producer-publication-graph-maintainer.js
@@ -4,7 +4,7 @@ export default [
       // anything
     },
     callback: {
-      url: 'http://delta-producer-publication-graph-maintainer/submissions/delta',
+      url: 'http://delta-producer-publication-graph-maintainer/delta',
       method: 'POST'
     },
     options: {
@@ -16,113 +16,5 @@ export default [
                           "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
                         ]
     }
-  },
-  {
-    match: {
-      // anything
-    },
-    callback: {
-      url: 'http://delta-producer-publication-graph-maintainer/persons-sensitive/delta',
-      method: 'POST'
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: [
-                          "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
-                          "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
-                        ]
-    }
-  },
-  {
-    match: {
-      // anything
-    },
-    callback: {
-      url: 'http://delta-producer-publication-graph-maintainer/worship-submissions/delta',
-      method: 'POST'
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: [
-        "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
-        "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
-      ]
-    }
-  },
-  {
-    match: {
-      // anything
-    },
-    callback: {
-      url: 'http://delta-producer-publication-graph-maintainer/mandatarissen/delta',
-      method: 'POST'
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: [
-                          "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
-                          "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
-                        ]
-    }
-  },
-  {
-    match: {
-      // anything
-    },
-    callback: {
-      url: 'http://delta-producer-publication-graph-maintainer/leidinggevenden/delta',
-      method: 'POST'
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: [
-                          "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
-                          "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
-                        ]
-    }
-  },
-  {
-    match: {
-      // anything
-    },
-    callback: {
-      url: 'http://delta-producer-publication-graph-maintainer/vendor-management/delta',
-      method: 'POST'
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: [
-        "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
-        "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
-      ]
-    }
-  },
-  {
-    match: {
-      // anything
-    },
-    callback: {
-      url: 'http://delta-producer-publication-graph-maintainer/worship-services-sensitive/delta',
-      method: 'POST'
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: [
-        "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
-        "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
-      ]
-    }
-  },
+  }
 ];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -548,7 +548,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-publication-graph-maintainer:
-    image: lblod/delta-producer-publication-graph-maintainer:1.1.0-rc.3
+    image: lblod/delta-producer-publication-graph-maintainer:1.1.1
     environment:
       MAX_BODY_SIZE: "50mb"
       PRETTY_PRINT_DIFF_JSON: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -548,7 +548,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-publication-graph-maintainer:
-    image: lblod/delta-producer-publication-graph-maintainer:1.0.8
+    image: lblod/delta-producer-publication-graph-maintainer:1.1.0-rc.1
     environment:
       MAX_BODY_SIZE: "50mb"
       PRETTY_PRINT_DIFF_JSON: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -548,7 +548,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-publication-graph-maintainer:
-    image: lblod/delta-producer-publication-graph-maintainer:1.1.0-rc.1
+    image: lblod/delta-producer-publication-graph-maintainer:1.1.0-rc.3
     environment:
       MAX_BODY_SIZE: "50mb"
       PRETTY_PRINT_DIFF_JSON: "true"


### PR DESCRIPTION
This PR, uses the version of publication graph maintainer: https://github.com/lblod/delta-producer-publication-graph-maintainer/pull/32
Updated the configuration. (Even if not strictly necessary)

If you want to test `drc up -d`. Assuming you ran all initial syncs. Else you can  use the configuration `waitForInitialSync: false` per deltastream.

What to test?
- does it produces delta files at the expected location. (So just check the created files)
- Doe it still respond to background jobs?

I don't expect any other issues.
SeeAlso: DL-4527