### PR TITLE
Fix: cleanup duplicate person

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Remove submissions export config replaced by op sync [DL-6394]
 - Repair old cross referencing submissions from CKB's. These predate the cross referencing feature. [DL-6415]
 - Add migration that removes three older, broken EredienstMandatarissen pointing to non-existing people and contact points [DL-5662]
+- Add migration that cleans up a duplicate person [DL-6378]
 
 ### Deploy instructions
 

--- a/config/migrations/2025/20250211102556-remove-duplicate-person.sparql
+++ b/config/migrations/2025/20250211102556-remove-duplicate-person.sparql
@@ -1,0 +1,31 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+
+# Update the reference of the duplicate person to the correct person
+DELETE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/functionarissen/677CFAAFA0D1558085B90DE6> mandaat:isBestuurlijkeAliasVan <http://data.lblod.info/id/personen/677CFA9FA0D1558085B90DE5> .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    <http://data.lblod.info/id/functionarissen/677CFAAFA0D1558085B90DE6> mandaat:isBestuurlijkeAliasVan <http://data.lblod.info/id/personen/5FCFA65879CE53000800061F> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/functionarissen/677CFAAFA0D1558085B90DE6> mandaat:isBestuurlijkeAliasVan <http://data.lblod.info/id/personen/677CFA9FA0D1558085B90DE5> .
+  }
+}
+;
+
+# Cleanup the duplicate person
+DELETE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/personen/677CFA9FA0D1558085B90DE5> ?p ?o .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/personen/677CFA9FA0D1558085B90DE5> ?p ?o .
+  }
+}

--- a/config/migrations/2025/20250211102556-remove-duplicate-person.sparql
+++ b/config/migrations/2025/20250211102556-remove-duplicate-person.sparql
@@ -1,21 +1,26 @@
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 # Update the reference of the duplicate person to the correct person
 DELETE {
   GRAPH ?g {
-    <http://data.lblod.info/id/functionarissen/677CFAAFA0D1558085B90DE6> mandaat:isBestuurlijkeAliasVan <http://data.lblod.info/id/personen/677CFA9FA0D1558085B90DE5> .
+    <http://data.lblod.info/id/functionarissen/677CFAAFA0D1558085B90DE6> mandaat:isBestuurlijkeAliasVan ?duplicatePerson .
   }
 }
 INSERT {
   GRAPH ?g {
-    <http://data.lblod.info/id/functionarissen/677CFAAFA0D1558085B90DE6> mandaat:isBestuurlijkeAliasVan <http://data.lblod.info/id/personen/5FCFA65879CE53000800061F> .
+    <http://data.lblod.info/id/functionarissen/677CFAAFA0D1558085B90DE6> mandaat:isBestuurlijkeAliasVan ?correctPerson .
   }
 }
 WHERE {
+  BIND(<http://data.lblod.info/id/personen/5FCFA65879CE53000800061F> AS ?correctPerson)
+  BIND(<http://data.lblod.info/id/personen/677CFA9FA0D1558085B90DE5> AS ?duplicatePerson)
+
   GRAPH ?g {
-    <http://data.lblod.info/id/functionarissen/677CFAAFA0D1558085B90DE6> mandaat:isBestuurlijkeAliasVan <http://data.lblod.info/id/personen/677CFA9FA0D1558085B90DE5> .
+    <http://data.lblod.info/id/functionarissen/677CFAAFA0D1558085B90DE6> mandaat:isBestuurlijkeAliasVan ?duplicatePerson .
   }
 }
+
 ;
 
 # Cleanup the duplicate person
@@ -27,5 +32,22 @@ DELETE {
 WHERE {
   GRAPH ?g {
     <http://data.lblod.info/id/personen/677CFA9FA0D1558085B90DE5> ?p ?o .
+  }
+}
+
+;
+
+# Link from duplicatePerson to correctPerson
+INSERT {
+  GRAPH ?g {
+    ?duplicatePerson owl:sameAs ?correctPerson .
+  }
+}
+WHERE {
+  BIND(<http://data.lblod.info/id/personen/5FCFA65879CE53000800061F> AS ?correctPerson)
+  BIND(<http://data.lblod.info/id/personen/677CFA9FA0D1558085B90DE5> AS ?duplicatePerson)
+
+  GRAPH ?g {
+    ?correctPerson ?p ?o .
   }
 }


### PR DESCRIPTION
## ID 
DL-6378

## Description

The person `http://data.lblod.info/id/personen/677CFA9FA0D1558085B90DE5` was a duplicate of `http://data.lblod.info/id/personen/5FCFA65879CE53000800061F`, and has now been consolidated into `http://data.lblod.info/id/personen/5FCFA65879CE53000800061F`

The migration cleans up the reference to the duplicate person, and removes all properties.

Note: data has to be pulled in from prod to test