### PR TITLE
Feature: make 'reglementen en verordeningen' available for extra admin units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `migrations-publication-triplestore` as a migration service for the publication-triplestore [DL-6349]
 - Re-export 12 submissions and their related subjects, because they are missing from Worship Decisions Database, see migrations and deploy instructions [DL-6349]
+- Update form 'Reglementen en verordeningen' decidableBy for 3 more admin units [DL-6357]
 
 ### Deploy instructions
 

--- a/config/migrations/2025/20250203134647-update-reglementen-en-verordeningen-besluittype-decidableby.sparql
+++ b/config/migrations/2025/20250203134647-update-reglementen-en-verordeningen-besluittype-decidableby.sparql
@@ -2,11 +2,11 @@ PREFIX besluit: <http://lblod.data.gift/vocabularies/besluit/>
 PREFIX BestuurseenheidClassificatieCode: <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/>
 PREFIX BesluitType: <https://data.vlaanderen.be/id/concept/BesluitType/>
 
-INSERT {
+INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
     BesluitType:67378dd0-5413-474b-8996-d992ef81637a
       besluit:decidableBy BestuurseenheidClassificatieCode:d01bb1f6-2439-4e33-9c25-1fc295de2e71 ; # Dienstverlenende vereniging
       besluit:decidableBy BestuurseenheidClassificatieCode:cd93f147-3ece-4308-acab-5c5ada3ec63d ; # Opdrachthoudende vereniging
-      besluit:decidableBy BestuurseenheidClassificatieCode:d46b2acb-4763-4532-9aff-fdede39e9520 . # Opdrachthoudende vereniging met private deelname
+      besluit:decidableBy BestuurseenheidClassificatieCode:4b8450cf-a326-4c66-9e63-b4ec10acc7f6 . # Opdrachthoudende vereniging met private deelname
    }
 }

--- a/config/migrations/2025/20250203134647-update-reglementen-en-verordeningen-besluittype-decidableby.sparql
+++ b/config/migrations/2025/20250203134647-update-reglementen-en-verordeningen-besluittype-decidableby.sparql
@@ -1,0 +1,12 @@
+PREFIX besluit: <http://lblod.data.gift/vocabularies/besluit/>
+PREFIX BestuurseenheidClassificatieCode: <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/>
+PREFIX BesluitType: <https://data.vlaanderen.be/id/concept/BesluitType/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    BesluitType:67378dd0-5413-474b-8996-d992ef81637a
+      besluit:decidableBy BestuurseenheidClassificatieCode:d01bb1f6-2439-4e33-9c25-1fc295de2e71 ; # Dienstverlenende vereniging
+      besluit:decidableBy BestuurseenheidClassificatieCode:cd93f147-3ece-4308-acab-5c5ada3ec63d ; # Opdrachthoudende vereniging
+      besluit:decidableBy BestuurseenheidClassificatieCode:d46b2acb-4763-4532-9aff-fdede39e9520 . # Opdrachthoudende vereniging met private deelname
+   }
+}


### PR DESCRIPTION
## ID

DL-6357

## Description

Make 'Reglementen en verordeningen’ in Module Toezicht  available for `Dienstverlenende vereniging`, `Opdrachthoudende vereniging` and `Opdrachthoudende vereniging met private deelname`

## How to test

Run migration, login as all three of the new admin units, go to toezicht and verify that the 'Reglementen en verordeningen' form is available.

Note that `Opdrachthoudende vereniging met private deelname (IVAGO)` is currently not able to go to toezicht, this should be resolved in DL-6384

## Linked PR's

- Centrale vindplaats: WIP