### PR TITLE
 [DL-6245]: Include kbo number for erediensten codelist labels

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,7 +291,7 @@ services:
     restart: always
     logging: *default-logging
   enrich-submission:
-    image: lblod/enrich-submission-service:1.11.0
+    image: lblod/enrich-submission-service:1.13.0
     environment:
       ACTIVE_FORM_FILE: "share://semantic-forms/20240527111832-forms.ttl"
     volumes:


### PR DESCRIPTION
## ID
DL-6245

## Description

Bumps the `enrich-submission-service` to include the KBO number for erediensten codelist, this way it's easier for users to differentiate between different orgs of the same name.