### PR TITLE
[DL-7227] Conditionally redirect to the external login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,21 @@
 - Export gemeenteweg Decision Types and bump `prepare-submissions-for-export-service` [DL-7179]
 - Bump berichtencentrum-sync-with-kalliope to `v0.23.2` [DL-7253]
 - Bump frontend-loket [473](https://github.com/lblod/frontend-loket/pull/473)
+- Conditionally redirect to the external login page [DL-7361]
 
 ## Deploy notes
+### Production
+Add the following environment variable to the docker-compose.override.yml file:
+
+```yml
+  dispatcher:
+    environment:
+      LOGIN_PAGE_REDIRECT_URL: "https://vlaanderen.be/loket-lokale-besturen"
 ```
-drc up -d prepare-submissions-for-export loket
+
+### All environments
+```
+drc up -d prepare-submissions-for-export loket dispatcher
 drc restart migrations
 drc logs --tail 200 -f migrations # ensure it finishes. it can take a few minutes
 drc pull berichtencentrum-sync-with-kalliope && drc up -d berichtencentrum-sync-with-kalliope

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -767,6 +767,17 @@ defmodule Dispatcher do
     forward conn, path, "http://loket/@appuniversum/"
   end
 
+  @login_page_redirect_url System.get_env("LOGIN_PAGE_REDIRECT_URL")
+  if @login_page_redirect_url do
+    # We need to use `""` to match the root path, `"/"` doesn't seem to work and always matches the `/*_path` matcher.
+    get "", @html do
+      conn
+      |> Plug.Conn.put_resp_header("location", @login_page_redirect_url)
+      |> Plug.Conn.send_resp(302, "Redirecting")
+      |> Plug.Conn.halt()
+    end
+  end
+
   match "/*_path", @html do
     forward conn, [], "http://loket/index.html"
   end


### PR DESCRIPTION
For the production environment we want the `/` url to redirect to an external information / login page, maintained by the government.

If the `LOGIN_PAGE_REDIRECT_URL` is set in the container, we redirect to that url instead of the built-in login page.

**Test instructions**
- Add the following config to your docker-compose.override.yml file:

```yml
  dispatcher:
    environment:
      LOGIN_PAGE_REDIRECT_URL: "https://vlaanderen.be/loket-lokale-besturen"
```

- Start the app and browse to `localhost:90`
- verify that it redirects to the configured url
- verify that the rest of the app still works (`localhost:90/mock-login`)