### PR TITLE
add script to purge LMB data from db

### DIFF
--- a/scripts/purge-lmb-data/README.md
+++ b/scripts/purge-lmb-data/README.md
@@ -1,0 +1,25 @@
+This script removes all LMB Graphs from the virtuoso triplestore by using `DROP SILENT GRAPH` statements (bypassing mu-auth)
+
+To connect this compose to your virtuoso either:
+
+Add your virtuoso to the script network in your docker-compose.override.yml
+
+```
+  virtuoso:
+    networks:
+      - default
+      - script
+
+networks:
+  script:
+    driver: bridge
+    name: debug
+```
+
+OR
+
+change the `sparqlEndpoint` in `app.ts` to your exposed sparql endpoint on your host machine: `http://172.17.0.1:8890/sparql` or use `http://host.docker.internal:8890/sparql` if you use docker-desktop
+
+OR
+
+copy this docker-compose.script.yml (without the network) and add it to your docker-compose.override.yml (updating the app volume )

--- a/scripts/purge-lmb-data/app.ts
+++ b/scripts/purge-lmb-data/app.ts
@@ -1,0 +1,88 @@
+import { querySudo, updateSudo } from "@lblod/mu-auth-sudo";
+const DROP_GRAPH_BATCH_SIZE = 50;
+const sparqlOptions = {
+  sparqlEndpoint: "http://virtuoso:8890/sparql",
+  mayRetry: true,
+};
+
+
+async function dropLMBGraphs() {
+  const count = await countUnimportantGraphs();
+  console.log(`dropping ${count} LMB graphs`);
+
+  let droppedGraphs = 1;
+  let droppedSoFar = 0;
+  while (droppedGraphs) {
+    droppedGraphs = await dropBatchOfLMBGraphs();
+    droppedSoFar += droppedGraphs;
+    console.log(`Dropped ${droppedSoFar}/${count} graphs... (${((droppedSoFar / count) * 100).toFixed(2)}%)`);
+  }
+  console.log(`Dropped all LMB graphs!`);
+}
+
+const graphTargetter = `
+  # using this instead of ?s ?p ?o for faster counting
+  {?s org:holds ?mandaat.}
+  UNION
+  { ?s a <http://data.vlaanderen.be/ns/mandaat#Fractie>. }
+  UNION
+  { ?s a <http://www.w3.org/ns/person#Person>. }
+  UNION
+  { ?s a <http://www.w3.org/ns/adms#Identifier>.}
+`;
+
+async function countUnimportantGraphs() {
+    const result = await querySudo(`
+    PREFIX org: <http://www.w3.org/ns/org#>
+
+    SELECT COUNT(DISTINCT(?g)) as ?count WHERE {
+      GRAPH ?g {
+        ${graphTargetter}
+      }
+      FILTER (STRENDS(STR(?g), "/LoketLB-mandaatGebruiker"))
+    }`, {}, sparqlOptions);
+    return parseInt(result.results.bindings[0].count.value);
+}
+
+async function getUnimportantGraphs() {
+  const result = await querySudo(
+    `
+    PREFIX org: <http://www.w3.org/ns/org#>
+    SELECT DISTINCT ?g WHERE {
+      GRAPH ?g {
+        ${graphTargetter}
+      }
+      FILTER (STRENDS(STR(?g), "/LoketLB-mandaatGebruiker"))
+    } LIMIT ${DROP_GRAPH_BATCH_SIZE}
+  `,
+    {},
+    sparqlOptions
+  );
+
+  return result.results.bindings.map((b) => b.g.value);
+}
+
+async function dropBatchOfLMBGraphs() {
+  const graphs = await getUnimportantGraphs();
+  if (graphs.length === 0) {
+    return 0;
+  }
+  const dropStatement = `DROP SILENT GRAPH <${graphs.join(
+    ">; DROP SILENT GRAPH <"
+  )}>;`;
+  await updateSudo(dropStatement, {}, sparqlOptions);
+  return graphs.length;
+}
+
+async function transform() {
+  console.log(
+    "\n\nWARNING: this script will DELETE all LMB data. Ctrl-C to cancel in the next 10 seconds\n\n"
+  );
+  await new Promise((resolve) => setTimeout(resolve, 10000));
+
+  console.log("transforming!");
+  await dropLMBGraphs();
+  console.log("done transforming!");
+}
+
+transform().catch((e) => console.log(e));

--- a/scripts/purge-lmb-data/docker-compose.script.yml
+++ b/scripts/purge-lmb-data/docker-compose.script.yml
@@ -1,0 +1,23 @@
+services:
+  script:
+    image: semtech/mu-javascript-template:1.8.0
+    restart: 'no'
+    labels:
+      - 'logging=true'
+    environment:
+      - NODE_ENV=development
+      - NO_BABEL_NODE=true
+      - SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES=500
+      - LOG_SPARQL_ALL=false
+      - DEBUG_AUTH_HEADERS=false
+    ports:
+      - '8083:80'
+      - '9221:9229'
+    volumes:
+      - ./:/app
+    networks:
+      - script
+
+networks:
+  script:
+    external: true

--- a/scripts/purge-lmb-data/package.json
+++ b/scripts/purge-lmb-data/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "loket-lmb-purge",
+  "version": "0.0.0",
+  "description": "Script purge lmb data from loket",
+  "main": "app.js",
+  "author": "redpencil.io",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^20.14.15",
+    "@typescript-eslint/eslint-plugin": "^6.13.2",
+    "eslint": "^8.23.1",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "prettier": "^3.0.0"
+  },
+  "scripts": {
+    "lint:js": "eslint . --cache --ext .ts",
+    "lint:js:fix": "eslint . --cache --ext .ts --fix",
+    "release": "release-it",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "@lblod/mu-auth-sudo": "^0.6.1"
+  }
+}


### PR DESCRIPTION
See also readme.

Script result on prod dump: 

```
script-1  | WARNING: this script will DELETE all LMB data. Ctrl-C to cancel in the next 10 seconds
script-1  | 
script-1  | 
script-1  | transforming!
script-1  | dropping 783 LMB graphs
script-1  | Dropped 50/783 graphs... (6.39%)
script-1  | Dropped 100/783 graphs... (12.77%)
script-1  | Dropped 150/783 graphs... (19.16%)
script-1  | Dropped 200/783 graphs... (25.54%)
script-1  | Dropped 250/783 graphs... (31.93%)
script-1  | Dropped 300/783 graphs... (38.31%)
script-1  | Dropped 350/783 graphs... (44.70%)
script-1  | Dropped 400/783 graphs... (51.09%)
script-1  | Dropped 450/783 graphs... (57.47%)
script-1  | Dropped 500/783 graphs... (63.86%)
script-1  | Dropped 550/783 graphs... (70.24%)
script-1  | Dropped 600/783 graphs... (76.63%)
script-1  | Dropped 650/783 graphs... (83.01%)
script-1  | Dropped 700/783 graphs... (89.40%)
script-1  | Dropped 750/783 graphs... (95.79%)
script-1  | Dropped 783/783 graphs... (100.00%)
script-1  | Dropped 783/783 graphs... (100.00%)
script-1  | Dropped all LMB graphs!
script-1  | done transforming!
```

