### PR TITLE
Add missing docker compose keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@
 - Update mandatarissen producer to stop producing what OP produces [DL-6210]
 - Update leidinggevenden producer to stop producing what OP produces [DL-6449]
 - Bump deliver-bbcdr [DL-6481]
+- Add missing `labels` key for some services. [DL-6490]
 
 ### Deploy instructions
 
-**General
+**General**
 
 Ensure on production, the line `image: lblod/deliver-bbcdr-rapporten-service:0.4.0-rc.1` in `docker-compose.override.yml` is removed.
 
@@ -23,7 +24,11 @@ Ensure on production, the line `image: lblod/deliver-bbcdr-rapporten-service:0.4
 
 - `drc restart migrations-publication-triplestore delta-producer-publication-graph-maintainer`
 
+**For adding the missing docker compose keys**
 
+```
+drc up -d impersonation virus-scanner vendor-login sparql-authorization-wrapper vendor-data-distribution berichtencentrum-melding delta-files-share mocklogin
+```
 
 ## 1.109.0 (2025-02-27)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,8 @@ services:
     logging: *default-logging
   impersonation:
     image: lblod/impersonation-service:0.2.0
+    labels:
+      - "logging=true"
     restart: always
     logging: *default-logging
   validation:
@@ -168,6 +170,8 @@ services:
       - ./data/files:/share
       # TODO: is this required? We'd like to avoid docker-volumes
       # - ./data/files/virus-scanner-signatures:/var/lib/clamav
+    labels:
+      - "logging=true"
     restart: always
     logging: *default-logging
   create-bbcdr:
@@ -462,12 +466,16 @@ services:
   ##############################################################################
   vendor-login:
     image: lblod/vendor-login-service:1.0.0
+    labels:
+      - "logging=true"
     restart: always
     logging: *default-logging
   sparql-authorization-wrapper:
     image: lblod/sparql-authorization-wrapper-service:1.0.0
     volumes:
       - ./config/sparql-authorization-wrapper:/config
+    labels:
+      - "logging=true"
     restart: always
     logging: *default-logging
   vendor-data-distribution:
@@ -482,12 +490,16 @@ services:
       SPARQL_ENDPOINT_HEALING_OPERATIONS: "http://virtuoso:8890/sparql"
     volumes:
       - ./config/vendor-data:/config
+    labels:
+      - "logging=true"
     restart: always
     logging: *default-logging
   berichtencentrum-melding:
     image: lblod/berichten-melding-service:1.0.2
     volumes:
       - ./data/files:/share
+    labels:
+      - "logging=true"
     restart: always
     logging: *default-logging
   ################################################################################
@@ -537,6 +549,8 @@ services:
     environment:
       ALLOW_SUPER_CONSUMER: "true"
       ALLOWED_ACCOUNTS: "http://services.lblod.info/diff-consumer/account,http://data.lblod.info/foaf/account/id/dd85f516-ee7c-406b-8245-91ce7f9545b7,http://data.lblod.info/foaf/account/id/4171b7a5-a4d6-42d0-bf37-f97b135fb885"
+    labels:
+      - "logging=true"
     restart: always
     logging: *default-logging
   ################################################################################


### PR DESCRIPTION
## Ticket ID

DL-6490

## Ticket Description

Some services were missing the `labels` key that allows `app-http-logger` to log in- and out-going traffic to those services.