### PR TITLE
Improved: VDDS deals with large datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Changelog
 
 # Unreleased
+
 - Bump validate-submission-service [15](https://github.com/lblod/validate-submission-service/pull/15) seeAlso: DL-7200
 - Bump berichtencentrum-sync-with-kalliope to `v0.23.2` [DL-7253]
 - Bump frontend-loket [473](https://github.com/lblod/frontend-loket/pull/473)
 - Conditionally redirect to the external login page [DL-7361]
 - Update non-sent-automatic-submissions report [DL-7336]
+- Bump the vendor-data-distribution-service to deal with large datasets caused by Kaliope omzendbrieven [DL-7378]
 
 ## Deploy notes
+
 ### Production
+
 Add the following environment variable to the docker-compose.override.yml file:
 
 ```yml
@@ -18,12 +22,15 @@ Add the following environment variable to the docker-compose.override.yml file:
 ```
 
 ### All environments
+
 ```
 drc up -d loket dispatcher
 drc restart migrations
 drc logs --tail 200 -f migrations # ensure it finishes. it can take a few minutes
 drc pull berichtencentrum-sync-with-kalliope && drc up -d berichtencentrum-sync-with-kalliope
 drc restart report-generation
+drc up -d vendor-data-distribution
+drc exec vendor-data-distribution curl http://localhost/heal # This can take hours
 ```
 # v1.121.4 (2026-05-20)
  - Fix migration export gemeentewegen

--- a/config/vendor-data/model.ttl
+++ b/config/vendor-data/model.ttl
@@ -34,7 +34,7 @@
 
 meb:Submission
   rdf:type vdds:Class ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject}
@@ -66,7 +66,7 @@ meb:Submission
       adms:status <http://redpencil.data.gift/id/concept/JobStatus/failed> ;
       task:operation <http://lblod.data.gift/id/jobs/concept/JobOperation/harvestBericht> .
   """ ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject}
@@ -102,7 +102,7 @@ task:error
       adms:status <http://redpencil.data.gift/id/concept/JobStatus/success> ;
       task:operation <http://lblod.data.gift/id/jobs/concept/JobOperation/harvestBericht> .
   """ ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject}
@@ -174,7 +174,7 @@ nie:dataSource
     ${subject}
       adms:status <http://data.lblod.info/id/status/berichtencentrum/sync-with-kalliope/delivered/confirmed> .
   """ ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject} schema:recipient ?organisation .
@@ -211,7 +211,7 @@ nie:dataSource
     ${subject}
       ext:creator <https://github.com/lblod/frontend-loket> .
   """ ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject}
@@ -250,7 +250,7 @@ nie:dataSource
       ext:creator <https://github.com/lblod/frontend-loket> ;
       schema:sender <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> .
   """ ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject}

--- a/config/vendor-data/model.ttl
+++ b/config/vendor-data/model.ttl
@@ -49,6 +49,7 @@ meb:Submission
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-toezichtGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 ##############################################################################
@@ -81,6 +82,7 @@ meb:Submission
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-toezichtGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 osc:Error
@@ -117,6 +119,7 @@ task:error
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-berichtenGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 schema:Conversation
@@ -187,6 +190,7 @@ nie:dataSource
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-berichtenGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 <RelConversationMessageKaliope>
@@ -225,6 +229,7 @@ nie:dataSource
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-berichtenGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 <RelConversationMessageLoket>
@@ -264,6 +269,7 @@ nie:dataSource
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-berichtenGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 <RelConversationMessageLoketControle>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -532,7 +532,7 @@ services:
     restart: always
     logging: *default-logging
   vendor-data-distribution:
-    image: lblod/vendor-data-distribution-service:2.0.0
+    image: lblod/vendor-data-distribution-service:2.1.0
     environment:
       LOGLEVEL: "error"
       WRITE_ERRORS: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -532,7 +532,7 @@ services:
     restart: always
     logging: *default-logging
   vendor-data-distribution:
-    image: lblod/vendor-data-distribution-service:2.1.0
+    image: lblod/vendor-data-distribution-service:2.2.0
     environment:
       LOGLEVEL: "error"
       WRITE_ERRORS: "true"


### PR DESCRIPTION
**[DL-7378]**

The VDDS had to deal with a bit of a strange dataset, where physical files where re-used between messages sent to all organisations in the application via Kaliope, but with slightly different properties between organisations. This caused huge slow downs and an explosion of data to copy to vendor graphs.

This PR aims to fix this by more carefully selecting the source graph for the data.

**TODO:**

* Bump the VDDS when it has been reviewed (https://github.com/lblod/vendor-data-distribution-service/pull/23)