### PR TITLE
Add a placeholder HOSTNAME for the vendor-data-distribution service 

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -143,6 +143,8 @@ services:
   sparql-authorization-wrapper:
     restart: "no"
   vendor-data-distribution:
+    environment:
+      HOSTNAME: "http://localhost"
     restart: "no"
   berichtencentrum-melding:
     restart: "no"


### PR DESCRIPTION
Without this variable the service crashes which causes issues with the deltanotifier in local development environments.