### PR TITLE
Remove wrong labels for bestuurseenheden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add kerkenbeleidsplan form [DL-6235]
 - Erediensten Dispatching from harvester, for OLV Temse [DL-6280]
   - Includes 3 migrations and perform a restart such that dispatching is automatically started.
+- Remove wrong labels for some bestuurseenheden. [DL-6323]
 
 ### Deploy notes
 

--- a/config/migrations/2024/20241210130157-remove-wrong-labels-for-bestuurseenheden.sparql
+++ b/config/migrations/2024/20241210130157-remove-wrong-labels-for-bestuurseenheden.sparql
@@ -1,0 +1,188 @@
+# Some of the URIs have a wrong label inside the automatic submissions graph.
+# We delete that and copy the correct one from the public graph.
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+    ?s <http://www.w3.org/2004/02/skos/core#prefLabel> ?automaticSubmissionLabel .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+    ?s <http://www.w3.org/2004/02/skos/core#prefLabel> ?publicLabel .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f257217efa1b9c366ce4f478fb02a205>
+    <http://data.lblod.info/id/bestuurseenheden/0ebab99ea0311baf2e6ac71dabc395f3fd8d457d08b90a6697c4453d1e649572>
+    <http://data.lblod.info/id/bestuurseenheden/0fcef44fd2fe177f4a92674f955d70378098c0e62479e953bf5930962b595b0b>
+    <http://data.lblod.info/id/bestuurseenheden/18014ccee1691f34adb3e438abb02982dc9bbce680063a8effdb213992f3b4cd>
+    <http://data.lblod.info/id/bestuurseenheden/4a2864750000a2d8dafa1128bab23143c8725f2c6d6aef400f9bce917bd4a94a>
+    <http://data.lblod.info/id/bestuurseenheden/56f5706b531b57eacf30076d6f8c51a4653ab2f7173746e7a503cf784f2c1ef2>
+    <http://data.lblod.info/id/bestuurseenheden/62750c0093310bc293d1a89dd44abb34a1402e0ccb5b06f9f7e590d7dfe642ec>
+    <http://data.lblod.info/id/bestuurseenheden/6c19ef9b94965f9ad2eaad940fb63f9ca7e23b3ac440fad96886e12725d61c4a>
+    <http://data.lblod.info/id/bestuurseenheden/6e163ed93509d81fff72ea3fee33318902f3e8b2aea9b1d6af02c5f555c5b925>
+    <http://data.lblod.info/id/bestuurseenheden/76a649af4784166f6dec6079e6fa38acde4d860ab9133c955085018a7875b1c9>
+    <http://data.lblod.info/id/bestuurseenheden/851f0fa90c8c44a593ac497b3fbc01a4a1147172269c4201030c6ff3751a8945>
+    <http://data.lblod.info/id/bestuurseenheden/a20c3dd6a449e3e934ac8e1ae35800d9e86b1286c4dd179da48fbb74068471d0>
+    <http://data.lblod.info/id/bestuurseenheden/a6caec4873f59befa70697c8fb180e501b7314cdf59d45b3b7a69ed9953d5123>
+    <http://data.lblod.info/id/bestuurseenheden/d17190b8c5cd15be8c7417dececcbf9a2410aaf83a5b639fc53cb130a1d1c602>
+    <http://data.lblod.info/id/bestuurseenheden/e1c62a335d473a956bdb049814a4660bf89560ae71b8621f6e7bc20f545838d5>
+    <http://data.lblod.info/id/bestuurseenheden/eee3be76b21c7862631b030da2bf267915cc128801eb35af1ece608dd7d3f169>
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s <http://www.w3.org/2004/02/skos/core#prefLabel> ?publicLabel .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+    ?s <http://www.w3.org/2004/02/skos/core#prefLabel> ?automaticSubmissionLabel .
+  }
+}
+
+;
+
+# The URIs below also have mismatching labels but in different graphs. I.e. the correct label is in the
+# public graph whereas the wrong one is in the org/subsidies/eredienstBedienaar/eredienstMandaat graphs.
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe/LoketLB-subsidies> {
+    <http://data.lblod.info/id/bestuurseenheden/c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe/LoketLB-subsidies> {
+    <http://data.lblod.info/id/bestuurseenheden/c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/e45e6ad275ae04001029796b3771fa418b32414269ee741a5cf120a580ff673b> {
+    <http://data.lblod.info/id/bestuurseenheden/e45e6ad275ae04001029796b3771fa418b32414269ee741a5cf120a580ff673b> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/e45e6ad275ae04001029796b3771fa418b32414269ee741a5cf120a580ff673b> {
+    <http://data.lblod.info/id/bestuurseenheden/e45e6ad275ae04001029796b3771fa418b32414269ee741a5cf120a580ff673b> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/b9c2cc5db5a08d33b049663f9591fba6/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/bestuurseenheden/b9c2cc5db5a08d33b049663f9591fba6> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/b9c2cc5db5a08d33b049663f9591fba6/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/bestuurseenheden/b9c2cc5db5a08d33b049663f9591fba6> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/27cd432cbfbba42816f0f3f9be6b7dd2/LoketLB-eredienstBedienaarGebruiker> {
+    <http://data.lblod.info/id/bestuurseenheden/27cd432cbfbba42816f0f3f9be6b7dd2> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label1 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/organizations/27cd432cbfbba42816f0f3f9be6b7dd2/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/bestuurseenheden/27cd432cbfbba42816f0f3f9be6b7dd2> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label2 .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/27cd432cbfbba42816f0f3f9be6b7dd2/LoketLB-eredienstBedienaarGebruiker> {
+    <http://data.lblod.info/id/bestuurseenheden/27cd432cbfbba42816f0f3f9be6b7dd2> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label1 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/organizations/27cd432cbfbba42816f0f3f9be6b7dd2/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/bestuurseenheden/27cd432cbfbba42816f0f3f9be6b7dd2> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label2 .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/b9c2cc5db5a08d33b049663f9591fba6/LoketLB-eredienstBedienaarGebruiker> {
+    <http://data.lblod.info/id/bestuurseenheden/b9c2cc5db5a08d33b049663f9591fba6> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label1 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/organizations/b9c2cc5db5a08d33b049663f9591fba6/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/bestuurseenheden/b9c2cc5db5a08d33b049663f9591fba6> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label2 .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/b9c2cc5db5a08d33b049663f9591fba6/LoketLB-eredienstBedienaarGebruiker> {
+    <http://data.lblod.info/id/bestuurseenheden/b9c2cc5db5a08d33b049663f9591fba6> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label1 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/organizations/b9c2cc5db5a08d33b049663f9591fba6/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/bestuurseenheden/b9c2cc5db5a08d33b049663f9591fba6> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label2 .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/f257217efa1b9c366ce4f478fb02a205/LoketLB-eredienstBedienaarGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f257217efa1b9c366ce4f478fb02a205> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label1 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/organizations/f257217efa1b9c366ce4f478fb02a205/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f257217efa1b9c366ce4f478fb02a205> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label2 .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/f257217efa1b9c366ce4f478fb02a205/LoketLB-eredienstBedienaarGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f257217efa1b9c366ce4f478fb02a205> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label1 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/organizations/f257217efa1b9c366ce4f478fb02a205/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f257217efa1b9c366ce4f478fb02a205> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label2 .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/27cd432cbfbba42816f0f3f9be6b7dd2/LoketLB-eredienstBedienaarGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27cd432cbfbba42816f0f3f9be6b7dd2> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label1 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/organizations/27cd432cbfbba42816f0f3f9be6b7dd2/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27cd432cbfbba42816f0f3f9be6b7dd2> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label2 .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/27cd432cbfbba42816f0f3f9be6b7dd2/LoketLB-eredienstBedienaarGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27cd432cbfbba42816f0f3f9be6b7dd2> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label1 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/organizations/27cd432cbfbba42816f0f3f9be6b7dd2/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27cd432cbfbba42816f0f3f9be6b7dd2> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label2 .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/b9c2cc5db5a08d33b049663f9591fba6/LoketLB-eredienstBedienaarGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b9c2cc5db5a08d33b049663f9591fba6> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label1 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/organizations/b9c2cc5db5a08d33b049663f9591fba6/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b9c2cc5db5a08d33b049663f9591fba6> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label2 .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/b9c2cc5db5a08d33b049663f9591fba6/LoketLB-eredienstBedienaarGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b9c2cc5db5a08d33b049663f9591fba6> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label1 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/organizations/b9c2cc5db5a08d33b049663f9591fba6/LoketLB-eredienstMandaatGebruiker> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b9c2cc5db5a08d33b049663f9591fba6> <http://www.w3.org/2004/02/skos/core#prefLabel> ?label2 .
+  }
+}


