### PR TITLE
Prune leidingevenden producer to stop producing what OP produces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ drc logs --tail 1000 -f prepare-submissions-for-export
 
 - `drc restart report-generation`
 
-**For the updated mandatarissen and leidingevenden producer configuration**
+**For the updated mandatarissen and leidinggevenden producer configuration**
 
 - `drc restart migrations-publication-triplestore delta-producer-publication-graph-maintainer`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Repair old cross referencing submissions from CKB's. These predate the cross referencing feature. [DL-6415]
 - Add migration that removes three older, broken EredienstMandatarissen pointing to non-existing people and contact points [DL-5662]
 - Update mandatarissen producer to stop producing what OP produces [DL-6210]
+- Update leidinggevenden producer to stop producing what OP produces [DL-6449]
 
 ### Deploy instructions
 
@@ -54,7 +55,7 @@ drc logs --tail 1000 -f prepare-submissions-for-export
 
 - `drc restart report-generation`
 
-**For the updated mandatarissen producer configuration**
+**For the updated mandatarissen and leidingevenden producer configuration**
 
 - `drc restart migrations-publication-triplestore delta-producer-publication-graph-maintainer`
 

--- a/config/delta-producer/leidinggevenden/export.json
+++ b/config/delta-producer/leidinggevenden/export.json
@@ -21,51 +21,6 @@
   },
   "export": [
     {
-      "type": "http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode",
-      "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
-      "hasRegexGraphsFilter": false,
-      "pathToConceptScheme": [
-        "http://www.w3.org/2004/02/skos/core#inScheme"
-      ],
-      "properties": [
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.w3.org/2004/02/skos/core#prefLabel",
-        "http://www.w3.org/2004/02/skos/core#scopeNote"
-      ]
-    },
-    {
-      "type": "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
-      "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
-      "hasRegexGraphsFilter": false,
-      "pathToConceptScheme": [
-        "http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://www.w3.org/2004/02/skos/core#inScheme"
-      ],
-      "properties": [
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.w3.org/2004/02/skos/core#prefLabel",
-        "http://www.w3.org/2004/02/skos/core#altLabel",
-        "http://data.vlaanderen.be/ns/besluit#werkingsgebied",
-        "http://data.vlaanderen.be/ns/besluit#classificatie"
-      ]
-    },
-    {
-      "type": "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
-      "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
-      "hasRegexGraphsFilter": false,
-      "pathToConceptScheme": [
-        "http://data.vlaanderen.be/ns/besluit#bestuurt",
-        "http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://www.w3.org/2004/02/skos/core#inScheme"
-      ],
-      "properties": [
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.w3.org/2004/02/skos/core#prefLabel",
-        "http://data.vlaanderen.be/ns/besluit#bestuurt",
-        "http://data.vlaanderen.be/ns/besluit#classificatie"
-      ]
-    },
-    {
       "type": "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
       "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
       "hasRegexGraphsFilter": false,
@@ -76,44 +31,7 @@
         "http://www.w3.org/2004/02/skos/core#inScheme"
       ],
       "properties": [
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://data.vlaanderen.be/ns/mandaat#bindingEinde",
-        "http://data.vlaanderen.be/ns/mandaat#bindingStart",
-        "http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan",
         "http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie"
-      ]
-    },
-    {
-      "type": "http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode",
-      "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
-      "hasRegexGraphsFilter": false,
-      "pathToConceptScheme": [
-        "^http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://data.vlaanderen.be/ns/besluit#bestuurt",
-        "http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://www.w3.org/2004/02/skos/core#inScheme"
-      ],
-      "properties": [
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.w3.org/2004/02/skos/core#prefLabel",
-        "http://www.w3.org/2004/02/skos/core#scopeNote"
-      ]
-    },
-    {
-      "type": "http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode",
-      "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
-      "hasRegexGraphsFilter": false,
-      "pathToConceptScheme": [
-        "^http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan",
-        "http://data.vlaanderen.be/ns/besluit#bestuurt",
-        "http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://www.w3.org/2004/02/skos/core#inScheme"
-      ],
-      "properties": [
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.w3.org/2004/02/skos/core#prefLabel",
-        "http://www.w3.org/2004/02/skos/core#scopeNote"
       ]
     },
     {
@@ -179,10 +97,7 @@
         "http://www.w3.org/2004/02/skos/core#inScheme"
       ],
       "properties": [
-        "http://mu.semte.ch/vocabularies/core/uuid",
-        "http://www.w3.org/ns/org#role",
-        "http://schema.org/contactPoint",
-        "http://www.w3.org/2004/02/skos/core#prefLabel"
+        "http://schema.org/contactPoint"
       ]
     },
     {

--- a/config/migrations-publication-triplestore/2025/20250221050000-flush-leidingevenden-triples-in-favour-of-op-public-sync.sparql
+++ b/config/migrations-publication-triplestore/2025/20250221050000-flush-leidingevenden-triples-in-favour-of-op-public-sync.sparql
@@ -13,7 +13,7 @@ WHERE {
       <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>
     }
     ?s
-      rfd:type ?type ;
+      rdf:type ?type ;
       ?p ?o .
   }
 }
