### PR TITLE
Re-export missing submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## Unreleased
+
+### General
+
+- Add `migrations-publication-triplestore` as a migration service for the publication-triplestore [DL-6349]
+- Re-export 12 submissions and their related subjects, because they are missing from Worship Decisions Database, see migrations and deploy instructions [DL-6349]
+
+### Deploy instructions
+
+**For re-exporting submissions**
+
+- Pull and start the new service
+  * `drc up -d migrations-publication-triplestore`
+- Make sure migrations have run `drc logs --tail 1000 -f migrations-publication-triplestore`
+- Run the following commands to send submissions to be marked for publication to Worship Decisions Database:
+
+```
+cd scripts/send-submissions-to-prepare-for-export/
+
+echo 'http://data.lblod.info/form-data/95c393b0-07f1-11ef-8911-1be0e451139c
+http://data.lblod.info/form-data/d86d0350-f8eb-11ee-8911-1be0e451139c
+http://data.lblod.info/form-data/54e5ea70-f89a-11ee-8911-1be0e451139c
+http://data.lblod.info/form-data/2fe55480-f710-11ee-8911-1be0e451139c
+http://data.lblod.info/form-data/dc3c4ab0-e048-11ee-8911-1be0e451139c' > form-data-uris.txt
+
+./run.sh
+
+rm form-data-uris.txt
+
+# Make sure that the prepare service has processed everything
+# This can take about 2 minutes
+drc logs --tail 1000 -f prepare-submissions-for-export
+```
+
+- Start healing on the `delta-producer-publication-graph-maintainer` via the `delta-producer-background-jobs-initiator`
+  * `drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/worship-submissions/healing-jobs`
+  * This can also take a while, up to an hour.
+
 ## 1.108.0 (2025-01-24)
 
 ### General

