### PR TITLE
Simplify vendor data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update Semantic Forms for adjusted form Afschrift Erkenningszoekende besturen [DL-6276]
 - Update frontend for showing rendered HTML in alert form field [DL-6276]
 - Export betrokken lokale besturen with submissions [DL-6352]
+- Simplify vendor data [DL-6328]
 
 #### Frontend
 - `v0.99.3` (DL-5449): https://github.com/lblod/frontend-loket/blob/development/CHANGELOG.md#v0993-2025-01-07
@@ -35,6 +36,8 @@ The following links;
 - `drc restart migrations`
 - `drc up -d enrich-submission loket`
 - `drc restart export-submissions`
+- `drc restart vendor-data-distribution`
+- `drc exec vendor-data-distribution curl -X POST http://localhost/healing`
 
 ## 1.107.3
 - Remove old decision type from toezicht decision scheme [DL-6366]

--- a/config/migrations/2025/20250124124100-flush-excess-vendor-data/20250124124200-flush-submission-document.sparql
+++ b/config/migrations/2025/20250124124100-flush-excess-vendor-data/20250124124200-flush-submission-document.sparql
@@ -1,0 +1,14 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a ext:SubmissionDocument .
+    ?s ?p ?o .
+  }
+  FILTER (REGEX(STR(?g), "^http://mu.semte.ch/graphs/vendors/"))
+}

--- a/config/migrations/2025/20250124124100-flush-excess-vendor-data/20250124124201-flush-formdata.sparql
+++ b/config/migrations/2025/20250124124100-flush-excess-vendor-data/20250124124201-flush-formdata.sparql
@@ -7,7 +7,7 @@ DELETE {
 }
 WHERE {
   GRAPH ?g {
-    ?s a am:FromData .
+    ?s a am:FormData .
     ?s ?p ?o .
   }
   FILTER (REGEX(STR(?g), "^http://mu.semte.ch/graphs/vendors/"))

--- a/config/migrations/2025/20250124124100-flush-excess-vendor-data/20250124124201-flush-formdata.sparql
+++ b/config/migrations/2025/20250124124100-flush-excess-vendor-data/20250124124201-flush-formdata.sparql
@@ -1,0 +1,14 @@
+PREFIX am: <http://lblod.data.gift/vocabularies/automatische-melding/>
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a am:FromData .
+    ?s ?p ?o .
+  }
+  FILTER (REGEX(STR(?g), "^http://mu.semte.ch/graphs/vendors/"))
+}

--- a/config/migrations/2025/20250124124100-flush-excess-vendor-data/20250124124202-flush-artikel.sparql
+++ b/config/migrations/2025/20250124124100-flush-excess-vendor-data/20250124124202-flush-artikel.sparql
@@ -1,0 +1,14 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a besluit:Artikel .
+    ?s ?p ?o .
+  }
+  FILTER (REGEX(STR(?g), "^http://mu.semte.ch/graphs/vendors/"))
+}