### PR DESCRIPTION
## Ticket ID

DL-6323

## Description

Some bestuurseenheden had two labels: the correct one in the public graph, and a wrong one in another (automatic submission, eredienstBedienaar and other graphs).

For the automatic submission graph, we delete the existing label and copy the correct one from the public graph. For the other graphs, we simply delete the label there.

## How to Test

You first need to run the below query which belongs to the `Generate Bestuurseenheden Report` on a local production backup:
```sparql
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

select distinct ?uri ?name ?kbonummer ?type ?province where {
  ?uri a besluit:Bestuurseenheid.
  OPTIONAL {
    ?uri skos:prefLabel ?name.
  }
  OPTIONAL {
    ?uri ext:kbonummer ?kbonummer.
  }
  OPTIONAL {
    ?uri ext:inProvincie ?provinceURI.
    ?provinceURI rdfs:label ?province.
  }
  OPTIONAL {
    ?uri besluit:classificatie ?typeURI.
    ?typeURI skos:prefLabel ?type .
  }
}
```

1. Set the `Results Format` in the Virtuoso interface to `CSV` and open the generated CSV in Libreoffice Calc.
2. Click on the `kbonummer` column to select all elements in that column.
     - Go to `Format -> Conditional -> Condition -> More Rules`.
     - Next to `Cell Value`, there is a dropdown. From the dropdown options, select `is duplicate`. For `Apply Style`, select `Error` (you should see a red background in the preview section next to it).
     - Once that is done, go to `Data -> More Filters -> Standard Filter`.
     - Click on `Options`, and you should see the `kbonummer` field name prefilled already.
     - In the `Condition` section, select `background color`. Afterwards, click on the `Value` dropdown; Libreoffice will directly suggest the red background we set in the `Format` part.
3. Once that is done, you should now only see the relevant rows with duplicate kbo numbers. You will notice there are two labels for the same kbo number: a correct one, and an another that needs to be removed.

Run the migration now and perform the same steps above listed in `1.`, `2.` and `3.`. You should now only see two rows: One row without a label and another with `Limgrond.be` as its label. The URI with the empty label is already slated for deletion in an [OP PR](https://github.com/lblod/app-organization-portal/pull/451/files#diff-4e8d6caa9d676e0c50375397180b3cf64a6da34563d74ff824e4862d7b75c5c4R104), which needs to be merged. 