### PR TITLE
Update mandatarissen producer to stop producing what OP produces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Remove submissions export config replaced by op sync [DL-6394]
 - Repair old cross referencing submissions from CKB's. These predate the cross referencing feature. [DL-6415]
 - Add migration that removes three older, broken EredienstMandatarissen pointing to non-existing people and contact points [DL-5662]
+- Update mandatarissen producer to stop producing what OP produces [DL-6210]
 
 ### Deploy instructions
 
@@ -52,6 +53,10 @@ drc logs --tail 1000 -f prepare-submissions-for-export
 **For the report**
 
 - `drc restart report-generation`
+
+**For the updated mandatarissen producer configuration**
+
+- `drc restart migrations-publication-triplestore delta-producer-publication-graph-maintainer`
 
 **For repairing CKB cross referencing submissions**
 

--- a/config/delta-producer/mandatarissen/export.json
+++ b/config/delta-producer/mandatarissen/export.json
@@ -99,9 +99,7 @@
         "http://www.w3.org/2004/02/skos/core#inScheme"
       ],
       "properties": [
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://data.vlaanderen.be/ns/mandaat#aantalHouders",
-        "http://www.w3.org/ns/org#role"
+        "http://data.vlaanderen.be/ns/mandaat#aantalHouders"
       ]
     },
     {
@@ -112,86 +110,6 @@
         "^http://www.w3.org/ns/org#role",
         "^http://www.w3.org/ns/org#hasPost",
         "http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan",
-        "http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://www.w3.org/2004/02/skos/core#inScheme"
-      ],
-      "properties": [
-        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.w3.org/2004/02/skos/core#prefLabel",
-        "http://www.w3.org/2004/02/skos/core#scopeNote"
-      ]
-    },
-    {
-      "type": "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
-      "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
-      "hasRegexGraphsFilter": false,
-      "pathToConceptScheme": [
-        "http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan",
-        "http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://www.w3.org/2004/02/skos/core#inScheme"
-      ],
-      "properties": [
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://data.vlaanderen.be/ns/mandaat#bindingEinde",
-        "http://data.vlaanderen.be/ns/mandaat#bindingStart",
-        "http://www.w3.org/ns/org#hasPost",
-        "http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan"
-      ]
-    },
-    {
-      "type": "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
-      "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
-      "hasRegexGraphsFilter": false,
-      "pathToConceptScheme": [
-        "http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://www.w3.org/2004/02/skos/core#inScheme"
-      ],
-      "properties": [
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.w3.org/2004/02/skos/core#prefLabel",
-        "http://data.vlaanderen.be/ns/besluit#bestuurt",
-        "http://data.vlaanderen.be/ns/besluit#classificatie"
-      ]
-    },
-    {
-      "type": "http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode",
-      "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
-      "hasRegexGraphsFilter": false,
-      "pathToConceptScheme": [
-        "http://www.w3.org/2004/02/skos/core#inScheme"
-      ],
-      "properties": [
-        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.w3.org/2004/02/skos/core#prefLabel",
-        "http://www.w3.org/2004/02/skos/core#scopeNote"
-      ]
-    },
-    {
-      "type": "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
-      "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
-      "hasRegexGraphsFilter": false,
-      "pathToConceptScheme": [
-        "^http://data.vlaanderen.be/ns/besluit#bestuurt",
-        "http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://www.w3.org/2004/02/skos/core#inScheme"
-      ],
-      "properties": [
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.w3.org/2004/02/skos/core#prefLabel",
-        "http://www.w3.org/2004/02/skos/core#altLabel",
-        "http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://data.vlaanderen.be/ns/besluit#werkingsgebied"
-      ]
-    },
-    {
-      "type": "http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode",
-      "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
-      "hasRegexGraphsFilter": false,
-      "pathToConceptScheme": [
-        "^http://data.vlaanderen.be/ns/besluit#classificatie",
-        "^http://data.vlaanderen.be/ns/besluit#bestuurt",
         "http://data.vlaanderen.be/ns/besluit#classificatie",
         "http://www.w3.org/2004/02/skos/core#inScheme"
       ],

--- a/config/migrations-publication-triplestore/2025/20250211095300-flush-mandatarissen-triples-from-op-public.sparql
+++ b/config/migrations-publication-triplestore/2025/20250211095300-flush-mandatarissen-triples-from-op-public.sparql
@@ -1,0 +1,41 @@
+DELETE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-mandatarissen-producer> {
+    ?s ?p ?o .
+  }
+} WHERE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-mandatarissen-producer> {
+    ?s ?p ?o .
+
+    FILTER EXISTS {
+      ?s a ?type .
+
+      VALUES ?type {
+        <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>
+        <http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode>
+        <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>
+        <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>
+      }
+    }
+
+  }
+}
+
+;
+
+# We need to be able to export aantalHouders but when doing so the type is also automatically produced
+# We don't flush it to avoid it being produced after the next healing
+DELETE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-mandatarissen-producer> {
+    ?s ?p ?o .
+  }
+} WHERE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-mandatarissen-producer> {
+    ?s a <http://data.vlaanderen.be/ns/mandaat#Mandaat>;
+      ?p ?o .
+
+    FILTER (?p NOT IN (
+      <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>,
+      <http://data.vlaanderen.be/ns/mandaat#aantalHouders>
+    ))
+  }
+}


### PR DESCRIPTION
:warning: DO NOT MERGE BEFORE ALL KNOWN CONSUMERS HAVE BEEN UPDATED

# Description

**DL-6210**

We are going to add the op-public-consumer to app-mandatendatabank, causing some triples being exported from Loket to MDB to be obsolete. In this PR, we:
1. Remove parts of the configuration of the mandatarissen producer so that the triples coming from OP stop being produced by Loket
2. Remove the same triples from the mandatarissen producer graph. This is to prevent annoying side effects as other applications consume from Loket and OP, for example it prevents having some administrative units being deleted from consuming applications.

# Testing instructions

1. Get a working Loket stack with some data in it. I tried on PROD data, maybe you can try with DEV or QA data, but whatever is the easiest for you
2. Before checkout-ing this branch, run a healing to be sure to be up-to-date on your publication triplestore: `drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/mandatarissen/healing-jobs`
3. Also run a dump `drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/mandatarissen/dump-publication-graph-jobs`
4. Checkout this branch and `drc restart migrations-publication-triplestore delta-producer-publication-graph-maintainer`
5. When the migrations are done running, run again a healing and when the healing is done a dump

Expected result:
- After the healing, no deltas should have been produced about the resources removed from the configuration
- The more recent dump should be substantially smaller and should not contain removed data