### PR TITLE
Adding new report `recentEmailsInFailbox`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## Unreleased
   - Fix custom info label field in forms LEKP-rapport - Melding correctie authentieke bron and LEKP-rapport - Toelichting Lokaal Bestuur (DL-5934)
-  - Add new report `emailsInFailboxWithin24Hours` which tracks failed emails (DL-5943)
+  - Add new report `recentEmailsInFailbox` which tracks failed emails (DL-5943)
 ### Deploy Notes
   - `drc up -d enrich-submission; drc restart migrations resource cache report-generation`
 ## 1.98.1 (2024-05-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 ## Unreleased
   - Fix custom info label field in forms LEKP-rapport - Melding correctie authentieke bron and LEKP-rapport - Toelichting Lokaal Bestuur (DL-5934)
+  - Add new report `emailsInFailboxWithin24Hours` which tracks failed emails (DL-5943)
 ### Deploy Notes
-  - `drc up -d enrich-submission; drc restart migrations resource cache`
+  - `drc up -d enrich-submission; drc restart migrations resource cache report-generation`
 ## 1.98.1 (2024-05-27)
 ### Fixes
  - Bump `worship-positions-graph-dispatcher-service-loket` to fix missing data in some organisations (DL-5823). This new version is better at dispatching data with its entire hierarchical model. For this, a migration needs to run to completion and this service then needs to be restarted. You can `drc up -d` it at the end of the deploy. This is included in the commands below.

--- a/config/reports/emailsInFailboxWithin24hoursReport.js
+++ b/config/reports/emailsInFailboxWithin24hoursReport.js
@@ -1,0 +1,41 @@
+import {generateReportFromData} from '../helpers.js';
+import { querySudo as query } from '@lblod/mu-auth-sudo';
+
+export default {
+  cronPattern: '0 0 0 * * *',
+  name: 'emailsInFailboxWithin24Hours',
+  execute: async () => {
+    const reportData = {
+      title: 'Lijst alle e-mails in failbox in de afgelopen 24 uur',
+      description: 'Lists all emails in failbox within previous 24 hours',
+      filePrefix: 'emails-in-failbox-within-24-hours'
+    };
+    console.log('Generate list of unsent e-mails within previous 24 hours report');
+    const queryString = `
+        PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    
+        SELECT ?emailUri ?sentDate ?currentDate
+        WHERE {
+          ?emailUri nmo:isPartOf <http://data.lblod.info/id/mail-folders/6> ;
+                 nmo:sentDate ?sentDateString .
+        
+          BIND(NOW() AS ?now)
+          BIND(?now - "P1D"^^xsd:duration AS ?yesterday)
+          BIND(xsd:dateTime(?sentDateString) AS ?sentDate)
+        
+          FILTER(?sentDate >= ?yesterday && ?sentDate <= ?now)
+        }
+    `;
+    const queryResponse = await query(queryString);
+    const data = queryResponse.results.bindings.map((row) => {
+      return {
+        emailUri: row.emailUri.value,
+        sentDate: row.sentDate.value,
+        currentDate: row.currentDate.value
+      };
+    });
+
+    await generateReportFromData(data, ['emailUri', 'sentDate', 'currentDate'], reportData);
+  }
+};

