### PR TITLE
[DL-6020] Remove outdated email predicates

### DIFF
--- a/config/migrations/2024/20240702144200-remove-outdated-mail-predicates.sparql
+++ b/config/migrations/2024/20240702144200-remove-outdated-mail-predicates.sparql
@@ -1,0 +1,16 @@
+# mu-auth inserted these predicates in other graphs in the past, but after some config changes those graphs are no longer writable.
+# Because of this, the values got out of sync, and mu-cl-resources sometimes returns the outdated value.
+# By purging everything but the berichtenGebruiker graph, this issue should be resolved
+DELETE {
+  GRAPH ?graph {
+    ?s <http://mu.semte.ch/vocabularies/ext/wilMailOntvangen> ?wilMailOntvangen ;
+       <http://mu.semte.ch/vocabularies/ext/mailAdresVoorNotificaties> ?email .
+  }
+}
+WHERE {
+  GRAPH ?graph {
+    ?s <http://mu.semte.ch/vocabularies/ext/wilMailOntvangen> ?wilMailOntvangen ;
+       <http://mu.semte.ch/vocabularies/ext/mailAdresVoorNotificaties> ?email .
+  }
+  FILTER(!STRENDS(STR(?graph), "/LoketLB-berichtenGebruiker"))
+}


### PR DESCRIPTION
These predicates are part of the berichtencentrum module, but due to some previous mu-auth config (or migrations) the predicates also ended up in different graphs. This wasn't really an issue until the values started to get out of sync since mu-cl-resources then returns the wrong value sometimes.

By removing the predicates from all graphs besides the berichtencentrum one we fix the problem.