### PR TITLE
Bump email berichtencentrum-notification [DL-6471]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### General
-
+- Bump berichtencentrum-email-notification-service [DL-6471](https://binnenland.atlassian.net/browse/DL-6471)
 - Re-enable mocklogin rules for use in DEV and QA environments. Although not
   needed in PROD and removed because of safety concerns, they were needed in
   DEV and QA. In PROD, there will be no service to respond to the requests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -234,7 +234,7 @@ services:
     restart: always
     logging: *default-logging
   berichtencentrum-email-notification:
-    image: lblod/berichtencentrum-email-notification-service:0.4.1
+    image: lblod/berichtencentrum-email-notification-service:0.5.2
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
For context https://binnenland.atlassian.net/browse/DL-6471
This PR updates berichtencentrum-notification to include new emails to be sent out.

# Testing
Given the high integration with bunch of external systems, we'd suggest to use a deployed environment and test end 2 end by the testing team.