### PR TITLE
Remove the pathToConceptScheme for beleidsdomein.

### DIFF
--- a/config/delta-producer/mandatarissen/export.json
+++ b/config/delta-producer/mandatarissen/export.json
@@ -5,14 +5,6 @@
       "type": "http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode",
       "graphsFilter": [ "http://mu.semte.ch/graphs/lmb/mandaten/public" ],
       "hasRegexGraphsFilter": false,
-      "pathToConceptScheme": [
-        "^http://data.vlaanderen.be/ns/mandaat#beleidsdomein",
-        "http://www.w3.org/ns/org#holds",
-        "^http://www.w3.org/ns/org#hasPost",
-        "http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan",
-        "http://data.vlaanderen.be/ns/besluit#classificatie",
-        "http://www.w3.org/2004/02/skos/core#inScheme"
-      ],
       "properties": [
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
         "http://mu.semte.ch/vocabularies/core/uuid",


### PR DESCRIPTION
This isn't required anymore, as this data is fully managed by LMB.