### PR TITLE
Hotfix/less performance heavy submissions delta stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## 1.108.2 (2025-02-26)
+- Fix performance issue (too large strings) for healing of submission.
+  - see also: `https://github.com/lblod/delta-producer-publication-graph-maintainer/pull/37`
+    - DL-6469
+### deploy notes
+```
+drc up -d  delta-producer-publication-graph-maintainer
+```
 ## 1.108.1 (2025-02-04)
 - Bump vendor-data-distribution
 ### Deploy instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 1.108.3 (2025-02-26)
+- updated the configuration of worship-submissions.
+  See DL-6469
+### deploy notes
+```
+drc up restart delta-producer-publication-graph-maintainer
+```
 ## 1.108.2 (2025-02-26)
 - Fix performance issue (too large strings) for healing of submission.
   - see also: `https://github.com/lblod/delta-producer-publication-graph-maintainer/pull/37`

--- a/config/delta-producer/submissions/export.json
+++ b/config/delta-producer/submissions/export.json
@@ -159,7 +159,42 @@
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url"
       ],
-      "additionalFilter": "?subject <http://schema.org/publication> <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325>."
+      "additionalFilter": "?subject <http://schema.org/publication> <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325>.",
+      "healingOptions": {
+         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+           "queryChunkSize": 500000
+         },
+         "http://mu.semte.ch/vocabularies/core/uuid": {
+           "queryChunkSize": 500000
+         },
+         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName": {
+           "queryChunkSize": 500000
+         },
+         "http://purl.org/dc/terms/format": {
+           "queryChunkSize": 500000
+         },
+         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize": {
+           "queryChunkSize": 500000
+         },
+         "http://dbpedia.org/ontology/fileExtension": {
+           "queryChunkSize": 500000
+         },
+         "http://purl.org/dc/terms/created": {
+           "queryChunkSize": 500000
+         },
+         "http://purl.org/dc/terms/modified": {
+           "queryChunkSize": 500000
+         },
+         "http://purl.org/dc/terms/type": {
+           "queryChunkSize": 500000
+         },
+         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource": {
+           "queryChunkSize": 500000
+         },
+         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url": {
+           "queryChunkSize": 500000
+         }
+       }
     },
     {
       "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject",
@@ -177,7 +212,45 @@
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
         "http://www.w3.org/ns/adms#status"
       ],
-      "additionalFilter": "?subject <http://schema.org/publication> <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325>."
+      "additionalFilter": "?subject <http://schema.org/publication> <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325>.",
+      "healingOptions": {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+          "queryChunkSize": 500000
+        },
+        "http://mu.semte.ch/vocabularies/core/uuid": {
+          "queryChunkSize": 500000
+        },
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url": {
+          "queryChunkSize": 500000
+        },
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName": {
+          "queryChunkSize": 500000
+        },
+        "http://purl.org/dc/terms/format": {
+          "queryChunkSize": 500000
+        },
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize": {
+          "queryChunkSize": 500000
+        },
+        "http://dbpedia.org/ontology/fileExtension": {
+          "queryChunkSize": 500000
+        },
+        "http://purl.org/dc/terms/created": {
+          "queryChunkSize": 500000
+        },
+        "http://purl.org/dc/terms/modified": {
+          "queryChunkSize": 500000
+        },
+        "http://purl.org/dc/terms/type": {
+          "queryChunkSize": 500000
+        },
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource": {
+          "queryChunkSize": 500000
+        },
+        "http://www.w3.org/ns/adms#status": {
+          "queryChunkSize": 500000
+        }
+      }
     }
   ]
 }

--- a/config/delta-producer/worship-submissions/export.json
+++ b/config/delta-producer/worship-submissions/export.json
@@ -118,7 +118,42 @@
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url"
       ],
-      "additionalFilter": "?subject <http://schema.org/publication> <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1>."
+      "additionalFilter": "?subject <http://schema.org/publication> <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1>.",
+      "healingOptions": {
+         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+           "queryChunkSize": 500000
+         },
+         "http://mu.semte.ch/vocabularies/core/uuid": {
+           "queryChunkSize": 500000
+         },
+         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName": {
+           "queryChunkSize": 500000
+         },
+         "http://purl.org/dc/terms/format": {
+           "queryChunkSize": 500000
+         },
+         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize": {
+           "queryChunkSize": 500000
+         },
+         "http://dbpedia.org/ontology/fileExtension": {
+           "queryChunkSize": 500000
+         },
+         "http://purl.org/dc/terms/created": {
+           "queryChunkSize": 500000
+         },
+         "http://purl.org/dc/terms/modified": {
+           "queryChunkSize": 500000
+         },
+         "http://purl.org/dc/terms/type": {
+           "queryChunkSize": 500000
+         },
+         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource": {
+           "queryChunkSize": 500000
+         },
+         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url": {
+           "queryChunkSize": 500000
+         }
+      }
     },
     {
       "type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject",
@@ -136,7 +171,45 @@
         "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
         "http://www.w3.org/ns/adms#status"
       ],
-      "additionalFilter": "?subject <http://schema.org/publication> <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1>."
+      "additionalFilter": "?subject <http://schema.org/publication> <http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1>.",
+      "healingOptions": {
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+          "queryChunkSize": 500000
+        },
+        "http://mu.semte.ch/vocabularies/core/uuid": {
+          "queryChunkSize": 500000
+        },
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url": {
+          "queryChunkSize": 500000
+        },
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName": {
+          "queryChunkSize": 500000
+        },
+        "http://purl.org/dc/terms/format": {
+          "queryChunkSize": 500000
+        },
+        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize": {
+          "queryChunkSize": 500000
+        },
+        "http://dbpedia.org/ontology/fileExtension": {
+          "queryChunkSize": 500000
+        },
+        "http://purl.org/dc/terms/created": {
+          "queryChunkSize": 500000
+        },
+        "http://purl.org/dc/terms/modified": {
+          "queryChunkSize": 500000
+        },
+        "http://purl.org/dc/terms/type": {
+          "queryChunkSize": 500000
+        },
+        "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource": {
+          "queryChunkSize": 500000
+        },
+        "http://www.w3.org/ns/adms#status": {
+          "queryChunkSize": 500000
+        }
+      }
     }
   ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -539,7 +539,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-publication-graph-maintainer:
-    image: lblod/delta-producer-publication-graph-maintainer:1.2.2
+    image: lblod/delta-producer-publication-graph-maintainer:1.4.0
     environment:
       MAX_BODY_SIZE: "50mb"
       PRETTY_PRINT_DIFF_JSON: "true"


### PR DESCRIPTION
Fixes an issue with submissions-delta-stream: the returned response was getting too big for node to handle.
See: https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/502/files
