### PR TITLE
remove option from codelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bump dashboard frontend to `v1.8.0`. [DL-6588]
   - This includes the ACM and impersonation changes.
 - Improve the dashboard setup
+- Remove option from codelist [DL-6613]
 
 ### Deploy instructions
 

--- a/config/migrations/2025/20250610141514-remove-from-codelist.sparql
+++ b/config/migrations/2025/20250610141514-remove-from-codelist.sparql
@@ -1,0 +1,9 @@
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.gift/concepts/f6084275-751d-4bf7-a744-904247571f64> a <http://www.w3.org/2004/02/skos/core#Concept>.
+    <http://lblod.data.gift/concepts/f6084275-751d-4bf7-a744-904247571f64> <http://mu.semte.ch/vocabularies/core/uuid> "f6084275-751d-4bf7-a744-904247571f64".
+    <http://lblod.data.gift/concepts/f6084275-751d-4bf7-a744-904247571f64> <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/0b93ef1c-4435-4922-8611-31b4f3ca3c85>.
+    <http://lblod.data.gift/concepts/f6084275-751d-4bf7-a744-904247571f64> <http://www.w3.org/2004/02/skos/core#prefLabel> "Correctie - tekst of cijfers zijn verkeerd"@nl.
+    <http://lblod.data.gift/concepts/f6084275-751d-4bf7-a744-904247571f64> <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/0b93ef1c-4435-4922-8611-31b4f3ca3c85> .
+  }
+}


### PR DESCRIPTION
## ID

DL-6613

## Description

Remove the 'correctie' option from the codelist used in 'LEKP-rapport - Toelichting Lokaal Bestuur'

~~Note: after approval I'll update the following repositories as well https://github.com/search?q=org%3Alblod+%22Correctie+-+tekst+of+cijfers+zijn+verkeerd%22&type=code~~

## How to test

1. Go to toezicht and create a 'LEKP-rapport - Toelichting Lokaal Bestuur' instance
2. Verify that the 'Correctie - tekst of cijfers zijn verkeerd' option is no longer present