### PR TITLE
Update Toezicht export filter

### DIFF
--- a/config/export/submissions/type-export.js
+++ b/config/export/submissions/type-export.js
@@ -59,6 +59,8 @@ FILTER NOT EXISTS { ?formData dct:type <https://data.vlaanderen.be/id/concept/Be
 FILTER NOT EXISTS { ?formData dct:type <https://data.vlaanderen.be/id/concept/BesluitType/d463b6d1-c207-4c1a-8c08-f2c7dd1fa53b> . }
 FILTER NOT EXISTS { ?formData dct:type <https://data.vlaanderen.be/id/concept/BesluitType/2b12630f-8c4e-40a4-8a61-a0c45621a1e6> . }
 FILTER NOT EXISTS { ?formData dct:type <https://data.vlaanderen.be/id/concept/BesluitType/0fc2c27d-a03c-4e3f-9db1-f10f026f76f8> . }
+FILTER NOT EXISTS { ?formData dct:type <https://data.vlaanderen.be/id/concept/BesluitType/df261490-cc74-4f80-b783-41c35e720b46> . }
+FILTER NOT EXISTS { ?formData dct:type <https://data.vlaanderen.be/id/concept/BesluitType/3fcf7dba-2e5b-4955-a489-6dd8285c013b> . }
 
 ?formData dct:type ?typeBesluit .
 


### PR DESCRIPTION
**[DL-6234]**

Filter out two more Submission Types:

* Besluit over budget(wijziging) eredienstbestuur
* Besluit over meerjarenplan(aanpassing) eredienstbestuur

These types are for Worship Services and should not be exported to Toezicht.