@@ -28,7 +28,7 @@ DELETE {
 WHERE {
   GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
     ?s
-      rfd:type <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan> ;
+      rdf:type <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan> ;
       ?p ?o .
 
     FILTER (?p NOT IN (
@@ -48,7 +48,7 @@ DELETE {
 WHERE {
   GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
     ?s
-      rfd:type <http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie> ;
+      rdf:type <http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie> ;
       ?p ?o .
 
     FILTER (?p NOT IN (

--- a/config/migrations-publication-triplestore/2025/20250221050000-flush-leidingevenden-triples-in-favour-of-op-public-sync.sparql
+++ b/config/migrations-publication-triplestore/2025/20250221050000-flush-leidingevenden-triples-in-favour-of-op-public-sync.sparql
@@ -1,0 +1,60 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+DELETE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
+    VALUES ?type {
+      <http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode>
+      <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>
+      <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>
+    }
+    ?s
+      rfd:type ?type ;
+      ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
+    ?s
+      rfd:type <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan> ;
+      ?p ?o .
+
+    FILTER (?p NOT IN (
+      <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ,
+      <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie>
+    ))
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
+    ?s
+      rfd:type <http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie> ;
+      ?p ?o .
+
+    FILTER (?p NOT IN (
+      <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ,
+      <http://schema.org/contactPoint>
+    ))
+  }
+}
+

--- a/config/migrations-publication-triplestore/2025/20250221050000-flush-leidingevenden-triples-in-favour-of-op-public-sync.sparql
+++ b/config/migrations-publication-triplestore/2025/20250221050000-flush-leidingevenden-triples-in-favour-of-op-public-sync.sparql
@@ -20,6 +20,9 @@ WHERE {
 
 ;
 
+# With the new configuration of the producer, we only export Bestuursorganen that have a `isTijdspecialisatieVan`
+# relationship. For those, we need to keep the type. For the others (aka organen NOT in time), we want to flush the type.
+
 DELETE {
   GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
     ?s ?p ?o .
@@ -29,12 +32,29 @@ WHERE {
   GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
     ?s
       rdf:type <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan> ;
+      <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan ;
       ?p ?o .
 
     FILTER (?p NOT IN (
       <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ,
       <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie>
     ))
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  GRAPH <http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer> {
+    ?s
+      rdf:type <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan> ;
+      <http://data.vlaanderen.be/ns/besluit#bestuurt> ?eenheid ;
+      ?p ?o .
   }
 }
 


### PR DESCRIPTION
**[DL-6449]**

See https://github.com/lblod/app-digitaal-loket/pull/638

The notes that would come in this description would be almost identical to the ones in the linked PR above from @claire-lovisa. Please use those notes and apply them to the `app-leidingevenden-databank`.

**NOTE:** I copied what @claire-lovisa did in their PR, but applied those changes to leidinggevenden.

**NOTE:** I found some predicates that seem to be added in Loket on the `Bestuursorgaan` and `Bestuursfunctie`. See the migration on the publication triplestore, where I attempt to keep them. I assume these are important.

**TODO:** I would like to still run a test, such as in the aforementioned PR to see if all runs well.