### PR TITLE
Adjust download/berichtencentrum url warning cleanup job

### DIFF
--- a/config/migrations/2024/20240822121755-adjust-harvesting-graph-cleanup-job/20240822121755-adjust-harvesting-graph-cleanup-job.sparql
+++ b/config/migrations/2024/20240822121755-adjust-harvesting-graph-cleanup-job/20240822121755-adjust-harvesting-graph-cleanup-job.sparql
@@ -1,0 +1,51 @@
+PREFIX cleanup: <http://mu.semte.ch/vocabularies/ext/cleanup/>
+
+DELETE {
+  GRAPH ?g {
+    ?cleanupJob cleanup:selectPattern ?selectPattern ;
+      cleanup:deletePattern ?deletePattern .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?cleanupJob cleanup:selectPattern """
+      GRAPH <http://mu.semte.ch/graphs/harvesting> {
+        VALUES ?operation {
+          <http://lblod.data.gift/id/jobs/concept/JobOperation/berichtencentrumWarning>
+          <http://lblod.data.gift/id/jobs/concept/JobOperation/downloadUrlWarning>
+        }
+
+        ?resource a <http://vocab.deri.ie/cogs#Job> ;
+          <http://redpencil.data.gift/vocabularies/tasks/operation> ?operation ;
+          <http://purl.org/dc/terms/modified> ?modified .
+
+        FILTER (?modified < (NOW() - "P1M"^^xsd:duration))
+
+        ?task <http://purl.org/dc/terms/isPartOf> ?resource ;
+          ?taskP ?taskO .
+        ?resource ?p ?o .
+
+        OPTIONAL {
+          ?task <http://redpencil.data.gift/vocabularies/tasks/inputContainer> ?inputContainer .
+          ?inputContainer ?pinputContainer ?oinputContainer .
+        }
+      }
+      """ .
+
+    ?cleanupJob cleanup:deletePattern """
+      GRAPH <http://mu.semte.ch/graphs/harvesting> {
+        ?resource ?p ?o .
+        ?task ?taskP ?taskO .
+        ?inputContainer ?pinputContainer ?oinputContainer .
+      }
+      """ .
+  }
+}
+WHERE {
+  BIND(<http://data.lblod.info/id/cleanup-job/3f623084-416f-44ef-90fa-7c7fa3d4efad> AS ?cleanupJob)
+
+  GRAPH ?g {
+    ?cleanupJob cleanup:selectPattern ?selectPattern ;
+      cleanup:deletePattern ?deletePattern .
+  }
+}

--- a/config/migrations/2024/20240822121755-adjust-harvesting-graph-cleanup-job/20240822121842-add-previously-removed-container-for-download-url-jobs.sparql
+++ b/config/migrations/2024/20240822121755-adjust-harvesting-graph-cleanup-job/20240822121842-add-previously-removed-container-for-download-url-jobs.sparql
@@ -11,8 +11,8 @@ INSERT {
     <http://data.lblod.info/cd4ea77a-f3aa-4fe3-af4c-892bd1ce1ffb> a nfo:DataContainer ;
       task:hasRemoteUrl ?remoteUrl ;
       skos:note "Placeholder container resulting from corrective action related to release v1.102.0, where background jobs eagerly cleaned up removed containers" .
-    }
   }
+}
 WHERE {
   GRAPH ?g {
     ?remoteUrl a nfo:RemoteDataObject ;

--- a/config/migrations/2024/20240822121755-adjust-harvesting-graph-cleanup-job/20240822121842-add-previously-removed-container-for-download-url-jobs.sparql
+++ b/config/migrations/2024/20240822121755-adjust-harvesting-graph-cleanup-job/20240822121842-add-previously-removed-container-for-download-url-jobs.sparql
@@ -1,0 +1,28 @@
+PREFIX task:    <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX nie:     <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+PREFIX adms:    <http://www.w3.org/ns/adms#>
+PREFIX nfo:     <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+  GRAPH ?g {
+    <http://data.lblod.info/cd4ea77a-f3aa-4fe3-af4c-892bd1ce1ffb> a nfo:DataContainer ;
+      task:hasRemoteUrl ?remoteUrl ;
+      skos:note "Placeholder container resulting from corrective action related to release v1.102.0, where background jobs eagerly cleaned up removed containers" .
+    }
+  }
+WHERE {
+  GRAPH ?g {
+    ?remoteUrl a nfo:RemoteDataObject ;
+      adms:status <http://lblod.data.gift/file-download-statuses/failure> ;
+      nie:url ?url ;
+      dcterms:modified ?modified .
+
+      OPTIONAL { ?remoteUrl ext:cacheError ?errorLabel . }
+      OPTIONAL { ?remoteUrl ext:httpStatusCode ?errorCode . }
+  }
+
+  FILTER NOT EXISTS { ?container task:hasRemoteUrl ?remoteUrl . }
+}


### PR DESCRIPTION
## PR Description

This PR ratifies some extra deletion that happend with the previous version of this cleanup job where result containers were deleted (these containers are needed for the `download-url` service to query failed downloads).

The PR also adds a dummy container to restore the link for failed remote data objects (i.e., ones with `<http://lblod.data.gift/file-download-statuses/failure>` status).