### PR TITLE
Vendor API improve missing Berichten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,13 @@
 ## Unreleased
 ### Fixes
 - Bump delta-producer-publication-graph-maintainer [DL-4527] and related [OP-3151]
-- Bump `vendor-data-distribution` for healing, needed for [DL-5925]. After deploy, see instructions below on how to start healing.
+- Bump `vendor-data-distribution` for healing, needed for [DL-5925]. Already been deployed via overrides in `docker-compose.override.yml`. Please remove the image override there.
 ### Toezicht
 - DL-5856: ensure some type of submissions are not exported to `app-toezicht-abb`
   - See also: DL-5922
 ### Deploy Notes
 - `drc up -d delta-producer-publication-graph-maintainer export-submissions; drc restart deltanotifier`
-- `drc up -d vendor-data-distribution`  
-  `drc exec vendor-data-distribution bash`  
-  `curl -X POST -H "Content-Type: application/json" -d '{ "skipDeletes": true, "onlyTheseTypes": [ "http://schema.org/Message" ] }'`  
-  Inspect the logs of this service to see that healing is being done.
+- Remove the image override for service `vendor-data-distribution` in `docker-compose.override.yml`
 ## 1.99.1 (2024-05-31)
 ### General
   - Hotfix: update lokaal bestuurlijk talen deadline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 ## Unreleased
 ### Fixes
 - Bump delta-producer-publication-graph-maintainer [DL-4527] and related [OP-3151]
+- Bump `vendor-data-distribution` for healing, needed for [DL-5925]. After deploy, see instructions below on how to start healing.
 ### Toezicht
 - DL-5856: ensure some type of submissions are not exported to `app-toezicht-abb`
   - See also: DL-5922
 ### Deploy Notes
 - `drc up -d delta-producer-publication-graph-maintainer export-submissions; drc restart deltanotifier`
+- `drc up -d vendor-data-distribution`  
+  `drc exec vendor-data-distribution bash`  
+  `curl -X POST -H "Content-Type: application/json" -d '{ "skipDeletes": true, "onlyTheseTypes": [ "http://schema.org/Message" ] }'`  
+  Inspect the logs of this service to see that healing is being done.
 ## 1.99.1 (2024-05-31)
 ### General
   - Hotfix: update lokaal bestuurlijk talen deadline

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -480,7 +480,7 @@ services:
     restart: always
     logging: *default-logging
   vendor-data-distribution:
-    image: lblod/vendor-data-distribution-service:1.3.3
+    image: lblod/vendor-data-distribution-service:1.6.1
     environment:
       LOGLEVEL: "error"
       WRITE_ERRORS: "true"


### PR DESCRIPTION
Due to reports of some missing Messages in the Vendor API, we needed the new version of the `vendor-data-distribution-service` to have healing. [DL-5925]

There should be no structural change in how the VDDS works, apart from the added healing.

After deploy, execute healing on the VDDS:

```
drc up -d vendor-data-distribution
drc exec vendor-data-distribution bash
curl -X POST -H "Content-Type: application/json" -d '{ "skipDeletes": true, "onlyTheseTypes": [ "http://schema.org/Message" ] }'
```