### PR TITLE
Add IVAGO classification type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `migrations-publication-triplestore` as a migration service for the publication-triplestore [DL-6349]
 - Re-export 12 submissions and their related subjects, because they are missing from Worship Decisions Database, see migrations and deploy instructions [DL-6349]
+- Add `Opdrachthoudende vereniging met private deelname` classification type for mock-login roles and submission types. [DL-6384]
 
 ### Deploy instructions
 
@@ -37,6 +38,11 @@ drc logs --tail 1000 -f prepare-submissions-for-export
 - Start healing on the `delta-producer-publication-graph-maintainer` via the `delta-producer-background-jobs-initiator`
   * `drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/worship-submissions/healing-jobs`
   * This can also take a while, up to an hour.
+
+**For adding new classification type**
+
+- `drc restart update-bestuurseenheid-mock-login migrations && drc logs -ft --tail=200 migrations`
+- `drc restart resource cache`
 
 ## 1.108.1 (2025-02-04)
 
@@ -115,7 +121,7 @@ For the resync of the harvested data:
   BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: "true"
   ```
 - `drc stop dispatcher-worship-mandates` to speed up the initial sync later
-- `drc up -d eredienst-mandatarissen-consumer` 
+- `drc up -d eredienst-mandatarissen-consumer`
 - `drc exec eredienst-mandatarissen-consumer curl -X POST http://localhost/flush`
   * Wait for the flush to be successful `drc logs -f eredienst-mandatarissen-consumer`
 - `drc exec eredienst-mandatarissen-consumer curl -X POST http://localhost/initial-sync-jobs`

--- a/config/migrations/2025/mocklogin/20250205110525-add-correct-session-roles-for-ivago.sparql
+++ b/config/migrations/2025/mocklogin/20250205110525-add-correct-session-roles-for-ivago.sparql
@@ -1,0 +1,12 @@
+INSERT {
+  GRAPH ?g {
+    ?account <http://mu.semte.ch/vocabularies/ext/sessionRole> "LoketLB-toezichtGebruiker", "LoketLB-bbcdrGebruiker", "LoketLB-leidinggevendenGebruiker", "LoketLB-LPDCGebruiker" .
+  }
+}
+WHERE {
+  BIND(<http://data.lblod.info/id/account/3dc8db6a00a32125acd2e215225442c8> AS ?account) # Mock-login account belonging to IVAGO
+
+  GRAPH ?g {
+    ?account a ?type .
+  }
+}

--- a/config/migrations/2025/submissions/20250204222225-add-opdrachthoudende-vereniging-met-private-deelname-classification-to-certain-submissions.sparql
+++ b/config/migrations/2025/submissions/20250204222225-add-opdrachthoudende-vereniging-met-private-deelname-classification-to-certain-submissions.sparql
@@ -1,0 +1,26 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?submissionType <http://lblod.data.gift/vocabularies/besluit/decidableBy> ?classification .
+  }
+}
+WHERE {
+  VALUES ?submissionType {
+    <https://data.vlaanderen.be/id/concept/BesluitType/b04bc642-c892-4aae-ac1f-f6ff21362704>
+    <https://data.vlaanderen.be/id/concept/BesluitType/a2836d2f-1fee-4549-bd85-b9c13698b757>
+    <https://data.vlaanderen.be/id/concept/BesluitType/afdb7387-da47-4dc4-bbbe-e86ea5c3df28>
+    <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+    <https://data.vlaanderen.be/id/concept/BesluitType/4511f992-2b52-42fe-9cb6-feae6241ad26>
+    <https://data.vlaanderen.be/id/concept/BesluitType/dbc58656-b0a5-4e43-8e9e-701acb75f9b0>
+    <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/cc831628-95a0-4874-bad5-cdf563896032>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/0ee460b1-5ef4-4d4a-b5e1-e2d7c1d5086e>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/365d561c-57c7-4523-af04-6e3c91426c56>
+  }
+
+  BIND(<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6> AS ?classification)
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?submissionType ?p ?o .
+  }
+}

