### PR TITLE
Migration: query to remove data with language tag

### DIFF
--- a/config/migrations/2025/20250115123400-remove-duplicate-data-with-lang-tag.sparql
+++ b/config/migrations/2025/20250115123400-remove-duplicate-data-with-lang-tag.sparql
@@ -1,0 +1,21 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?srtTagged .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s
+      prov:wasGeneratedBy <http://lblod.data.gift/id/app/lblod-harvesting> ;
+      ?p ?str ;
+      ?p ?srtTagged .
+    FILTER (?str = STR(?srtTagged))
+    FILTER (lang(?str) = "")
+    FILTER (lang(?srtTagged) != "")
+  }
+}
+


### PR DESCRIPTION
**[DL-6301]** (and **[DL-6286]**)

Remove only harvested data that with a language tag is a duplicate of already existing data without a language tag. These tags remained after the producer-consumer weren't able to remove this.

The hope is that the producer in Loket for OP is going to heal and see that these triples also need to be removed in OP.