### PR TITLE
Improve the dashboard setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added next rapportperiode for Meerjarenplan(aanpassing) [DL-6597]
 - Bump dashboard frontend to `v1.8.0`. [DL-6588]
   - This includes the ACM and impersonation changes.
+- Improve the dashboard setup
 
 ### Deploy instructions
 
@@ -16,13 +17,19 @@ drc restart migrations && drc logs -ft --tail=200 migrations
 drc up -d enrich-submission berichtencentrum-sync-with-kalliope prepare-submissions-for-export
 ```
 
-**For bumping the dashboard**
+**For bumping and improving the dashboard setup**
 
 When deploying on QA and PROD (DEV does not have an ACM login flow), follow the ACM setup for the Loket frontend image listed in `docker-compose.override.yml`.
 
 ```
+drc restart dispatcher
+```
+
+```
 drc up -d dashboard
 ```
+
+> NOTE: For now, the `dashboard` virtual host configuration has been moved to `identifier` in `docker-compose.override.yml` for the dashboard to function correctly. This is because the frontend and dashboard base images are different, but [DL-6629](https://binnenland.atlassian.net/browse/DL-6629) should bring things back to normal.
 
 ## 1.111.0 (2025-04-25)
 

--- a/README.md
+++ b/README.md
@@ -328,3 +328,13 @@ This service is configured through a custom [subjectsAndPaths.js](https://github
 ##### Healing Process
 
 The healing process allows the service to "manually" copy data to vendor graphs by the following the same rules defined in `subjectsAndPaths.js`. Trigger a `POST` request to the `/healing` endpoint of the service to start the healing.
+
+## Dashboard
+
+Starting from `v1.7.0`, the dashboard uses a different base image than the Loket frontend. This means that simply mapping ports in `docker-compose.override` to use the dashboard locally will not work anymore. A workaround for now is to have `identifier` be the first point of entry and run `dashboard.localhost:90`:
+* `90` is the mapped port for `identifier` in `docker-compose.override.yml`.
+* For `dashboard.localhost`, there's no need to update anything in `/etc/hosts`. `Docker Compose` seems to set up the necessary proxy functionality for this to work out of the box.
+
+### For DEV and QA Setups
+
+With the dashboard and frontend having different base images, the `dashboard` virtual host config is moved to `identifier` for the time being so that the dashboard can start. As mentioned above, the reason is so that `identifier` becomes the first point of entry for the dashboard.

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -658,6 +658,20 @@ defmodule Dispatcher do
     forward conn, path, "http://resource/remote-data-objects/"
   end
 
+  get "/assets/*path",  %{ reverse_host: ["dashboard" | _rest] }  do
+    forward conn, path, "http://dashboard/assets/"
+  end
+
+  get "/@appuniversum/*path", %{ reverse_host: ["dashboard" | _rest] } do
+    forward conn, path, "http://dashboard/@appuniversum/"
+  end
+
+  match "/*_path", %{ reverse_host: ["dashboard" | _rest] } do
+    # *_path allows a path to be supplied, but will not yield
+    # an error that we don't use the path variable.
+    forward conn, [], "http://dashboard/index.html"
+  end
+
   #################################################################
   # Other
   #################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     image: lblod/frontend-dashboard:1.8.0
     environment:
       EMBER_LOGIN_ROUTE: "mock-login"
+      EMBER_ADMIN_ROLE: "LoketLB-admin"
     labels:
       - "logging=true"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ services:
     image: lblod/frontend-dashboard:1.8.0
     environment:
       EMBER_LOGIN_ROUTE: "mock-login"
-    links:
-      - identifier:backend
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
The dashboard frontend uses the static-file-service as a base image which needs to be integrated in a different way.