### PR TITLE
Cleanup old session data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Update semantic forms with `Opdrachthoudende vereniging met private deelname` classification. [DL-6447]
 - Bump enrich-submission-serivce to show kbo numbers in dropdowns [DL-6416]
 - Add migration that removes mock-logins (impersonation) for certain fusiegemeenten and their OCMWs, for mock-login repair [DL-6375]
+- Delete user login sessions older than a month. [DL-6467]
 
 ### Deploy instructions
 
@@ -79,6 +80,17 @@ drc logs --tail 1000 -f prepare-submissions-for-export
 **For repairing mock-logins (and impersonation)**
 
 - `drc exec update-bestuurseenheid-mock-login curl -X POST http://localhost/heal-mock-logins`
+
+**For adding the new cleanup job**
+
+```shell
+drc restart migrations && drc logs -ft --tail=200 migrations
+```
+
+Make sure `dbcleanup` is not currently executing a job:
+```shell
+drc stop dbcleanup && drc up -d dbcleanup && drc logs -ft --tail=200 dbcleanup
+```
 
 ## 1.108.2 (2025-02-24)
 ### General

--- a/config/migrations/2025/cleanup-jobs/old-session-data/20250225175844-add-old-session-data-cleanup-job.sparql
+++ b/config/migrations/2025/cleanup-jobs/old-session-data/20250225175844-add-old-session-data-cleanup-job.sparql
@@ -1,0 +1,18 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/sessions> {
+    ?session ?sessionP ?sessionO .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/sessions> {
+  ?session <http://mu.semte.ch/vocabularies/ext/sessionGroup> ?organization ;
+    <http://mu.semte.ch/vocabularies/ext/sessionRole> ?sessionRole ;
+    <http://purl.org/dc/terms/modified> ?modified ;
+    ?sessionP ?sessionO .
+  }
+
+  BIND(xsd:dateTime(REPLACE(STR(?modified), "Z", "")) AS ?date)
+  BIND(xsd:date(NOW() - "P1Y"^^xsd:duration) AS ?lastYear)
+
+  FILTER(xsd:date(?date) <= ?lastYear)
+}

--- a/config/migrations/2025/cleanup-jobs/old-session-data/20250225175845-add-old-session-data-cleanup-job.sparql
+++ b/config/migrations/2025/cleanup-jobs/old-session-data/20250225175845-add-old-session-data-cleanup-job.sparql
@@ -1,0 +1,18 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/sessions> {
+    ?session ?sessionP ?sessionO .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/sessions> {
+  ?session <http://mu.semte.ch/vocabularies/ext/sessionGroup> ?organization ;
+    <http://mu.semte.ch/vocabularies/ext/sessionRole> ?sessionRole ;
+    <http://purl.org/dc/terms/modified> ?modified ;
+    ?sessionP ?sessionO .
+  }
+
+  BIND(xsd:dateTime(REPLACE(STR(?modified), "Z", "")) AS ?date)
+  BIND(xsd:date(NOW() - "P6M"^^xsd:duration) AS ?sixMonthsAgo)
+
+  FILTER(xsd:date(?date) <= ?sixMonthsAgo)
+}

--- a/config/migrations/2025/cleanup-jobs/old-session-data/20250225175846-add-old-session-data-cleanup-job.sparql
+++ b/config/migrations/2025/cleanup-jobs/old-session-data/20250225175846-add-old-session-data-cleanup-job.sparql
@@ -1,0 +1,18 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/sessions> {
+    ?session ?sessionP ?sessionO .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/sessions> {
+  ?session <http://mu.semte.ch/vocabularies/ext/sessionGroup> ?organization ;
+    <http://mu.semte.ch/vocabularies/ext/sessionRole> ?sessionRole ;
+    <http://purl.org/dc/terms/modified> ?modified ;
+    ?sessionP ?sessionO .
+  }
+
+  BIND(xsd:dateTime(REPLACE(STR(?modified), "Z", "")) AS ?date)
+  BIND(xsd:date(NOW() - "P1M"^^xsd:duration) AS ?lastMonth)
+
+  FILTER(xsd:date(?date) <= ?lastMonth)
+}

--- a/config/migrations/2025/cleanup-jobs/old-session-data/20250225175846-add-old-session-data-cleanup-job/20250225180011-add-old-session-data-cleanup-job.graph
+++ b/config/migrations/2025/cleanup-jobs/old-session-data/20250225175846-add-old-session-data-cleanup-job/20250225180011-add-old-session-data-cleanup-job.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2025/cleanup-jobs/old-session-data/20250225175846-add-old-session-data-cleanup-job/20250225180011-add-old-session-data-cleanup-job.ttl
+++ b/config/migrations/2025/cleanup-jobs/old-session-data/20250225175846-add-old-session-data-cleanup-job/20250225180011-add-old-session-data-cleanup-job.ttl
@@ -1,0 +1,28 @@
+@prefix cleanup:  <http://mu.semte.ch/vocabularies/ext/cleanup/> .
+@prefix mu:       <http://mu.semte.ch/vocabularies/core/> .
+@prefix dcterms:  <http://purl.org/dc/terms/> .
+
+<http://data.lblod.info/id/cleanup-job/f294e44b-e322-437c-9832-8440cbd18b0e> a cleanup:Job ;
+  mu:uuid "f294e44b-e322-437c-9832-8440cbd18b0e" ;
+  dcterms:title "Cleanup user sessions older than a month" ;
+  cleanup:randomQuery """
+    DELETE {
+      GRAPH <http://mu.semte.ch/graphs/sessions> {
+        ?session ?sessionP ?sessionO .
+      }
+    }
+    WHERE {
+      GRAPH <http://mu.semte.ch/graphs/sessions> {
+        ?session <http://mu.semte.ch/vocabularies/ext/sessionGroup> ?organization ;
+          <http://mu.semte.ch/vocabularies/ext/sessionRole> ?sessionRole ;
+          <http://purl.org/dc/terms/modified> ?modified ;
+          ?sessionP ?sessionO .
+      }
+
+      BIND(xsd:dateTime(REPLACE(STR(?modified), "Z", "")) AS ?date)
+      BIND(xsd:date(NOW() - "P1M"^^xsd:duration) AS ?lastMonth)
+
+      FILTER(xsd:date(?date) <= ?lastMonth)
+    }
+  """ ;
+  cleanup:cronPattern "0 22 * * 5" . # Every Friday at 22:00 UTC


### PR DESCRIPTION
## Ticket ID

DL-6467

## Ticket Description

Remove user sessions older than a month. This helps keep session data sanitized and prevents long-lasting sessions.

## How to test

TODO