### PR TITLE
Fix failed email report date-time comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@
 #### Frontend
  - `v0.94.1` (DGS-316): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0941-2024-06-25 
  - `v0.94.0` (DL-5816, DGS-161): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0940-2024-06-19
-### Berichtencentrum
-  - [DL-6020] Fix an issue where the configured email would revert to the old value after updating it
 ### Deploy Notes
 On production, remove the delta-producer-publication-graph-maintainer image in the docker-compose.override.yml.
 #### Docker Commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### General
  - Add open proces huis session role for all organizations [DL-5816]
  - Bumped delta-producer-publication-graph-maintainer.
+ - Fixed failed emails report. [DL-6044]
 #### Frontend
  - `v0.94.1` (DGS-316): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0941-2024-06-25 
  - `v0.94.0` (DL-5816, DGS-161): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0940-2024-06-19
@@ -12,7 +13,7 @@
 On production, remove the delta-producer-publication-graph-maintainer image in the docker-compose.override.yml.
 #### Docker Commands
  - `drc restart migrations && drc logs -ft --tail=200 migrations`
- - `drc restart resource cache`
+ - `drc restart report-generation resource cache`
  - `drc up -d loket`
 ## 1.100.1 (2024-07-03)
 ### Berichtencentrum

--- a/config/reports/recentEmailsInFailboxReport.js
+++ b/config/reports/recentEmailsInFailboxReport.js
@@ -14,17 +14,16 @@ export default {
     const queryString = `
         PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-    
-        SELECT ?emailUri ?messageSubject ?sentDate 
+
+        SELECT ?emailUri ?messageSubject ?sentDate
         WHERE {
           ?emailUri nmo:isPartOf <http://data.lblod.info/id/mail-folders/6> ;
-                    nmo:messageSubject ?messageSubject ;
-                    nmo:sentDate ?sentDateString .
-        
-          BIND(NOW() AS ?now)
-          BIND(?now - "P1D"^^xsd:duration AS ?yesterday)
-          BIND(xsd:dateTime(?sentDateString) AS ?sentDate)
-        
+            nmo:messageSubject ?messageSubject ;
+            nmo:sentDate ?sentDate .
+
+          BIND(xsd:dateTime(NOW()) AS ?now)
+          BIND(xsd:dateTime(?now - "P1D"^^xsd:duration) AS ?yesterday)
+
           FILTER(?sentDate >= ?yesterday && ?sentDate <= ?now)
         } ORDER BY DESC(?sentDate)
     `;


### PR DESCRIPTION
## Ticket Number

DL-6044

## Ticket Description

The query running inside the report tries to locate failed emails within the last 24 hours; however, the date-time calculations were not working as expected. I cast today's and yesterday's result to `xsd:dateTime` to amend the issue.

## How to test

I have already tested the change while working on a relevant ticket related to a failed email, and the query now returns the expected results.