### PR TITLE
Remove 3 broken EredienstMandatarissen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `Opdrachthoudende vereniging met private deelname` classification type for mock-login roles and submission types. [DL-6384]
 - Add report to detect harvested and non-harvested mandatarissen having the same position in the same organization. [DL-6342]
 - Remove submissions export config replaced by op sync [DL-6394]
+- Add migration that removes three older, broken EredienstMandatarissen pointing to non-existing people and contact points [DL-5662]
 
 ### Deploy instructions
 

--- a/config/migrations/2025/20250207040000-remove-3-broken-madates-willibrordus-neerpelt.sparql
+++ b/config/migrations/2025/20250207040000-remove-3-broken-madates-willibrordus-neerpelt.sparql
@@ -1,0 +1,16 @@
+DELETE {
+  GRAPH ?g {
+    ?eredienstmandataris ?p ?o .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?eredienstmandataris {
+      <http://data.lblod.info/id/mandatarissen/655261E264C1DE6C7E83956F>
+      <http://data.lblod.info/id/mandatarissen/655261A964C1DE6C7E83956E>
+      <http://data.lblod.info/id/mandatarissen/6552621E64C1DE6C7E839572>
+    }
+    ?eredienstmandataris ?p ?o .
+  }
+}
+


### PR DESCRIPTION
**[DL-5662]**

Old issue. Three EredienstMandatarissen pointing to non-existing people and contact points. These can not be edited, nor removed in the frontend, so they are useless.

This removes the three EredienstMandatarissen so that they can be re-added by the organisation, with correct person information this time.