### PR TITLE
Correct failed status uri for cogs jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Erediensten Dispatching from harvester, for OLV Temse [DL-6280]
   - Includes 3 migrations and perform a restart such that dispatching is automatically started.
 - Remove wrong labels for some bestuurseenheden. [DL-6323]
+- Correct failed status URI for authentication data cleanup job. [DL-6341]
 
 ### Deploy notes
 

--- a/config/migrations/2024/cleanup-jobs/20241211153723-fix-failed-status-uri-for-authentication-data-cleanup.sparql
+++ b/config/migrations/2024/cleanup-jobs/20241211153723-fix-failed-status-uri-for-authentication-data-cleanup.sparql
@@ -1,0 +1,80 @@
+PREFIX cleanup: <http://mu.semte.ch/vocabularies/ext/cleanup/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/cleanup-job/4d3b2cec-68a7-4703-9cbc-0a8ca6c29539> cleanup:randomQuery ?randomQuery .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/cleanup-job/4d3b2cec-68a7-4703-9cbc-0a8ca6c29539> cleanup:randomQuery """
+    DELETE {
+      GRAPH ?g {
+        ?resource <http://lblod.data.gift/vocabularies/security/targetAuthenticationConfiguration> ?targetAuthenticationConfiguration .
+      }
+
+      GRAPH ?h {
+        ?resource <http://lblod.data.gift/vocabularies/security/targetAuthenticationConfiguration> ?targetAuthenticationConfiguration .
+      }
+
+      GRAPH ?i {
+        ?targetAuthenticationConfiguration ?targetAuthenticationConfigurationP ?targetAuthenticationConfigurationO .
+        ?targetAuthenticationConfigurationO ?p_t ?o_t .
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        {
+          VALUES ?status {
+            <http://lblod.data.gift/file-download-statuses/success>
+            <http://lblod.data.gift/file-download-statuses/failure>
+          }
+
+          ?resource a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject> ;
+            <http://www.w3.org/ns/adms#status> ?status ;
+            <http://lblod.data.gift/vocabularies/security/targetAuthenticationConfiguration> ?targetAuthenticationConfiguration .
+        }
+        UNION
+        {
+          VALUES ?status {
+            <http://redpencil.data.gift/id/concept/JobStatus/success>
+            <http://redpencil.data.gift/id/concept/JobStatus/failed>
+          }
+
+          ?resource a <http://vocab.deri.ie/cogs#Job> ;
+            <http://www.w3.org/ns/adms#status> ?status ;
+            <http://lblod.data.gift/vocabularies/security/targetAuthenticationConfiguration> ?targetAuthenticationConfiguration .
+        }
+        UNION
+        {
+          VALUES ?status {
+            <http://redpencil.data.gift/id/concept/JobStatus/success>
+            <http://redpencil.data.gift/id/concept/JobStatus/failed>
+          }
+
+          ?job a <http://vocab.deri.ie/cogs#Job> ;
+            <http://www.w3.org/ns/prov#generated> ?resource ;
+            <http://www.w3.org/ns/adms#status> ?status .
+
+          GRAPH ?h {
+            ?resource a <http://rdf.myexperiment.org/ontologies/base/Submission> ;
+              <http://lblod.data.gift/vocabularies/security/targetAuthenticationConfiguration> ?targetAuthenticationConfiguration .
+          }
+        }
+      }
+
+      OPTIONAL {
+        GRAPH ?i {
+          ?targetAuthenticationConfiguration ?targetAuthenticationConfigurationP ?targetAuthenticationConfigurationO .
+          ?targetAuthenticationConfigurationO ?p_t ?o_t .
+        }
+      }
+    }
+    """
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/cleanup-job/4d3b2cec-68a7-4703-9cbc-0a8ca6c29539> cleanup:randomQuery ?randomQuery .
+  }
+}


### PR DESCRIPTION
## Ticket ID

DL-6341

## Description

`cogs:Job` resource types had `http://redpencil.data.gift/id/concept/JobStatus/failure` set as the failed status URI instead of `http://redpencil.data.gift/id/concept/JobStatus/failed`.
