### PR TITLE
Feature: show kbo number in dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add migration that removes two submissions from Gemeente Beveren that should have been submitted under the new fusie gemeente [DL-6431]
 - Add migration that cleans up a duplicate person [DL-6378]
 - Update semantic forms with `Opdrachthoudende vereniging met private deelname` classification. [DL-6447]
+- Bump enrich-submission-serivce to show kbo numbers in dropdowns [DL-6416]
 
 ### Deploy instructions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -303,7 +303,7 @@ services:
     restart: always
     logging: *default-logging
   enrich-submission:
-    image: lblod/enrich-submission-service:1.13.2
+    image: lblod/enrich-submission-service:1.13.3
     environment:
       ACTIVE_FORM_FILE: "share://semantic-forms/20250213131736-forms.ttl"
     volumes:


### PR DESCRIPTION
## ID

DL-6416

## Description

Bump the `enrich-submission-service` to  show KBO numbers in two more dropdown concept-schemes.

See https://github.com/lblod/enrich-submission-service/pull/27 

## How to Test

_Centrale besturen and besturen van eredienst_
1. Login as 'Gemeente Deinze' for example
2. Go to toezicht module
3. Choose `Schorsing beslissing eredienstbesturen`
4. Open the `Betreffend (centraal) bestuur van de eredienst`
5. Verify that the dropdown now shows the kbo number for the two `CKB Deinze` options

_Erediensten selector RO (FILTERED):_
1. Login as a Representatief Orgaan, `Representatief orgaan Centraal Comité van de Anglicaanse Kerk` for example
2. Go to toezicht module
3. Create a `Adview budget(wijziging)` dossier
4. Open the `Betreffend bestuur van de eredienst`
5. Verify that the dropdown now shows kbo numbers for the orgs
