### PR TITLE
[DL-7222]: Add end date to LEKP forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  - Bumped `vendor-data-distribution-service` and rewrote the config [DL-7231]
  - Clean up Decision Types to remove duplicates from report 'Toezicht module: Meldingen' [DL-7258]
  - Changed scope for Concept and ConceptScheme in `uuid-generation-service` & removed generated uuid for representative organ [DL-7289]
+ - Removed LEKP-forms from dropdown in Toezicht (from 01/05/2026) [DL-7222]
 
 ## Deploy notes
 ### Deployement prelude (all environments)

--- a/config/migrations/2026/20260413113044-update-end-dates-lekp.sparql
+++ b/config/migrations/2026/20260413113044-update-end-dates-lekp.sparql
@@ -1,0 +1,19 @@
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        ?rule <http://schema.org/validThrough> "2026-05-01T01:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+    }
+}
+WHERE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        VALUES ?rule {
+            <http://data.lblod.info/id/notification-rule/e7cc67b7-8977-49c9-bed9-f758a7c10f51>
+            <http://data.lblod.info/id/notification-rule/c9cdb5d9-9921-4811-8a37-d4cf65bd3178>
+            <http://data.lblod.info/id/notification-rule/7f91d1be-2725-43c2-8e7b-7b3f4af176fc>
+            <http://data.lblod.info/id/notification-rule/4e6fdd0e-2aee-4939-aaaa-ef6d1e055e27>
+            <http://data.lblod.info/id/notification-rule/1ee16f4f-ce45-4938-9b7a-7d511b52ab12>
+            <http://data.lblod.info/id/notification-rule/ae755652-6172-436e-9429-c95939e8521c>
+            <http://data.lblod.info/id/notification-rule/066edf24-d71e-41a4-9b94-86b9fb363623>
+        }
+        ?rule a <http://lblod.data.gift/vocabularies/notification/NotificationRule> .
+    }
+}

--- a/config/migrations/2026/20260413113044-update-end-dates-lekp.sparql
+++ b/config/migrations/2026/20260413113044-update-end-dates-lekp.sparql
@@ -7,11 +7,17 @@ WHERE {
     GRAPH <http://mu.semte.ch/graphs/public> {
         VALUES ?rule {
             <http://data.lblod.info/id/notification-rule/e7cc67b7-8977-49c9-bed9-f758a7c10f51>
+            <http://data.lblod.info/id/notification-rule/5d5a7e8e-252a-414d-b43e-92e9a45aeb90>
             <http://data.lblod.info/id/notification-rule/c9cdb5d9-9921-4811-8a37-d4cf65bd3178>
+            <http://data.lblod.info/id/notification-rule/f9e14748-5e87-4e95-82cb-585f9b5d2b16>
             <http://data.lblod.info/id/notification-rule/7f91d1be-2725-43c2-8e7b-7b3f4af176fc>
+            <http://data.lblod.info/id/notification-rule/44c563f6-c817-43e5-8369-1e0c202dd047>
             <http://data.lblod.info/id/notification-rule/4e6fdd0e-2aee-4939-aaaa-ef6d1e055e27>
+            <http://data.lblod.info/id/notification-rule/b2647f63-7308-4854-9b72-f60ae34873d2>
             <http://data.lblod.info/id/notification-rule/1ee16f4f-ce45-4938-9b7a-7d511b52ab12>
+            <http://data.lblod.info/id/notification-rule/8a1107ba-e91c-430f-a925-7f1e04a873e5>
             <http://data.lblod.info/id/notification-rule/ae755652-6172-436e-9429-c95939e8521c>
+            <http://data.lblod.info/id/notification-rule/1df30ddc-8e4c-4966-837d-a317e418e5b7>
             <http://data.lblod.info/id/notification-rule/066edf24-d71e-41a4-9b94-86b9fb363623>
         }
         ?rule a <http://lblod.data.gift/vocabularies/notification/NotificationRule> .


### PR DESCRIPTION
LEKP forms should no longer be available as an option in the drop down list to create a new submission in Loket Toezicht starting 1 May 2026, so we give their notification rules an end date.