### PR TITLE
Remove 2 submission Beveren fusie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,15 @@
 - Remove submissions export config replaced by op sync [DL-6394]
 - Repair old cross referencing submissions from CKB's. These predate the cross referencing feature. [DL-6415]
 - Add migration that removes three older, broken EredienstMandatarissen pointing to non-existing people and contact points [DL-5662]
+- Add migration that removes two submissions from Gemeente Beveren that should have been submitted under the new fusie gemeent [DL-6431]
 
 ### Deploy instructions
+
+**New migrations**
+
+```
+drc restart migrations
+```
 
 **For re-exporting submissions**
 

--- a/config/migrations/2025/20250210103100-remove-beveren-submission-for-resubmit-fusie/20250210103100-remove-beveren-submission-for-resubmit-fusie.sparql
+++ b/config/migrations/2025/20250210103100-remove-beveren-submission-for-resubmit-fusie/20250210103100-remove-beveren-submission-for-resubmit-fusie.sparql
@@ -1,0 +1,43 @@
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+DELETE {
+  GRAPH ?g {
+    ?submission ?sp ?so .
+    ?submissionDocument ?sdp ?sdo .
+    ?pFile ?pp ?po .
+    ?formData ?fp ?fo .
+    ?lFile ?lp ?lo .
+    ?pFile2 ?p2p ?p2o .
+  }
+}
+WHERE {
+  BIND (<http://data.lblod.info/submissions/e584c610-c9cc-11ef-8dbd-999796ee841d> as ?submission)
+  GRAPH ?g {
+    {
+      ?submission ?sp ?so .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument ?sdp ?sdo .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument dct:source ?pFile .
+      ?pFile ?pp ?po .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData ?fp ?fo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?lFile ?lp ?lo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?pFile2 nie:dataSource ?lFile .
+      ?pFile2 ?p2p ?p2o .
+    }
+  }
+}

--- a/config/migrations/2025/20250210103100-remove-beveren-submission-for-resubmit-fusie/20250210103101-remove-beveren-submission-for-resubmit-fusie.sparql
+++ b/config/migrations/2025/20250210103100-remove-beveren-submission-for-resubmit-fusie/20250210103101-remove-beveren-submission-for-resubmit-fusie.sparql
@@ -1,0 +1,43 @@
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+DELETE {
+  GRAPH ?g {
+    ?submission ?sp ?so .
+    ?submissionDocument ?sdp ?sdo .
+    ?pFile ?pp ?po .
+    ?formData ?fp ?fo .
+    ?lFile ?lp ?lo .
+    ?pFile2 ?p2p ?p2o .
+  }
+}
+WHERE {
+  BIND (<http://data.lblod.info/submissions/cb7f1ed0-c9c9-11ef-8dbd-999796ee841d> as ?submission)
+  GRAPH ?g {
+    {
+      ?submission ?sp ?so .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument ?sdp ?sdo .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument dct:source ?pFile .
+      ?pFile ?pp ?po .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData ?fp ?fo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?lFile ?lp ?lo .
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData dct:hasPart ?lFile .
+      ?pFile2 nie:dataSource ?lFile .
+      ?pFile2 ?p2p ?p2o .
+    }
+  }
+}


### PR DESCRIPTION
**[DL-6431]**

Migration to remove 2 submissions that were submitted under Gemeente Beveren, but at the time when they should have been submitted in the new fusie-gemeente Beveren-Kruibeke-Zwijndrecht. The vendor will re-submit the submissions.

**To be deployed together with https://github.com/lblod/app-toezicht-abb/pull/51**