### PR TITLE
Delete AGB Stekene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Erediensten Dispatching from harvester, for OLV Temse [DL-6280]
   - Includes 3 migrations and perform a restart such that dispatching is automatically started.
 - Remove wrong labels for some bestuurseenheden. [DL-6323]
+- Remove AGB Stekene. [OP-3409]
 
 ### Deploy notes
 

--- a/config/migrations/2024/20241212193803-delete-agb-stekene.sparql
+++ b/config/migrations/2024/20241212193803-delete-agb-stekene.sparql
@@ -1,0 +1,124 @@
+# Remove forward properties + mock person/account
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?org ?orgP ?orgO .
+  }
+
+  GRAPH ?g {
+    ?mockPerson ?mockPersonP ?mockPersonO .
+    ?mockAccount ?mockAccountP ?mockAccountO .
+  }
+}
+WHERE {
+  BIND(<http://data.lblod.info/id/bestuurseenheden/8d6609b4-1a20-46b8-97ed-150c6d53acd6> AS ?org)
+  BIND(<http://data.lblod.info/id/persoon/05ab337fad326fa39ecdfc2aa0bad35b> AS ?mockPerson)
+  BIND(<http://data.lblod.info/id/account/8bcc4a2df7d2f45274fdd911342795eb> AS ?mockAccount)
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?org ?orgP ?orgO .
+  }
+
+  GRAPH ?g {
+    ?mockPerson ?mockPersonP ?mockPersonO .
+    ?mockAccount ?mockAccountP ?mockAccountO .
+  }
+}
+
+;
+
+# Remove bestuursorganen
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuursorganen ?bestuursorganenP ?bestuursorganenO .
+    ?bestuursorganenInTijd ?bestuursorganenInTijdP ?bestuursorganenInTijdO .
+  }
+}
+WHERE {
+  VALUES ?bestuursorganen {
+    <http://data.lblod.info/id/bestuursorganen/24d8e602a8ddbe0adf3dea8c40277706>
+    <http://data.lblod.info/id/bestuursorganen/dad1789d9b9f8f6cb3c81cc2ca88154f>
+    <http://data.lblod.info/id/bestuursorganen/b90d16f2c8043bc20b88da232c0389fc>
+    <http://data.lblod.info/id/bestuursorganen/2f27a688e1728c1906a4bbd8670d7810>
+  }
+
+  VALUES ?bestuursorganenInTijd {
+    <http://data.lblod.info/id/bestuursorganen/c5bb7bca7363109b94b58b1aef6ed59c>
+    <http://data.lblod.info/id/bestuursorganen/8d43a29c6ed4a8af0cd43d4aba2c7014>
+    <http://data.lblod.info/id/bestuursorganen/f54979f47464bae1cc001788aedb8b86>
+    <http://data.lblod.info/id/bestuursorganen/c9a7d9130e1dd8f26ddb8c96fdd94c64>
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuursorganen ?bestuursorganenP ?bestuursorganenO .
+    ?bestuursorganenInTijd ?bestuursorganenInTijdP ?bestuursorganenInTijdO .
+  }
+}
+
+;
+
+# Remove bestuursorganen in tijd
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuursorganenInTijd ?bestuursorganenInTijdP ?bestuursorganenInTijdO .
+  }
+}
+WHERE {
+  VALUES ?bestuursorganenInTijd {
+    <http://data.lblod.info/id/bestuursorganen/c5bb7bca7363109b94b58b1aef6ed59c>
+    <http://data.lblod.info/id/bestuursorganen/8d43a29c6ed4a8af0cd43d4aba2c7014>
+    <http://data.lblod.info/id/bestuursorganen/f54979f47464bae1cc001788aedb8b86>
+    <http://data.lblod.info/id/bestuursorganen/c9a7d9130e1dd8f26ddb8c96fdd94c64>
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuursorganenInTijd ?bestuursorganenInTijdP ?bestuursorganenInTijdO .
+  }
+}
+
+;
+
+# Remove sessions
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/sessions> {
+    ?session ?sessionP ?sessionO .
+  }
+}
+WHERE {
+  BIND(<http://data.lblod.info/id/bestuurseenheden/8d6609b4-1a20-46b8-97ed-150c6d53acd6> AS ?org)
+
+  GRAPH <http://mu.semte.ch/graphs/sessions> {
+    ?session <http://mu.semte.ch/vocabularies/ext/sessionGroup> ?org ;
+      ?sessionP ?sessionO .
+  }
+}
+
+;
+
+# Clear the org graph
+CLEAR GRAPH <http://mu.semte.ch/graphs/organizations/8d6609b4-1a20-46b8-97ed-150c6d53acd6>
+
+;
+
+# Clear the toezichtGebruiker graph
+CLEAR GRAPH <http://mu.semte.ch/graphs/organizations/8d6609b4-1a20-46b8-97ed-150c6d53acd6/LoketLB-toezichtGebruiker>
+
+;
+
+# Clear the personeelsbeheer graph
+CLEAR GRAPH <http://mu.semte.ch/graphs/organizations/8d6609b4-1a20-46b8-97ed-150c6d53acd6/LoketLB-personeelsbeheer>
+
+;
+
+# Clear berichtenGebruiker graph with the exception of the `dataSource` property
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/8d6609b4-1a20-46b8-97ed-150c6d53acd6/LoketLB-berichtenGebruiker> {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/8d6609b4-1a20-46b8-97ed-150c6d53acd6/LoketLB-berichtenGebruiker> {
+    ?s ?p ?o .
+
+    FILTER (?p != <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource>)
+  }
+}


