### PR TITLE
Remove old decision type from toezicht decision scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## Unreleased
+## 1.107.3
 - Remove old decision type from toezicht decision scheme [DL-6366]
 ### Deploy notes
 #### Docker commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## Unreleased
+- Remove old decision type from toezicht decision scheme [DL-6366]
+### Deploy notes
+#### Docker commands
+- `drc restart migrations`
+- `drc up -d loket`
 ## 1.107.2 (2025-01-09)
  - Bump op-public-consumer [DL-6347]
 ### General

--- a/config/migrations/2025/20250113094500-remove-outdated-type-from-toezicht-dossier-types-concept-scheme.sparql
+++ b/config/migrations/2025/20250113094500-remove-outdated-type-from-toezicht-dossier-types-concept-scheme.sparql
@@ -1,0 +1,6 @@
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <https://data.vlaanderen.be/id/concept/BesluitType/e2928231-d377-48c7-98b4-3bb2f7de65db> <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> .
+    <https://data.vlaanderen.be/id/concept/BesluitType/e2928231-d377-48c7-98b4-3bb2f7de65db> <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> .
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   loket:
-    image: lblod/frontend-loket:0.98.1
+    image: lblod/frontend-loket:0.98.2
     links:
       - identifier:backend
     labels:


### PR DESCRIPTION
# Context

DL-6366

The decision type `https://data.vlaanderen.be/id/concept/BesluitType/e2928231-d377-48c7-98b4-3bb2f7de65db` is not used anymore and can be removed from the concept scheme of `Type dossier inzending voor toezicht`.

# Notes

:warning: Tag before merge, it's a hotfix. Bump frontend as well.