### PR TITLE
Add report for duplicate harvested and non harvested mandatarissen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `migrations-publication-triplestore` as a migration service for the publication-triplestore [DL-6349]
 - Re-export 12 submissions and their related subjects, because they are missing from Worship Decisions Database, see migrations and deploy instructions [DL-6349]
+- Add report to detect harvested and non-harvested mandatarissen having the same position in the same organization. [DL-6342]
 
 ### Deploy instructions
 
@@ -37,6 +38,10 @@ drc logs --tail 1000 -f prepare-submissions-for-export
 - Start healing on the `delta-producer-publication-graph-maintainer` via the `delta-producer-background-jobs-initiator`
   * `drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/worship-submissions/healing-jobs`
   * This can also take a while, up to an hour.
+
+**For the report**
+
+- `drc restart report-generation`
 
 ## 1.108.1 (2025-02-04)
 
@@ -115,7 +120,7 @@ For the resync of the harvested data:
   BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: "true"
   ```
 - `drc stop dispatcher-worship-mandates` to speed up the initial sync later
-- `drc up -d eredienst-mandatarissen-consumer` 
+- `drc up -d eredienst-mandatarissen-consumer`
 - `drc exec eredienst-mandatarissen-consumer curl -X POST http://localhost/flush`
   * Wait for the flush to be successful `drc logs -f eredienst-mandatarissen-consumer`
 - `drc exec eredienst-mandatarissen-consumer curl -X POST http://localhost/initial-sync-jobs`

--- a/config/reports/harvested-and-non-harvested-mandataris-for-same-position.js
+++ b/config/reports/harvested-and-non-harvested-mandataris-for-same-position.js
@@ -2,7 +2,7 @@ import { query } from 'mu';
 import { generateReportFromData } from '../helpers.js';
 
 export default {
-  cronPattern: '0 10 22 * * 6',
+  cronPattern: '0 10 0 * * *',
   name: 'harvested-and-non-harvested-mandatarissen-report',
   execute: async () => {
     const reportData = {

--- a/config/reports/harvested-and-non-harvested-mandataris-for-same-position.js
+++ b/config/reports/harvested-and-non-harvested-mandataris-for-same-position.js
@@ -1,0 +1,51 @@
+import { query } from 'mu';
+import { generateReportFromData } from '../helpers.js';
+
+export default {
+  cronPattern: '0 10 22 * * 6',
+  name: 'harvested-and-non-harvested-mandatarissen-report',
+  execute: async () => {
+    const reportData = {
+      title: 'List of harvested and non-harvested mandatarissen having the same position',
+      description: 'Selects harvested and non-harvested mandatarissen having the same position alongside the organization name',
+      filePrefix: 'harvested-and-non-harvested-mandataris-for-same-position'
+    };
+
+    console.log('Generate Report for detecting harvested and non-harvested mandatarissen having the same position');
+
+    const queryString = `
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT DISTINCT ?worshipServiceName ?subject ?subjectHarvested WHERE {
+        GRAPH <http://mu.semte.ch/graphs/public> {
+          ?timedGoverningBody org:hasPost ?post ;
+            <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?governingBody ;
+            <http://data.vlaanderen.be/ns/mandaat#bindingStart> ?startDate .
+
+          ?governingBody besluit:bestuurt ?worshipService .
+
+          ?worshipService skos:prefLabel ?worshipServiceName .
+        }
+
+        GRAPH ?g {
+          ?subject org:holds ?post .
+          FILTER NOT EXISTS { ?subject <http://www.w3.org/ns/prov#wasGeneratedBy> <http://lblod.data.gift/id/app/lblod-harvesting> . }
+
+          ?subjectHarvested org:holds ?post .
+          FILTER EXISTS { ?subjectHarvested <http://www.w3.org/ns/prov#wasGeneratedBy> <http://lblod.data.gift/id/app/lblod-harvesting> . }
+        }
+      } ORDER BY ?worshipServiceName
+    `;
+
+    const queryResponse = await query(queryString);
+    const data = queryResponse.results.bindings.map((result) => ({
+      worshipServiceName: result.uri.worshipServiceName,
+      subject: result.uri.subject,
+      subjectHarvested: result.uri.subjectHarvested
+    }));
+
+    await generateReportFromData(data, ['worshipServiceName', 'subject', 'subjectHarvested'], reportData);
+  }
+};

--- a/config/reports/index.js
+++ b/config/reports/index.js
@@ -26,6 +26,7 @@ import bedienaren from './worship/bedienaren';
 import mandatarissen from './worship/mandatarissen';
 import tempDeletes from './worship/temp-deletes';
 import tempInserts from './worship/temp-inserts';
+import harvestedAndNonHarvestedMandatarisForSamePosition from './harvested-and-non-harvested-mandataris-for-same-position';
 
 //Berichten reports
 import berichten from './berichten/messages-with-provenance';
@@ -61,6 +62,7 @@ export default [
   mandatarissen,
   tempDeletes,
   tempInserts,
+  harvestedAndNonHarvestedMandatarisForSamePosition,
 
   //Berichten reports
   berichten,


### PR DESCRIPTION
## Ticket ID

DL-6342

## Description

Organizations moving from Loket to a vendor (or vice-versa) may end up having duplicate mandatarissen, which confuse the user. The report will serve as a sentinel to catch any future cases.

## How to test

1. `docker compose restart report-generation` to load the report
2. `docker compose exec report-generation curl -X POST -H "Content-Type: application/vnd.api+json"  -d '{  "data": { "attributes": { "reportName": "harvested-and-non-harvested-mandatarissen-report" }  }  }' http://localhost/reports` to run the report.
3. If you are running it on a recent production backup, it should a count of around 464 rows.