### PR TITLE
DL-7336: Cleanup non-sent-automatic-submissions.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bump berichtencentrum-sync-with-kalliope to `v0.23.2` [DL-7253]
 - Bump frontend-loket [473](https://github.com/lblod/frontend-loket/pull/473)
 - Conditionally redirect to the external login page [DL-7361]
+- Update non-sent-automatic-submissions report [DL-7336]
 
 ## Deploy notes
 ### Production
@@ -23,6 +24,7 @@ drc up -d prepare-submissions-for-export loket dispatcher
 drc restart migrations
 drc logs --tail 200 -f migrations # ensure it finishes. it can take a few minutes
 drc pull berichtencentrum-sync-with-kalliope && drc up -d berichtencentrum-sync-with-kalliope
+drc restart report-generation
 ```
 
 # v1.121.3 (2026-05-13)

--- a/config/reports/toezicht-submissions/non-sent-automatic-submissions.js
+++ b/config/reports/toezicht-submissions/non-sent-automatic-submissions.js
@@ -95,7 +95,7 @@ WHERE {
    ?vendor foaf:name ?vendorLabel.
    ?submissionStatus skos:prefLabel ?submissionStatusLabel.
 
-  BIND(CONCAT("http://dashboard.loket.lblod.info//jobs/", ?jobUuid, "/index") as ?dashboardUrl)
+  BIND(CONCAT("http://dashboard.loket.lblod.info/jobs/", ?jobUuid) as ?dashboardUrl)
   BIND(CONCAT(STR(YEAR(?jobCreated)), '-', STR(MONTH(?jobCreated)), '-', STR(DAY(?jobCreated))) as ?jobCreatedShort)
   BIND(STRAFTER(STR(?jobStatus), "http://redpencil.data.gift/id/concept/JobStatus/") as ?jobStatusShort)
 

--- a/config/reports/toezicht-submissions/non-sent-automatic-submissions.js
+++ b/config/reports/toezicht-submissions/non-sent-automatic-submissions.js
@@ -95,7 +95,7 @@ WHERE {
    ?vendor foaf:name ?vendorLabel.
    ?submissionStatus skos:prefLabel ?submissionStatusLabel.
 
-  BIND(CONCAT("http://dashboard.loket.lblod.info/jobs/", ?jobUuid) as ?dashboardUrl)
+  BIND(CONCAT("https://dashboard.loket.lblod.info/jobs/", ?jobUuid) as ?dashboardUrl)
   BIND(CONCAT(STR(YEAR(?jobCreated)), '-', STR(MONTH(?jobCreated)), '-', STR(DAY(?jobCreated))) as ?jobCreatedShort)
   BIND(STRAFTER(STR(?jobStatus), "http://redpencil.data.gift/id/concept/JobStatus/") as ?jobStatusShort)
 

--- a/config/reports/toezicht-submissions/non-sent-automatic-submissions.js
+++ b/config/reports/toezicht-submissions/non-sent-automatic-submissions.js
@@ -55,7 +55,6 @@ SELECT DISTINCT
 ?jobCreatedShort
 ?jobStatusShort
 ?dashboardUrl
-?controleUrl
 ?job
 ?jobCreated
 ?jobStatus
@@ -96,8 +95,7 @@ WHERE {
    ?vendor foaf:name ?vendorLabel.
    ?submissionStatus skos:prefLabel ?submissionStatusLabel.
 
-  BIND(CONCAT("https://controle.loket.lblod.info/supervision/submissions/", ?uuid) as ?controleUrl)
-  BIND(CONCAT("https://dashboard.prod.lblod.info/jobs/", ?jobUuid, "/index") as ?dashboardUrl)
+  BIND(CONCAT("http://dashboard.loket.lblod.info//jobs/", ?jobUuid, "/index") as ?dashboardUrl)
   BIND(CONCAT(STR(YEAR(?jobCreated)), '-', STR(MONTH(?jobCreated)), '-', STR(DAY(?jobCreated))) as ?jobCreatedShort)
   BIND(STRAFTER(STR(?jobStatus), "http://redpencil.data.gift/id/concept/JobStatus/") as ?jobStatusShort)
 


### PR DESCRIPTION
Cleanup some old links in the non-automatic-submissions-report

### Ticket
DL-7336

### Test
Run the report (name is toezicht-submissions), see if the new link is in there and everything works correctly