### PR TITLE
Redispatch Worship Position Data for full model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### Fixes
  - Fix reports with too many quotes around fields in the data. (DL-5811)
  - Bump `deltanotifier` (DL-5684)
+ - Bump `worship-positions-graph-dispatcher-service-loket` to fix missing data in some organisations (DL-5823)
 ### Deploy Notes
 #### Consolidation Worship-Sensitive Delta-Producer
 ##### Edit `config/delta-producer/background-jobs-initiator/config.override.json`
@@ -40,12 +41,15 @@ We no longer need this environment since we now have the admin role and imperson
 > The PROD environment has more controle-* prefixed services, but we can't remove those yet since they are used by the `vendor-management` and `dashboard` services as well.
 
 The standard `docker-compose.yml` config seems in accordance with what is provided by the dispatcher. Remember Loket exposed two flavors of paths, one for the files and one for the login.
+#### Worship position dispatcher
+There is a new version of the `dispatcher-worship-mandates` service. This new version is better at dispatching data with its entire hierarchical model. For this, a migration needs to run to completion and this service then needs to be restarted. You can `drc up -d` it at the end of the deploy. This is included in the commands below.
 #### Docker Commands
  - `drc up -d --remove-orphans deltanotifier automatic-submission loket`
  - `drc restart report-generation`
  - `drc restart delta-producer-publication-graph-maintainer enrich-submission`
  - `drc restart migrations && drc logs -ft --tail=200 migrations`
  - `drc restart resource cache database dispatcher identifier`
+ - `drc up -d dispatcher-worship-mandates`
 ## 1.97.2 (2024-05-02)
 ### General
  - bump-berichtencentrum (DL-5775)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 1.98.1 (2024-05-27)
+### Fixes
+ - Bump `worship-positions-graph-dispatcher-service-loket` to fix missing data in some organisations (DL-5823). This new version is better at dispatching data with its entire hierarchical model. For this, a migration needs to run to completion and this service then needs to be restarted. You can `drc up -d` it at the end of the deploy. This is included in the commands below.
+### Commands
+ - `drc restart migrations && drc logs -ft --tail=200 migrations` (wait for these to complete)
+ - `drc up -d dispatcher-worship-mandates`
 ## 1.98.0 (2024-05-16)
 #### Frontend
  - `v0.93.1` (DL-5888): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0931-2024-05-06
@@ -15,7 +21,6 @@
 #### Fixes
  - Fix reports with too many quotes around fields in the data. (DL-5811)
  - Bump `deltanotifier` (DL-5684)
- - Bump `worship-positions-graph-dispatcher-service-loket` to fix missing data in some organisations (DL-5823)
 ### Deploy Notes
 #### Consolidation Worship-Sensitive Delta-Producer
 ##### Edit `config/delta-producer/background-jobs-initiator/config.override.json`
@@ -44,15 +49,12 @@ We no longer need this environment since we now have the admin role and imperson
 > The PROD environment has more controle-* prefixed services, but we can't remove those yet since they are used by the `vendor-management` and `dashboard` services as well.
 
 The standard `docker-compose.yml` config seems in accordance with what is provided by the dispatcher. Remember Loket exposed two flavors of paths, one for the files and one for the login.
-#### Worship position dispatcher
-There is a new version of the `dispatcher-worship-mandates` service. This new version is better at dispatching data with its entire hierarchical model. For this, a migration needs to run to completion and this service then needs to be restarted. You can `drc up -d` it at the end of the deploy. This is included in the commands below.
 #### Docker Commands
  - `drc up -d --remove-orphans deltanotifier automatic-submission loket enrich-submission`
  - `drc restart report-generation`
  - `drc restart delta-producer-publication-graph-maintainer`
  - `drc restart migrations && drc logs -ft --tail=200 migrations`
  - `drc restart resource cache database dispatcher identifier`
- - `drc up -d dispatcher-worship-mandates`
 ## 1.97.2 (2024-05-02)
 ### General
  - bump-berichtencentrum (DL-5775)

--- a/config/migrations/2024/20240515000000-re-dispatch-previous-dispatched-subjects.sparql
+++ b/config/migrations/2024/20240515000000-re-dispatch-previous-dispatched-subjects.sparql
@@ -1,0 +1,16 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+INSERT {
+  GRAPH <http://eredienst-mandatarissen-consumer/temp-inserts> {
+    ?s rdf:type ?type .
+  }
+} WHERE {
+  VALUES ?type {
+    <http://data.lblod.info/vocabularies/erediensten/EredienstMandataris>
+    <http://data.lblod.info/vocabularies/erediensten/RolBedienaar>
+    <http://www.w3.org/ns/person#Person>
+    <http://schema.org/ContactPoint>
+  }
+  ?s rdf:type ?type .
+  ?s <http://www.w3.org/ns/prov#wasGeneratedBy> <http://lblod.data.gift/id/app/lblod-harvesting> .
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -448,9 +448,11 @@ services:
     restart: always
     logging: *default-logging
   dispatcher-worship-mandates:
-    image: lblod/worship-positions-graph-dispatcher-service-loket:1.4.0
+    image: lblod/worship-positions-graph-dispatcher-service-loket:1.5.0
     environment:
       LOGLEVEL: "info"
+      SUDO_QUERY_RETRY: "true"
+      SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: "500"
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
Previous Worship Position harvesting showed holes in the data caused by lacking dispatching logic. The dispatcher used to be naive and would only dispatch the data in the temp-inserts graph. This is a problem when multiple entities point to the same entity, but arrive out of order.

This new version of the `worship-positions-graph-dispatcher-service-loket` also copies related subjects to the allowed organisation graph, by searching data that points to the same subjects and has also been harvested by the same vendor, effectively filling up the holes in the data.

**On how to test**

Before checking out these changes and running the dispatching, checkout a couple of organisations with holes in the data for Mandaten and/or Bedienaren ([see examples here](https://binnenland.atlassian.net/browse/DL-5662)). Then run the migration and restart the `worship-positions-graph-dispatcher-service-loket` to trigger a re-dispatch. Wait for the `http://eredienst-mandatarissen-consumer/temp-inserts` graph to be empty (or the service to be finished). This can take a couple of hours. Check the same organisation to see if the data is repaired.