### PR TITLE
Repair some OP public data for "toezichthoudende provincie"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Add open proces huis session role for all organizations [DL-5816]
  - Bumped delta-producer-publication-graph-maintainer.
  - Fixed failed emails report. [DL-6044]
+ - Link Toezichthoudende Provincie Antwerpen to "Orthodoxe Parochie Heilige Sophrony de Athoniet" [DL-6014]
 #### Frontend
  - `v0.95.0` (DL-6042, DL-6050): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0950-2024-07-11 
  - `v0.94.1` (DGS-316): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0941-2024-06-25 

--- a/config/migrations/2024/20240723185100-op-public-data-sophroniet-repair.sparql
+++ b/config/migrations/2024/20240723185100-op-public-data-sophroniet-repair.sparql
@@ -1,0 +1,12 @@
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/bestuurseenheden/bd74ee38a4b1e296821a11729c1f704cf439576c7ab2c910c95b067cf183d923> <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> .
+    <http://data.lblod.info/id/bestuurseenheden/bd74ee38a4b1e296821a11729c1f704cf439576c7ab2c910c95b067cf183d923> <http://www.w3.org/ns/regorg#legalName> "Antwerpen" .
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen> .
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> <http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100.0 .
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1> .
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> <http://mu.semte.ch/vocabularies/core/uuid> "66716592A87E31723DA31871" .
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/besturenVanDeEredienst/6564B9CA6DEE214B7207D427> .
+  }
+}
+


### PR DESCRIPTION
**[DL-6014]**

This migration links the "Provincie Antwerpen" to the "Orthodoxe Parochie Heilige Sophrony de Athoniet" as Toezichthoudend unit.

Tested succesfully that a Submission posted by "Orthodoxe Parochie Heilige Sophrony de Athoniet" is actually dispatched to the province.

See also https://github.com/lblod/app-worship-decisions-database/pull/85