### PR TITLE
Add vendor to OLV Temse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
 # Changelog
+
 ## Unreleased
+
 ### General
- - Adjust anomalies in names [DL-6278]
- - Submissions cross referencing [DL-5814]
- - Add kerkenbeleidsplan form [DL-6235]
+
+- Adjust anomalies in names [DL-6278]
+- Submissions cross referencing [DL-5814]
+- Add kerkenbeleidsplan form [DL-6235]
 
 ### Deploy notes
+
 #### docker-compose.override.yml
+
 ##### worship-decisions-cross-reference
+
 Ensure the environment variables are correctly set for `worship-decisions-cross-reference`, e.g. :
+
 ```
 worship-decisions-cross-reference:
   environment;
@@ -20,9 +27,10 @@ The following links;
 - PROD: "https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/"
 
 #### Docker Commands
- - `drc restart migrations && drc logs -ft --tail=200 migrations`
- - `drc restart dispatcher resource cache vendor-data-distribution delta-producer-publication-graph-maintainer`
- - `drc up -d`
+
+- `drc restart migrations && drc logs -ft --tail=200 migrations`
+- `drc restart dispatcher resource cache vendor-data-distribution delta-producer-publication-graph-maintainer`
+- `drc up -d`
 
 ## 1.106.0 (2024-11-18)
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Adjust anomalies in names [DL-6278]
 - Submissions cross referencing [DL-5814]
 - Add kerkenbeleidsplan form [DL-6235]
+- Erediensten Dispatching from harvester, for OLV Temse [DL-6280]
+  - Includes 2 migrations and restart command such that dispatching is automatically started.
 
 ### Deploy notes
 
@@ -30,6 +32,7 @@ The following links;
 
 - `drc restart migrations && drc logs -ft --tail=200 migrations`
 - `drc restart dispatcher resource cache vendor-data-distribution delta-producer-publication-graph-maintainer`
+- `drc restart dispatcher-worship-mandates` # For "healing" erediensten positions after migrations
 - `drc up -d`
 
 ## 1.106.0 (2024-11-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Submissions cross referencing [DL-5814]
 - Add kerkenbeleidsplan form [DL-6235]
 - Erediensten Dispatching from harvester, for OLV Temse [DL-6280]
-  - Includes 2 migrations and restart command such that dispatching is automatically started.
+  - Includes 3 migrations and perform a restart such that dispatching is automatically started.
 
 ### Deploy notes
 

--- a/config/migrations/2024/20241121120600-vendor-for-olv-temse/20241121120700-add-vdb-as-vendor.sparql
+++ b/config/migrations/2024/20241121120600-vendor-for-olv-temse/20241121120700-add-vdb-as-vendor.sparql
@@ -1,0 +1,8 @@
+PREFIX account: <http://mu.semte.ch/vocabularies/account/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+    <http://data.lblod.info/vendors/b1e41693-639a-4f61-92a9-5b9a3e0b924e>
+      account:canActOnBehalfOf <http://data.lblod.info/id/besturenVanDeEredienst/567a1bd8a4e2be8817ff8af27c93efbd> .
+  }
+}

--- a/config/migrations/2024/20241121120600-vendor-for-olv-temse/20241121120800-prepare-for-semi-healing-worship-positions.sparql
+++ b/config/migrations/2024/20241121120600-vendor-for-olv-temse/20241121120800-prepare-for-semi-healing-worship-positions.sparql
@@ -1,0 +1,15 @@
+DELETE {
+  GRAPH <http://eredienst-mandatarissen-consumer/temp-discards> {
+    ?s ?p ?o .
+  }
+}
+INSERT {
+  GRAPH <http://eredienst-mandatarissen-consumer/temp-inserts> {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  GRAPH <http://eredienst-mandatarissen-consumer/temp-discards> {
+    ?s ?p ?o .
+  }
+}

--- a/config/migrations/2024/20241121120600-vendor-for-olv-temse/20241121120900-remove-positions-entered-in-loket.sparql
+++ b/config/migrations/2024/20241121120600-vendor-for-olv-temse/20241121120900-remove-positions-entered-in-loket.sparql
@@ -1,0 +1,51 @@
+PREFIX locn: <http://www.w3.org/ns/locn#>
+PREFIX schema: <http://schema.org/>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+
+DELETE {
+  GRAPH ?g {
+    ?rolbedienaar ?rp ?ro .
+    ?contact ?cp ?co .
+    ?address ?ap ?ao .
+    ?persoon ?pp ?po .
+    ?geboorte ?gp ?go .
+  }
+}
+WHERE {
+  VALUES ?positie {
+    <http://data.lblod.info/id/positiesBedienaar/583e4d61115ba9981f8bc1725e2567e5>
+    <http://data.lblod.info/id/positiesBedienaar/5998f47210c3ced12e48d84eae65939b>
+    <http://data.lblod.info/id/positiesBedienaar/66a6d5e5c12dcd00acf32142ce27d336>
+    <http://data.lblod.info/id/positiesBedienaar/e444dd456bcaec5e7166ca95fd1c7967>
+  }
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/organizations/567a1bd8a4e2be8817ff8af27c93efbd/LoketLB-eredienstBedienaarGebruiker>
+    <http://mu.semte.ch/graphs/organizations/567a1bd8a4e2be8817ff8af27c93efbd/LoketLB-eredienstMandaatGebruiker>
+  }
+  GRAPH ?g {
+    ?rolbedienaar org:holds ?positie .
+    FILTER NOT EXISTS {
+      ?rolbedienaar prov:wasGeneratedBy <http://lblod.data.gift/id/app/lblod-harvesting> .
+    }
+    ?rolbedienaar ?rp ?ro .
+    
+    ?rolbedienaar schema:contactPoint ?contact .
+    ?contact ?cp ?co .
+    
+    ?contact locn:address ?address .
+    ?address ?ap ?ao .
+    
+    ?rolbedienaar org:heldBy ?persoon .
+    ?persoon ?pp ?po .
+    
+    ?persoon persoon:heeftGeboorte ?geboorte .
+    ?geboorte ?gp ?go .
+  }
+}


### PR DESCRIPTION
**[DL-6280]**

O.L.V. van Temse had duplicate entries for the 2 eredienst positions. One set of entries was entered in Loket, and the other set was harvested, but not correctly dispatched. The data was discarded because VDB was not enabled as a vendor for that bestuurseenheid. Only the first set was therefore shown in the frontend.

These migrations remove the entered-in-Loket entries, enable VDB as a vendor, and copy the discarded data to the graph that is used by the worship-position-dispatcher to restart the dispatching. This time, the vendor is correctly enabled, so the data for Temse should be correctly copied, replacing the removed entries.