--- a/config/migrations-publication-triplestore/2025/20250129150000-remove-submission-to-re-export.sparql
+++ b/config/migrations-publication-triplestore/2025/20250129150000-remove-submission-to-re-export.sparql
@@ -1,0 +1,43 @@
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+DELETE {
+  GRAPH ?g {
+    ?submission ?sp ?so .
+    ?submissionDocument ?sdp ?sdo .
+    ?pFile ?pp ?po .
+    ?formData ?fp ?fo .
+    ?lFile ?lp ?lo .
+    ?pFile2 ?p2p ?p2o .
+  }
+}
+WHERE {
+  BIND (<http://data.lblod.info/submissions/07bb1a40-a624-11ee-b59d-2563fb773ec4> as ?submission)
+  GRAPH ?g {
+    {
+      ?submission ?sp ?so .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument ?sdp ?sdo .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument dct:source ?pFile .
+      ?pFile ?pp ?po .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData ?fp ?fo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?lFile ?lp ?lo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?pFile2 nie:dataSource ?lFile .
+      ?pFile2 ?p2p ?p2o .
+    }
+  }
+}

--- a/config/migrations-publication-triplestore/2025/20250129150001-remove-submission-to-re-export.sparql
+++ b/config/migrations-publication-triplestore/2025/20250129150001-remove-submission-to-re-export.sparql
@@ -1,0 +1,43 @@
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+DELETE {
+  GRAPH ?g {
+    ?submission ?sp ?so .
+    ?submissionDocument ?sdp ?sdo .
+    ?pFile ?pp ?po .
+    ?formData ?fp ?fo .
+    ?lFile ?lp ?lo .
+    ?pFile2 ?p2p ?p2o .
+  }
+}
+WHERE {
+  BIND (<http://data.lblod.info/submissions/a9329ee0-aed8-11ee-b59d-2563fb773ec4> as ?submission)
+  GRAPH ?g {
+    {
+      ?submission ?sp ?so .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument ?sdp ?sdo .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument dct:source ?pFile .
+      ?pFile ?pp ?po .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData ?fp ?fo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?lFile ?lp ?lo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?pFile2 nie:dataSource ?lFile .
+      ?pFile2 ?p2p ?p2o .
+    }
+  }
+}

--- a/config/migrations-publication-triplestore/2025/20250129150002-remove-submission-to-re-export.sparql
+++ b/config/migrations-publication-triplestore/2025/20250129150002-remove-submission-to-re-export.sparql
@@ -1,0 +1,43 @@
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+DELETE {
+  GRAPH ?g {
+    ?submission ?sp ?so .
+    ?submissionDocument ?sdp ?sdo .
+    ?pFile ?pp ?po .
+    ?formData ?fp ?fo .
+    ?lFile ?lp ?lo .
+    ?pFile2 ?p2p ?p2o .
+  }
+}
+WHERE {
+  BIND (<http://data.lblod.info/submissions/658D49F4E3FFD8BBF65D80B9> as ?submission)
+  GRAPH ?g {
+    {
+      ?submission ?sp ?so .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument ?sdp ?sdo .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument dct:source ?pFile .
+      ?pFile ?pp ?po .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData ?fp ?fo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?lFile ?lp ?lo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?pFile2 nie:dataSource ?lFile .
+      ?pFile2 ?p2p ?p2o .
+    }
+  }
+}

--- a/config/migrations-publication-triplestore/2025/20250129150003-remove-submission-to-re-export.sparql
+++ b/config/migrations-publication-triplestore/2025/20250129150003-remove-submission-to-re-export.sparql
@@ -1,0 +1,43 @@
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+DELETE {
+  GRAPH ?g {
+    ?submission ?sp ?so .
+    ?submissionDocument ?sdp ?sdo .
+    ?pFile ?pp ?po .
+    ?formData ?fp ?fo .
+    ?lFile ?lp ?lo .
+    ?pFile2 ?p2p ?p2o .
+  }
+}
+WHERE {
+  BIND (<http://data.lblod.info/submissions/07095670-a624-11ee-b59d-2563fb773ec4> as ?submission)
+  GRAPH ?g {
+    {
+      ?submission ?sp ?so .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument ?sdp ?sdo .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument dct:source ?pFile .
+      ?pFile ?pp ?po .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData ?fp ?fo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?lFile ?lp ?lo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?pFile2 nie:dataSource ?lFile .
+      ?pFile2 ?p2p ?p2o .
+    }
+  }
+}

--- a/config/migrations-publication-triplestore/2025/20250129150004-remove-submission-to-re-export.sparql
+++ b/config/migrations-publication-triplestore/2025/20250129150004-remove-submission-to-re-export.sparql
@@ -1,0 +1,43 @@
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+DELETE {
+  GRAPH ?g {
+    ?submission ?sp ?so .
+    ?submissionDocument ?sdp ?sdo .
+    ?pFile ?pp ?po .
+    ?formData ?fp ?fo .
+    ?lFile ?lp ?lo .
+    ?pFile2 ?p2p ?p2o .
+  }
+}
+WHERE {
+  BIND (<http://data.lblod.info/submissions/062a4110-a624-11ee-b59d-2563fb773ec4> as ?submission)
+  GRAPH ?g {
+    {
+      ?submission ?sp ?so .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument ?sdp ?sdo .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument dct:source ?pFile .
+      ?pFile ?pp ?po .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData ?fp ?fo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?lFile ?lp ?lo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?pFile2 nie:dataSource ?lFile .
+      ?pFile2 ?p2p ?p2o .
+    }
+  }
+}

--- a/config/migrations-publication-triplestore/2025/20250129150005-remove-submission-to-re-export.sparql
+++ b/config/migrations-publication-triplestore/2025/20250129150005-remove-submission-to-re-export.sparql
@@ -1,0 +1,43 @@
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+DELETE {
+  GRAPH ?g {
+    ?submission ?sp ?so .
+    ?submissionDocument ?sdp ?sdo .
+    ?pFile ?pp ?po .
+    ?formData ?fp ?fo .
+    ?lFile ?lp ?lo .
+    ?pFile2 ?p2p ?p2o .
+  }
+}
+WHERE {
+  BIND (<http://data.lblod.info/submissions/087394d0-a624-11ee-b59d-2563fb773ec4> as ?submission)
+  GRAPH ?g {
+    {
+      ?submission ?sp ?so .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument ?sdp ?sdo .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument dct:source ?pFile .
+      ?pFile ?pp ?po .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData ?fp ?fo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?lFile ?lp ?lo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?pFile2 nie:dataSource ?lFile .
+      ?pFile2 ?p2p ?p2o .
+    }
+  }
+}

--- a/config/migrations-publication-triplestore/2025/20250129150006-remove-submission-to-re-export.sparql
+++ b/config/migrations-publication-triplestore/2025/20250129150006-remove-submission-to-re-export.sparql
@@ -1,0 +1,43 @@
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+DELETE {
+  GRAPH ?g {
+    ?submission ?sp ?so .
+    ?submissionDocument ?sdp ?sdo .
+    ?pFile ?pp ?po .
+    ?formData ?fp ?fo .
+    ?lFile ?lp ?lo .
+    ?pFile2 ?p2p ?p2o .
+  }
+}
+WHERE {
+  BIND (<http://data.lblod.info/submissions/b85c9d70-7a4a-11ee-bd72-9da63c9df7c5> as ?submission)
+  GRAPH ?g {
+    {
+      ?submission ?sp ?so .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument ?sdp ?sdo .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument dct:source ?pFile .
+      ?pFile ?pp ?po .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData ?fp ?fo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?lFile ?lp ?lo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?pFile2 nie:dataSource ?lFile .
+      ?pFile2 ?p2p ?p2o .
+    }
+  }
+}

--- a/config/migrations-publication-triplestore/README.md
+++ b/config/migrations-publication-triplestore/README.md
@@ -1,0 +1,16 @@
+# Migrations on the publication-triplestore
+
+If you want to fix something in the frontend or other service in this stack, DO
+NOT MAKE ANY MIGRATIONS HERE.
+
+The publication triplestore is only meant to be used as a intermediate for the
+producers in the stack. It is used for calculating differences between what's
+in the actual triplestore that is used for all the services, and what has
+already been sent to the consuming apps in terms of delta files.
+
+It can be used as a trick to re-export certain data. For example, if some
+Sumbission is missing from consuming apps, you can remove it and related
+subjects from the publication-triplestore and trigger healing on the producer
+in question. This will generate the delta files for those subjects, ready to be
+consumed. Look at some existing migrations for examples.
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,6 +33,8 @@ services:
     restart: "no"
   migrations:
     restart: "no"
+  migrations-publication-triplestore:
+    restart: "no"
   cache:
     restart: "no"
   resource:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,18 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  migrations-publication-triplestore:
+    image: semtech/mu-migrations-service:0.9.0
+    links:
+      - publication-triplestore:database
+    environment:
+      MU_SPARQL_TIMEOUT: "300"
+    volumes:
+      - ./config/migrations-publication-triplestore:/data/migrations
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
   cache:
     image: semtech/mu-cache:2.0.1
     links:


### PR DESCRIPTION
**[DL-6349]**

A number of submissions were missed by the `prepare-submissions-for-export` service, certain submissions were not properly exported by the `delta-producer-publication-graph-maintainer`, and certain submissions were not properly consumed and/or dispatched by the Worship Decisions Database application. Solved by re-exporting all of these by two mechanisms:

* Some submissions still needed their `schema:publication` triple
  - Sending mock delta messages via a script to the `prepare-submissions-for-export` service to restart the process 
* The rest is simply removed from the `publication-triplestore` and re-produced via healing

These instructions are laid out in the CHANGELOG.