### PR TITLE
Task: add migration to update end date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 ## Unreleased
+### Subsidies
+ - Update Lekp 1.0 (2021 - 2024) opvolgmoment 2024 deadline (DGS-238)
 ### General
 #### Fixes
   - Update predicates to export for `melding:FormData` (in context of DL-5738)
 ### Deploy notes
 - `drc restart delta-producer-publication-graph-maintainer`
+- `drc restart migrations && drc logs -ft --tail=200 migrations`
+- `drc restart resource cache`
 ## 1.97.0 (2024-04-12)
 ### General
 #### Fixes

--- a/config/migrations/2024/subsidies/20240430132932-update-opvolgmoment-2024-deadline.sparql
+++ b/config/migrations/2024/subsidies/20240430132932-update-opvolgmoment-2024-deadline.sparql
@@ -20,7 +20,7 @@ WHERE {
       <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> # LEKP 1.0 subsidy deadline
       <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> # LEKP 1.0 Opvolgmoment 2024 step deadline
     }
-    ?s m8g:endTime ?endTimeSubsidy.
+    ?s m8g:endTime ?endTimeSubsidy .
     ?s m8g:endTime ?endTimeStep .
   }
 }

--- a/config/migrations/2024/subsidies/20240430132932-update-opvolgmoment-2024-deadline.sparql
+++ b/config/migrations/2024/subsidies/20240430132932-update-opvolgmoment-2024-deadline.sparql
@@ -1,0 +1,26 @@
+PREFIX m8g: <http://data.europa.eu/m8g/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+# Update LEKP 1.0 Opvolgmoment 2024 deadline
+DELETE {
+  GRAPH ?g {
+    ?s m8g:endTime ?endTimeSubsidy .
+    ?s m8g:endTime ?endTimeStep .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    # Time is set to 21:59:00 because Belgium time is UTC+2 instead of UTC+1 in June.
+    ?s m8g:endTime "2024-06-28T21:59:00Z"^^xsd:dateTime .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?s {
+      <http://data.lblod.info/id/periodes/d177ffb3-5934-4005-b481-5a424f136ec6> # LEKP 1.0 subsidy deadline
+      <http://data.lblod.info/id/periodes/cea1f5f8-a659-4f59-886a-fe8f75cb2305> # LEKP 1.0 Opvolgmoment 2024 step deadline
+    }
+    ?s m8g:endTime ?endTimeSubsidy.
+    ?s m8g:endTime ?endTimeStep .
+  }
+}


### PR DESCRIPTION
## ID
DGS-238

## Description

Update `LEKP 1.0 (2021 – 2024) - Opvolgmoment 2024` enddate to 28 june 2024.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Related services

- deltanotifier
- ...

## How to test

Verify the lekp 1.0 (2021 – 2024) has a new enddate of 28 june 2024 for the `opvolgmoment 2024` step