### PR TITLE
Remove obsolete `version` attribute from docker compose config

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   proxy:
     image: nginx:1.13

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-logging: &default-logging
   driver: "json-file"
   options:


### PR DESCRIPTION
## PR Description

The `version` attribute is now obsolete, and `docker compose` will always warn about it unless it's removed. This PR removes the attribute from `docker-compose.yml` and `docker-compose.dev.yml`.