### PR TITLE
Add next rapportperiode Meerjarenplan(aanpassing) worship services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### General
 
 - Added new form 'melding interne beslissing tot samenvoeging' [DL-6361]
+- Added next rapportperiode for Meerjarenplan(aanpassing) [DL-6597]
 
 ### Deploy instructions
 

--- a/config/migrations/2025/20250429143000-add-next-bestuursperiode-meerjarenplan-aanpassing.sparql
+++ b/config/migrations/2025/20250429143000-add-next-bestuursperiode-meerjarenplan-aanpassing.sparql
@@ -1,0 +1,18 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX m8g: <http://data.europa.eu/m8g/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.gift/concepts/2bbfee8-0a29-4b5c-b647-c27ccca9f8de>
+      rdf:type
+        skos:Concept ,
+        m8g:PeriodOfTime ;
+      skos:inScheme <http://lblod.data.gift/concept-schemes/4e719768-d43b-4ca1-ab92-b463e15721f5> ;
+      skos:prefLabel "2026-2031" ;
+      skos:topConceptOf <http://lblod.data.gift/concept-schemes/4e719768-d43b-4ca1-ab92-b463e15721f5> ;
+      m8g:startTime "2025-12-31T22:59:59Z"^^xsd:dateTime ; # To account for CET -> start of 2026
+      m8g:endTime "2031-12-31T22:59:59Z"^^xsd:dateTime .
+  }
+}


### PR DESCRIPTION
**[DL-6597]**

Adds the next "Rapportperiode" (2026-2031) for worship services in the Meerjarenplan(aanpassing) form in Toezicht.

**To test:**

* Let the new migration run.
* Pick a worship service (kerkfabriek, ...) to (mock) login with. Go to the Toezicht module, and create a new submission.
* Choose "Meerjarenplan(aanpassing)" and select a "beslissingsorgaan".
* You should be able to select the new Rapportperiode 2026-2031 in the next dropdown.

![image](https://github.com/user-attachments/assets/bc6fc6b2-0c06-48e5-b27f-2ed309a19cc7)
