### PR TITLE
Hotfix/fix migration gemeentewegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ drc restart migrations
 drc logs --tail 200 -f migrations # ensure it finishes. it can take a few minutes
 drc pull berichtencentrum-sync-with-kalliope && drc up -d berichtencentrum-sync-with-kalliope
 ```
+# v1.121.3 (2026-05-0x)
+ - Fix migration export gemeentewegen
+
+## Deploy notes
+```
+drc restart migrations # (or up -d migrations on prod)
+```
+
 # v1.121.2 (2026-05-06)
   - Bump acm-login service [DL-7334]
 ## Deploy notes

--- a/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102539-prepare-gemeentewegen-attachments.sparql
+++ b/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102539-prepare-gemeentewegen-attachments.sparql
@@ -1,49 +1,18 @@
-PREFIX schema: <http://schema.org/>
-PREFIX pav: <http://purl.org/pav/>
-PREFIX prov: <http://www.w3.org/ns/prov#>
-PREFIX lblodBesluit: <http://lblod.data.gift/vocabularies/besluit/>
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-PREFIX eli: <http://data.europa.eu/eli/ontology#>
-PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
-PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-PREFIX prov: <http://www.w3.org/ns/prov#>
-PREFIX dct: <http://purl.org/dc/terms/>
-
-INSERT {
-  GRAPH ?h {
-    ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
-  }
-}
-WHERE {
-  {
-    ?submission schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> ;
-      nie:hasPart |
-      nie:hasPart/^nie:dataSource |
-      dct:hasPart/^nie:dataSource |
-      nie:hasPart/^nie:dataSource/^nie:dataSource |
-      prov:generated/dct:hasPart |
-      prov:generated/dct:hasPart/nie:dataSource ?attachment .
-  }
-  UNION
-  {
-    ?submission schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> ;
-      dct:subject/dct:source ?attachment.
-    ?attachment dct:type ?type .
-
-    FILTER (?type IN (
-      <http://data.lblod.gift/concepts/meta-file-type>,
-      <http://data.lblod.gift/concepts/form-data-file-type>,
-      <http://data.lblod.gift/concepts/form-file-type>
-    ))
-  }
-
-  FILTER NOT EXISTS { ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> . }
-
-  GRAPH ?g {
-    ?attachment a ?attachmentType .
-  }
-  FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))
-
-  BIND(?g as ?h)
-}
+# We had a problem with performance with the previous migrations.
+# So we had to re-write them.
+#
+# Please check:
+#   20260416102540-prepare-gemeentewegen-attachments-haspart.sparql
+#     -> ?submission nie:hasPart ?attachment
+#   20260416102541-prepare-gemeentewegen-attachments-haspart-source.sparql
+#     -> ?submission nie:hasPart/^nie:dataSource ?attachment
+#   20260416102542-prepare-gemeentewegen-attachments-dct-haspart-source.sparql
+#     -> ?submission dct:hasPart/^nie:dataSource ?attachment
+#   20260416102543-prepare-gemeentewegen-attachments-haspart-source-source.sparql
+#     -> ?submission nie:hasPart/^nie:dataSource/^nie:dataSource ?attachment
+#   20260416102544-prepare-gemeentewegen-attachments-generated-haspart.sparql
+#     -> ?submission prov:generated/dct:hasPart ?attachment
+#   20260416102545-prepare-gemeentewegen-attachments-generated-haspart-source.sparql
+#     -> ?submission prov:generated/dct:hasPart/nie:dataSource ?attachment
+#   20260416102546-prepare-gemeentewegen-attachments-subject-source.sparql
+#     -> ?submission dct:subject/dct:source ?attachment (with dct:type filter)

--- a/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102540-prepare-gemeentewegen-attachments-haspart.sparql
+++ b/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102540-prepare-gemeentewegen-attachments-haspart.sparql
@@ -1,0 +1,31 @@
+PREFIX schema: <http://schema.org/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+# Split 1/7 of prepare-gemeentewegen-attachments.
+# Pattern: ?submission nie:hasPart ?attachment
+# Scope:   submission's form must be one of the gemeentewegen besluit types.
+
+INSERT {
+  GRAPH ?g {
+    ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+  }
+}
+WHERE {
+  ?submission schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> ;
+              prov:generated ?form ;
+              nie:hasPart ?attachment .
+  ?form ext:decisionType ?decisionType .
+  VALUES ?decisionType {
+    <https://data.vlaanderen.be/id/concept/BesluitType/b0fcc0c3-bb33-427f-8da2-4ef3833c9060>
+    <https://data.vlaanderen.be/id/concept/BesluitType/f1fd8f88-95b0-4085-b766-008b5867d992>
+  }
+
+  FILTER NOT EXISTS { ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> . }
+
+  GRAPH ?g {
+    ?attachment a ?attachmentType .
+  }
+  FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))
+}

--- a/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102541-prepare-gemeentewegen-attachments-haspart-source.sparql
+++ b/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102541-prepare-gemeentewegen-attachments-haspart-source.sparql
@@ -1,0 +1,31 @@
+PREFIX schema: <http://schema.org/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+# Split 2/7 of prepare-gemeentewegen-attachments.
+# Pattern: ?submission nie:hasPart/^nie:dataSource ?attachment
+# Scope:   submission's form must be one of the gemeentewegen besluit types.
+
+INSERT {
+  GRAPH ?g {
+    ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+  }
+}
+WHERE {
+  ?submission schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> ;
+              prov:generated ?form ;
+              nie:hasPart/^nie:dataSource ?attachment .
+  ?form ext:decisionType ?decisionType .
+  VALUES ?decisionType {
+    <https://data.vlaanderen.be/id/concept/BesluitType/b0fcc0c3-bb33-427f-8da2-4ef3833c9060>
+    <https://data.vlaanderen.be/id/concept/BesluitType/f1fd8f88-95b0-4085-b766-008b5867d992>
+  }
+
+  FILTER NOT EXISTS { ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> . }
+
+  GRAPH ?g {
+    ?attachment a ?attachmentType .
+  }
+  FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))
+}

--- a/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102542-prepare-gemeentewegen-attachments-dct-haspart-source.sparql
+++ b/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102542-prepare-gemeentewegen-attachments-dct-haspart-source.sparql
@@ -1,0 +1,32 @@
+PREFIX schema: <http://schema.org/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+# Split 3/7 of prepare-gemeentewegen-attachments.
+# Pattern: ?submission dct:hasPart/^nie:dataSource ?attachment
+# Scope:   submission's form must be one of the gemeentewegen besluit types.
+
+INSERT {
+  GRAPH ?g {
+    ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+  }
+}
+WHERE {
+  ?submission schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> ;
+              prov:generated ?form ;
+              dct:hasPart/^nie:dataSource ?attachment .
+  ?form ext:decisionType ?decisionType .
+  VALUES ?decisionType {
+    <https://data.vlaanderen.be/id/concept/BesluitType/b0fcc0c3-bb33-427f-8da2-4ef3833c9060>
+    <https://data.vlaanderen.be/id/concept/BesluitType/f1fd8f88-95b0-4085-b766-008b5867d992>
+  }
+
+  FILTER NOT EXISTS { ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> . }
+
+  GRAPH ?g {
+    ?attachment a ?attachmentType .
+  }
+  FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))
+}

--- a/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102543-prepare-gemeentewegen-attachments-haspart-source-source.sparql
+++ b/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102543-prepare-gemeentewegen-attachments-haspart-source-source.sparql
@@ -1,0 +1,32 @@
+PREFIX schema: <http://schema.org/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+# Split 4/7 of prepare-gemeentewegen-attachments.
+# Pattern: ?submission nie:hasPart/^nie:dataSource/^nie:dataSource ?attachment
+# (Two-hop inverse path — the heaviest of the path patterns.)
+# Scope:   submission's form must be one of the gemeentewegen besluit types.
+
+INSERT {
+  GRAPH ?g {
+    ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+  }
+}
+WHERE {
+  ?submission schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> ;
+              prov:generated ?form ;
+              nie:hasPart/^nie:dataSource/^nie:dataSource ?attachment .
+  ?form ext:decisionType ?decisionType .
+  VALUES ?decisionType {
+    <https://data.vlaanderen.be/id/concept/BesluitType/b0fcc0c3-bb33-427f-8da2-4ef3833c9060>
+    <https://data.vlaanderen.be/id/concept/BesluitType/f1fd8f88-95b0-4085-b766-008b5867d992>
+  }
+
+  FILTER NOT EXISTS { ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> . }
+
+  GRAPH ?g {
+    ?attachment a ?attachmentType .
+  }
+  FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))
+}

--- a/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102544-prepare-gemeentewegen-attachments-generated-haspart.sparql
+++ b/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102544-prepare-gemeentewegen-attachments-generated-haspart.sparql
@@ -1,0 +1,32 @@
+PREFIX schema: <http://schema.org/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+# Split 5/7 of prepare-gemeentewegen-attachments.
+# Pattern: ?submission prov:generated ?form . ?form dct:hasPart ?attachment
+# Scope:   the form leading to the attachment must be one of the gemeentewegen
+#          besluit types (?form is bound mid-path, then filtered).
+
+INSERT {
+  GRAPH ?g {
+    ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+  }
+}
+WHERE {
+  ?submission schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> ;
+              prov:generated ?form .
+  ?form dct:hasPart ?attachment ;
+        ext:decisionType ?decisionType .
+  VALUES ?decisionType {
+    <https://data.vlaanderen.be/id/concept/BesluitType/b0fcc0c3-bb33-427f-8da2-4ef3833c9060>
+    <https://data.vlaanderen.be/id/concept/BesluitType/f1fd8f88-95b0-4085-b766-008b5867d992>
+  }
+
+  FILTER NOT EXISTS { ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> . }
+
+  GRAPH ?g {
+    ?attachment a ?attachmentType .
+  }
+  FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))
+}

--- a/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102545-prepare-gemeentewegen-attachments-generated-haspart-source.sparql
+++ b/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102545-prepare-gemeentewegen-attachments-generated-haspart-source.sparql
@@ -1,0 +1,34 @@
+PREFIX schema: <http://schema.org/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+# Split 6/7 of prepare-gemeentewegen-attachments.
+# Pattern: ?submission prov:generated ?form .
+#          ?form dct:hasPart/nie:dataSource ?attachment
+# Scope:   the form leading to the attachment must be one of the gemeentewegen
+#          besluit types (?form is bound mid-path, then filtered).
+
+INSERT {
+  GRAPH ?g {
+    ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+  }
+}
+WHERE {
+  ?submission schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> ;
+              prov:generated ?form .
+  ?form dct:hasPart/nie:dataSource ?attachment ;
+        ext:decisionType ?decisionType .
+  VALUES ?decisionType {
+    <https://data.vlaanderen.be/id/concept/BesluitType/b0fcc0c3-bb33-427f-8da2-4ef3833c9060>
+    <https://data.vlaanderen.be/id/concept/BesluitType/f1fd8f88-95b0-4085-b766-008b5867d992>
+  }
+
+  FILTER NOT EXISTS { ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> . }
+
+  GRAPH ?g {
+    ?attachment a ?attachmentType .
+  }
+  FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))
+}

--- a/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102546-prepare-gemeentewegen-attachments-subject-source.sparql
+++ b/config/migrations/2026/20260416102304-export-old-gemeentewegen/20260416102546-prepare-gemeentewegen-attachments-subject-source.sparql
@@ -1,0 +1,39 @@
+PREFIX schema: <http://schema.org/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+# Split 7/7 of prepare-gemeentewegen-attachments.
+# Pattern: ?submission dct:subject/dct:source ?attachment, restricted to
+# attachments whose dct:type is one of the three known submission file types.
+# Scope:   submission's form must be one of the gemeentewegen besluit types.
+
+INSERT {
+  GRAPH ?g {
+    ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+  }
+}
+WHERE {
+  ?submission schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> ;
+              prov:generated ?form ;
+              dct:subject/dct:source ?attachment .
+  ?form ext:decisionType ?decisionType .
+  VALUES ?decisionType {
+    <https://data.vlaanderen.be/id/concept/BesluitType/b0fcc0c3-bb33-427f-8da2-4ef3833c9060>
+    <https://data.vlaanderen.be/id/concept/BesluitType/f1fd8f88-95b0-4085-b766-008b5867d992>
+  }
+  ?attachment dct:type ?type .
+
+  FILTER (?type IN (
+    <http://data.lblod.gift/concepts/meta-file-type>,
+    <http://data.lblod.gift/concepts/form-data-file-type>,
+    <http://data.lblod.gift/concepts/form-file-type>
+  ))
+
+  FILTER NOT EXISTS { ?attachment schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> . }
+
+  GRAPH ?g {
+    ?attachment a ?attachmentType .
+  }
+  FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))
+}


### PR DESCRIPTION
We had a problem with performance with the previous migrations. So we had to re-write them. This commit splits the mega-migration in smaller chunks and filters on the specific type of submission. See also [DL-7397]