### PR TITLE
Opt out of VDDS deltas for `resource` and `toezicht-flattened`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Update leidinggevenden producer to stop producing what OP produces [DL-6449]
 - Bump deliver-bbcdr [DL-6481]
 - Add missing `labels` key for some services. [DL-6490]
+- Opt out of VDDS deltas for `resource` and `toezicht-flattened-form-data-generator`.
 
 ### Deploy instructions
 
@@ -21,6 +22,12 @@ Ensure on production, the line `image: lblod/deliver-bbcdr-rapporten-service:0.4
 ```
 drc up -d op-public-consumers
 drc restart migrations-publication-triplestore delta-producer-publication-graph-maintainer migrations
+```
+
+**For the opt out of VDDS deltas**
+
+```
+drc restart deltanotifier
 ```
 
 ## 1.109.0 (2025-02-27)

--- a/config/delta/resource.js
+++ b/config/delta/resource.js
@@ -11,7 +11,10 @@ export default [
       resourceFormat: 'v0.0.1',
       gracePeriod: 250,
       ignoreFromSelf: true,
-      optOutMuScopeIds: [ "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync" ]
+      optOutMuScopeIds: [ 
+        "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
+        "http://redpencil.data.gift/id/concept/muScope/deltas/vendor-data"
+      ]
     }
   }
 ];

--- a/config/delta/toezicht-flattened-form-data-generator.js
+++ b/config/delta/toezicht-flattened-form-data-generator.js
@@ -20,7 +20,8 @@ export default [
       ignoreFromSelf: true,
       optOutMuScopeIds: [
                           "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
-                          "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
+                          "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance",
+                          "http://redpencil.data.gift/id/concept/muScope/deltas/vendor-data"
       ]
     }
   },

--- a/config/delta/toezicht-flattened-form-data-generator.js
+++ b/config/delta/toezicht-flattened-form-data-generator.js
@@ -45,7 +45,8 @@ export default [
       ignoreFromSelf: true,
       optOutMuScopeIds: [
                           "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
-                          "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
+                          "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance",
+                          "http://redpencil.data.gift/id/concept/muScope/deltas/vendor-data"
       ]
     }
   },


### PR DESCRIPTION
## Description

The PR adds an VDDS deltas opt outs for `resource` and `toezicht-flattened-form-data-generator`.

* **resource**: This tracks what we already do for `app-worship-decisions-database`. There's no need for `resource` to be aware of VDDS deltas.
* **toezicht-flattened-form-data-generator**: This was part of [this commit for `app-meldingsplichtige-api`](https://github.com/lblod/app-meldingsplichtige-api/commit/d89cf5e6467b1c4a4dcccd162cba8a3199bc8f33). VDDS for Loket matches on `http://www.w3.org/ns/adms#status` and may insert documents that have a `adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c>` that match the `toezicht-flattened` delta rules => `toezicht-flattened` will then receive a delta match which will re-trigger a flattening on that submission (which may have already occurred in the past).