--- a/config/migrations/2025/submissions/20250204222225-add-opdrachthoudende-vereniging-met-private-deelname-classification-to-certain-submissions.sparql
+++ b/config/migrations/2025/submissions/20250204222225-add-opdrachthoudende-vereniging-met-private-deelname-classification-to-certain-submissions.sparql
@@ -5,20 +5,21 @@ INSERT {
 }
 WHERE {
   VALUES ?submissionType {
-    <https://data.vlaanderen.be/id/concept/BesluitType/b04bc642-c892-4aae-ac1f-f6ff21362704>
-    <https://data.vlaanderen.be/id/concept/BesluitType/a2836d2f-1fee-4549-bd85-b9c13698b757>
-    <https://data.vlaanderen.be/id/concept/BesluitType/afdb7387-da47-4dc4-bbbe-e86ea5c3df28>
-    <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
-    <https://data.vlaanderen.be/id/concept/BesluitType/4511f992-2b52-42fe-9cb6-feae6241ad26>
-    <https://data.vlaanderen.be/id/concept/BesluitType/dbc58656-b0a5-4e43-8e9e-701acb75f9b0>
-    <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b>
-    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/cc831628-95a0-4874-bad5-cdf563896032>
-    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/0ee460b1-5ef4-4d4a-b5e1-e2d7c1d5086e>
-    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
-    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/365d561c-57c7-4523-af04-6e3c91426c56>
+    <https://data.vlaanderen.be/id/concept/BesluitType/b04bc642-c892-4aae-ac1f-f6ff21362704> # Code van goed bestuur
+    <https://data.vlaanderen.be/id/concept/BesluitType/a2836d2f-1fee-4549-bd85-b9c13698b757> # Niet-bindend advies op oprichting
+    <https://data.vlaanderen.be/id/concept/BesluitType/afdb7387-da47-4dc4-bbbe-e86ea5c3df28> # Niet-bindend advies op statuten
+    <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8> # Rechtspositieregeling (RPR)
+    <https://data.vlaanderen.be/id/concept/BesluitType/4511f992-2b52-42fe-9cb6-feae6241ad26> # Saneringsplan - Plan vrijwaring continuïteit (art. 457 DLB)
+    <https://data.vlaanderen.be/id/concept/BesluitType/dbc58656-b0a5-4e43-8e9e-701acb75f9b0> # Statutenwijziging IGS
+    <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/13fefad6-a9d6-4025-83b5-e4cbee3a8965> # Agenda
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/cc831628-95a0-4874-bad5-cdf563896032> # Afwijking principes regiovorming
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/0ee460b1-5ef4-4d4a-b5e1-e2d7c1d5086e> # Andere documenten BBC
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee> # Besluitenlijst
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/365d561c-57c7-4523-af04-6e3c91426c56> # Overzicht vergoedingen en presentiegelden
   }
 
-  BIND(<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6> AS ?classification)
+  BIND(<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6> AS ?classification) # Opdrachthoudende vereniging met private deelname
 
   GRAPH <http://mu.semte.ch/graphs/public> {
     ?submissionType ?p ?o .

--- a/config/mock-login/rules.json
+++ b/config/mock-login/rules.json
@@ -15,7 +15,8 @@
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc",
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562",
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71",
-        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d90c511e-f827-488c-84ba-432c8f69561c"
+        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d90c511e-f827-488c-84ba-432c8f69561c",
+        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6"
       ]
     },
     {
@@ -54,7 +55,8 @@
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562",
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054",
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d90c511e-f827-488c-84ba-432c8f69561c",
-        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213"
+        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213",
+        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6"
       ]
     },
     {
@@ -79,7 +81,8 @@
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/2ad46df5-5c79-4d67-84d5-604c1377231e",
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/088784b6-e188-48bf-b94f-94665f9e1f53",
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9",
-        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267"
+        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267",
+        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6"
       ]
     },
     {
@@ -105,7 +108,8 @@
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc",
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562",
         "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71",
-        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d90c511e-f827-488c-84ba-432c8f69561c"
+        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d90c511e-f827-488c-84ba-432c8f69561c",
+        "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6"
       ]
     },
     {


### PR DESCRIPTION
## Ticket ID

DL-6384

## Description

IVAGO is an organization that currently has a new classification type (`Opdrachthoudende vereniging met private deelname`). Given its recency, our mock-login and submissions configurations were not updated with this new URI, which led to modules not showing up for mock logins in addition to IVAGO not being able to see any submissions in the dropdown menu.

## How to reproduce

Make sure first that you either:
* have already synced organizations locally from OP
* or are using a backup (dev, qa or prod) that already has the data.

1. Go to the mock-login page and type in `ivago` => you should see a match.
2. After logging in, you will only see `berichtencentrum` and `subsidiepunt` (it's possible to see others depending on your type of backup, but it will still be missing modules in any case).

## How to test

1. `drc restart migrations && drc logs -ft --tail=200 migrations`
2. `drc restart resource cache`
    - If you were already logged in, log out and back in again.
4. You should now see: `Toezicht`, `Berichtencentrum`, `BBC-DR`, `Leidinggevendenbeheer` and `Producten- en dienstencatalogus`.
    - `SubsidiePunt` and `Data Monitoring Tool` modules should also show up if you have the external URLs configured in `docker-compose.override.yml`.
5. Go to `Toezicht` and try to submit any submission from the dropdown list => the submission should be successfully processed once you click on send.