--- a/config/vendor-data/subjectsAndPaths.js
+++ b/config/vendor-data/subjectsAndPaths.js
@@ -14,10 +14,11 @@ export const subjects = [
   //
   // The following queries always copy the whole model at once. E.g. if there
   // is a Submission to be copied to the vendor graph, also copy the FormData,
-  // SubmissionDocument, Artikel (for cross referencing), ... if they exist.
-  // All data is also deleted before copied again. This is to make sure changes
-  // are correctly updated. Otherwise you would see multiple values for the
-  // same predicate because the old values are never deleted.
+  // SubmissionDocument, Artikel (for cross referencing), ... if they exist and
+  // if they are needed (not in this case). All data is also deleted before
+  // copied again. This is to make sure changes are correctly updated.
+  // Otherwise you would see multiple values for the same predicate because the
+  // old values are never deleted.
   // Note: Submissions via Loket are not copied to the vendor graphs. This is
   // because there is no vendor linked to the Submissions from Loket, and
   // vendors don't need to see Submission they haven't posted themselves. It is
@@ -40,245 +41,20 @@ export const subjects = [
     remove: {
       delete: `
         ?subject ?p ?o .
-        ?submissionDocument ?sdp ?sdo .
-        ?formdata ?fp ?fo .
-        ?artikel ?ap ?ao .
       `,
       where: `
         {
           ?subject ?p ?o .
-        } UNION {
-          ?subject <http://purl.org/dc/terms/subject> ?submissionDocument .
-          ?submissionDocument ?sdp ?sdo .
-        } UNION {
-          ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
-          ?formdata ?fp ?fo .
-        } UNION {
-          ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
-          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?artikel .
-          ?artikel ?ap ?ao .
         }
       `,
     },
     copy: {
       insert: `
         ?subject ?p ?o .
-        ?submissionDocument ?sdp ?sdo .
-        ?formdata ?fp ?fo .
-        ?artikel ?ap ?ao .
       `,
       where: `
         {
           ?subject ?p ?o .
-        } UNION {
-          ?subject <http://purl.org/dc/terms/subject> ?submissionDocument .
-          ?submissionDocument ?sdp ?sdo .
-        } UNION {
-          ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
-          ?formdata ?fp ?fo .
-        } UNION {
-          ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
-          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?artikel .
-          ?artikel ?ap ?ao .
-        }
-      `,
-    },
-  },
-
-  /**
-   * SubmissionDocument
-   */
-
-  {
-    type: 'http://mu.semte.ch/vocabularies/ext/SubmissionDocument',
-    trigger: `
-      ?subject a <http://mu.semte.ch/vocabularies/ext/SubmissionDocument> .
-    `,
-    path: `
-      ?submission <http://purl.org/dc/terms/subject> ?subject .
-      ?submission
-        pav:createdBy ?organisation ;
-        pav:providedBy ?vendor .
-    `,
-    remove: {
-      delete: `
-        ?submission ?sp ?so .
-        ?subject ?sdp ?sdo .
-        ?formdata ?fp ?fo .
-        ?artikel ?ap ?ao .
-      `,
-      where: `
-        {
-          ?submission <http://purl.org/dc/terms/subject> ?subject .
-          ?submission ?p ?o .
-        } UNION {
-          ?subject ?p ?o .
-        } UNION {
-          ?submission <http://purl.org/dc/terms/subject> ?subject .
-          ?submission <http://www.w3.org/ns/prov#generated> ?formdata .
-          ?formdata ?fp ?fo .
-        } UNION {
-          ?subject <http://data.europa.eu/eli/ontology#has_part> ?artikel .
-          ?artikel ?ap ?ao .
-        }
-      `,
-    },
-    copy: {
-      insert: `
-        ?submission ?sp ?so .
-        ?subject ?sdp ?sdo .
-        ?formdata ?fp ?fo .
-        ?artikel ?ap ?ao .
-      `,
-      where: `
-        {
-          ?submission <http://purl.org/dc/terms/subject> ?subject .
-          ?submission ?sp ?so .
-        } UNION {
-          ?subject ?sdp ?sdo .
-        } UNION {
-          ?submission <http://purl.org/dc/terms/subject> ?subject .
-          ?submission <http://www.w3.org/ns/prov#generated> ?formdata .
-          ?formdata ?fp ?fo .
-        } UNION {
-          ?subject <http://data.europa.eu/eli/ontology#has_part> ?artikel .
-          ?artikel ?ap ?ao .
-        }
-      `,
-    },
-  },
-
-  /**
-   * Artikel
-   * This is a cross-referenced document
-   */
-
-  {
-    type: 'http://data.vlaanderen.be/ns/besluit#Artikel',
-    trigger: `
-      ?subject a <http://data.vlaanderen.be/ns/besluit#Artikel> .
-    `,
-    path: `
-      ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
-      ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?subject .
-      ?submission
-        pav:createdBy ?organisation ;
-        pav:providedBy ?vendor .
-    `,
-    remove: {
-      delete: `
-        ?submission ?p ?o .
-        ?submissionDocument ?sdp ?sdo .
-        ?formdata ?fp ?fo .
-        ?subject ?ap ?ao .
-      `,
-      where: `
-        {
-          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
-          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?subject .
-          ?submission ?p ?o .
-        } UNION {
-          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?subject .
-          ?submissionDocument ?sdp ?sdo .
-        } UNION {
-          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
-          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?subject .
-          ?submission <http://www.w3.org/ns/prov#generated> ?formdata .
-          ?formdata ?fp ?fo .
-        } UNION {
-          ?subject ?ap ?ao .
-        }
-      `,
-    },
-    copy: {
-      insert: `
-        ?submission ?p ?o .
-        ?submissionDocument ?sdp ?sdo .
-        ?formdata ?fp ?fo .
-        ?subject ?ap ?ao .
-      `,
-      where: `
-        {
-          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
-          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?subject .
-          ?submission ?p ?o .
-        } UNION {
-          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?subject .
-          ?submissionDocument ?sdp ?sdo .
-        } UNION {
-          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
-          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?subject .
-          ?submission <http://www.w3.org/ns/prov#generated> ?formdata .
-          ?formdata ?fp ?fo .
-        } UNION {
-          ?subject ?ap ?ao .
-        }
-      `,
-    },
-  },
-
-  /**
-   * FormData
-   */
-
-  {
-    type: 'http://lblod.data.gift/vocabularies/automatische-melding/FormData',
-    trigger: `
-      ?subject a <http://lblod.data.gift/vocabularies/automatische-melding/FormData> .
-    `,
-    path: `
-      ?submission <http://www.w3.org/ns/prov#generated> ?subject .
-      ?submission
-        pav:createdBy ?organisation ;
-        pav:providedBy ?vendor .
-    `,
-    remove: {
-      delete: `
-        ?submission ?p ?o .
-        ?submissionDocument ?sdp ?sdo .
-        ?subject ?fp ?fo .
-        ?artikel ?ap ?ao .
-      `,
-      where: `
-        {
-          ?submission <http://www.w3.org/ns/prov#generated> ?subject .
-          ?submission ?p ?o .
-        } UNION {
-          ?submission <http://www.w3.org/ns/prov#generated> ?subject .
-          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
-          ?submissionDocument ?sdp ?sdo .
-        } UNION {
-          ?subject ?fp ?fo .
-        } UNION {
-          ?submission <http://www.w3.org/ns/prov#generated> ?subject .
-          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
-          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?artikel .
-          ?artikel ?ap ?ao .
-        }
-      `,
-    },
-    copy: {
-      insert: `
-        ?submission ?p ?o .
-        ?submissionDocument ?sdp ?sdo .
-        ?subject ?fp ?fo .
-        ?artikel ?ap ?ao .
-      `,
-      where: `
-        {
-          ?submission <http://www.w3.org/ns/prov#generated> ?subject .
-          ?submission ?p ?o .
-        } UNION {
-          ?submission <http://www.w3.org/ns/prov#generated> ?subject .
-          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
-          ?submissionDocument ?sdp ?sdo .
-        } UNION {
-          ?subject ?fp ?fo .
-        } UNION {
-          ?submission <http://www.w3.org/ns/prov#generated> ?subject .
-          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
-          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?artikel .
-          ?artikel ?ap ?ao .
         }
       `,
     },


### PR DESCRIPTION
**[DL-6328]**

After a discussion, we decided to (carefully) remove all the unneeded subjects from the vendor data in Loket. To be left with only the Submission such that Vendors can inspect the status of their submission. The rest of the data can be found in the Worship Decision Database.

**Note: this PR only includes a single commit with useful changes. This is to allow for easier reverting if needed later.**