--- a/config/reports/emailsInFailboxWithin24hoursReport.js
+++ b/config/reports/emailsInFailboxWithin24hoursReport.js
@@ -26,7 +26,7 @@ export default {
           BIND(xsd:dateTime(?sentDateString) AS ?sentDate)
         
           FILTER(?sentDate >= ?yesterday && ?sentDate <= ?now)
-        }
+        } ORDER BY DESC(?sentDate)
     `;
     const queryResponse = await query(queryString);
     const data = queryResponse.results.bindings.map((row) => {

--- a/config/reports/emailsInFailboxWithin24hoursReport.js
+++ b/config/reports/emailsInFailboxWithin24hoursReport.js
@@ -15,10 +15,11 @@ export default {
         PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     
-        SELECT ?emailUri ?sentDate ?currentDate
+        SELECT ?emailUri ?messageSubject ?sentDate 
         WHERE {
           ?emailUri nmo:isPartOf <http://data.lblod.info/id/mail-folders/6> ;
-                 nmo:sentDate ?sentDateString .
+                    nmo:messageSubject ?messageSubject ;
+                    nmo:sentDate ?sentDateString .
         
           BIND(NOW() AS ?now)
           BIND(?now - "P1D"^^xsd:duration AS ?yesterday)
@@ -31,11 +32,11 @@ export default {
     const data = queryResponse.results.bindings.map((row) => {
       return {
         emailUri: row.emailUri.value,
-        sentDate: row.sentDate.value,
-        currentDate: row.currentDate.value
+        messageSubject: row.messageSubject.value,
+        sentDate: row.sentDate.value
       };
     });
 
-    await generateReportFromData(data, ['emailUri', 'sentDate', 'currentDate'], reportData);
+    await generateReportFromData(data, ['emailUri', 'messageSubject', 'sentDate'], reportData);
   }
 };

--- a/config/reports/index.js
+++ b/config/reports/index.js
@@ -25,6 +25,7 @@ import toezichtTaxRegulationSubmissionReport from './toezicht-tax-regulation-sub
 import ukraineSubsidyOproepOneReport from './ukraineSubsidyOproep1Report';
 import linksBetweenWorshipServicesAndAdminUnitsReport from './links-between-worship-services-and-admin-units-report';
 import virusScanReport from './virusScanReport';
+import emailsInFailboxWithin24Hours from './emailsInFailboxWithin24hoursReport';
 
 //Worship reports
 import bedienaren from './worship/bedienaren';
@@ -65,6 +66,7 @@ export default [
   ukraineSubsidyOproepOneReport,
   linksBetweenWorshipServicesAndAdminUnitsReport,
   virusScanReport,
+  emailsInFailboxWithin24Hours,
 
   //Worship reports
   bedienaren,

--- a/config/reports/index.js
+++ b/config/reports/index.js
@@ -25,7 +25,7 @@ import toezichtTaxRegulationSubmissionReport from './toezicht-tax-regulation-sub
 import ukraineSubsidyOproepOneReport from './ukraineSubsidyOproep1Report';
 import linksBetweenWorshipServicesAndAdminUnitsReport from './links-between-worship-services-and-admin-units-report';
 import virusScanReport from './virusScanReport';
-import emailsInFailboxWithin24Hours from './emailsInFailboxWithin24hoursReport';
+import recentEmailsInFailbox from './recentEmailsInFailboxReport';
 
 //Worship reports
 import bedienaren from './worship/bedienaren';
@@ -66,7 +66,7 @@ export default [
   ukraineSubsidyOproepOneReport,
   linksBetweenWorshipServicesAndAdminUnitsReport,
   virusScanReport,
-  emailsInFailboxWithin24Hours,
+  recentEmailsInFailbox,
 
   //Worship reports
   bedienaren,

--- a/config/reports/recentEmailsInFailboxReport.js
+++ b/config/reports/recentEmailsInFailboxReport.js
@@ -3,12 +3,12 @@ import { querySudo as query } from '@lblod/mu-auth-sudo';
 
 export default {
   cronPattern: '0 0 0 * * *',
-  name: 'emailsInFailboxWithin24Hours',
+  name: 'recentEmailsInFailbox',
   execute: async () => {
     const reportData = {
       title: 'Lijst alle e-mails in failbox in de afgelopen 24 uur',
       description: 'Lists all emails in failbox within previous 24 hours',
-      filePrefix: 'emails-in-failbox-within-24-hours'
+      filePrefix: 'recent-emails-in-failbox'
     };
     console.log('Generate list of unsent e-mails within previous 24 hours report');
     const queryString = `


### PR DESCRIPTION
# Description

DL-5943

This PR adds a new report ~`emailsInFailboxWithin24Hours`~ `recentEmailsInFailbox`, it checks if emails are in failbox within previous 24 hours and lists `?emailUri`, `?sentDate` and `?currentDate` into a csv file every day at 00:00:00.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- report-generation

# How to test 

1. Add in `docker-compose.override.yml` 
```yml
  report-generation:
    links:
      - virtuoso:database  # we need to because performance
    ports:
      - 9999:80
```
3. `drc up -d`
4. Generate report recentEmailsInFailbox → 
```bash 
curl -X POST -H "Content-Type: application/vnd.api+json"  -d '{  "data": { "attributes": { "reportName": "recentEmailsInFailbox" }  }  }'  http://localhost:9999/reports
```
5. Generated report = `{"data":{"type":"report-generation-tasks","attributes":{"status":"success"}}}` and should be visible in `/data/files/`

# What to check

- Best time to run the report, currently at 00:00:00 every day

# Links to other PR's

- N/A

# Notes

- drc restart report-generation