### PR TITLE
DL-7272-DL-7260: added migration to remove empty submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
  - IPDC-enrich service: added datePublished to filter in the overview table [DL-7224]
  - Bump frontend to v1.7.1 [DL-7255]
  - Bumped `vendor-data-distribution-service` and rewrote the config [DL-7231]
+ - Removed empty submissions [DL-7260] [DL-7272]
 
 ## Deploy notes
 ### Deployement prelude (all environments)

--- a/config/migrations/2026/20260331142919-cleanup-empty-submissions.sparql
+++ b/config/migrations/2026/20260331142919-cleanup-empty-submissions.sparql
@@ -1,0 +1,38 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+DELETE {
+  GRAPH ?g {
+    ?submission ?sp ?so .
+    ?submissionDocument ?sdp ?sdo .
+    ?pFile ?pp ?po .
+    ?formData ?fp ?fo .
+  }
+}
+WHERE {
+  VALUES ?submission {
+    <http://data.lblod.info/submissions/69BBE08C5324D71F255A7AFA>
+    <http://data.lblod.info/submissions/69BAD4C15324D71F255A7A73>
+    <http://data.lblod.info/submissions/69BBEA4B5324D71F255A7B01>
+    <http://data.lblod.info/submissions/69BC099B5324D71F255A7B33>
+  }
+
+  GRAPH ?g {
+    {
+      ?submission ?sp ?so .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument ?sdp ?sdo .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument dct:source ?pFile .
+      ?pFile ?pp ?po .
+      FILTER NOT EXISTS {
+        ?pFile dct:type <http://data.lblod.gift/concepts/form-file-type> .
+      }
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData ?fp ?fo .
+    }
+  }
+}


### PR DESCRIPTION
- Added a migration that removes the data from the empty submissions mentioned in the tickets.