### PR DESCRIPTION
## Ticket ID

OP-3409

## Description

`AGB Stekene` is archived in this OP PR: https://github.com/lblod/app-organization-portal/pull/486 . On the Loket side, we have to delete the organization and its connected data since Loket does not have archival support yet.

## How to Test

### Query the data

Run the following queries to inspect the org's data on a local production backup:
```sparql
SELECT * WHERE {
  GRAPH <http://mu.semte.ch/graphs/organizations/8d6609b4-1a20-46b8-97ed-150c6d53acd6> {
    ?s ?p ?o .
  }
}
```
```sparql
SELECT * WHERE {
  GRAPH <http://mu.semte.ch/graphs/organizations/8d6609b4-1a20-46b8-97ed-150c6d53acd6/LoketLB-berichtenGebruiker> {
    ?s ?p ?o .
  }
}
```
```sparql
SELECT * WHERE {
  GRAPH <http://mu.semte.ch/graphs/organizations/8d6609b4-1a20-46b8-97ed-150c6d53acd6/LoketLB-toezichtGebruiker> {
    ?s ?p ?o .
  }
}
```
```sparql
SELECT * WHERE {
  GRAPH <http://mu.semte.ch/graphs/organizations/8d6609b4-1a20-46b8-97ed-150c6d53acd6/LoketLB-personeelsbeheer> {
    ?s ?p ?o .
  }
}
```
```sparql
SELECT ?p ?o WHERE {
  GRAPH <http://mu.semte.ch/graphs/public> {
    <http://data.lblod.info/id/bestuurseenheden/8d6609b4-1a20-46b8-97ed-150c6d53acd6> ?p ?o .
  }
}
```
```sparql
SELECT ?g ?s ?p WHERE {
  GRAPH ?g {
    ?s ?p <http://data.lblod.info/id/bestuurseenheden/8d6609b4-1a20-46b8-97ed-150c6d53acd6> .
  }
}
```
```sparql
SELECT DISTINCT ?s WHERE {
  VALUES ?bestuursorganen {
    <http://data.lblod.info/id/bestuursorganen/24d8e602a8ddbe0adf3dea8c40277706>
    <http://data.lblod.info/id/bestuursorganen/dad1789d9b9f8f6cb3c81cc2ca88154f>
    <http://data.lblod.info/id/bestuursorganen/b90d16f2c8043bc20b88da232c0389fc>
    <http://data.lblod.info/id/bestuursorganen/2f27a688e1728c1906a4bbd8670d7810>
  }
  
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?s ?p ?bestuursorganen .
  }
}
```

### Run the migration

Run the migration and refresh the results of the queries run above => All results should now be empty with the exception of the query for `/LoketLB-berichtenGebruiker`. In this case, you will still see the `<http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource>` property, which is intended.