### PR TITLE
Feature/make vendor info availble for user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Redistribute vendor information per organisation. Each organisation now only sees the vendor acting on its own behalf. [DL-7373]
 - Fixes to validate-submission-service [DL-7411] [DL-7412]
 - Make ldes-graph not public [DL-7401]
+- Redistribute vendor information per organisation. Each organisation now only sees own vendor. [DL-7373]
 
 ## Deploy notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Unreleased
 
 - Add Cross Referencing rules on the BesluitType and BesluitDocumentType [DL-7202] [DL-7204] [DL-7325]
+- Redistribute vendor information per organisation. Each organisation now only sees the vendor acting on its own behalf. [DL-7373]
 - Fixes to validate-submission-service [DL-7411] [DL-7412]
 - Make ldes-graph not public [DL-7401]
 
@@ -20,6 +21,10 @@ Then search should be re-indexed
 
 ```
 mu script search manage-indexes # follow the steps there. Re-index "public-services"
+drc restart migrations 
+drc restart database search dbcleanup
+# Trigger the job immediatly
+drc exec dbcleanup curl "http://localhost/runCronjob?cronJobID=cdf450a5-b4b6-4e19-b538-f778451f14b9"
 ```
 
 # v1.223.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ```
 drc restart migrations
-drc up -d validate-submission worship-decisions-cross-reference
+drc up -d validate-submission worship-decisions-cross-reference loket
 drc restart database identifier
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,6 @@ Then search should be re-indexed
 mu script search manage-indexes # follow the steps there. Re-index "public-services"
 drc restart migrations 
 drc restart database search dbcleanup
-# Trigger the job immediatly
-drc exec dbcleanup curl "http://localhost/runCronjob?cronJobID=cdf450a5-b4b6-4e19-b538-f778451f14b9"
 ```
 
 # v1.223.1

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -280,6 +280,9 @@ defmodule Acl.UserGroups.Config do
                         "http://xmlns.com/foaf/0.1/Person",
                         "http://xmlns.com/foaf/0.1/OnlineAccount",
                         "http://www.w3.org/ns/adms#Identifier",
+                        # // own vendor data, redistributed per organisation by the
+                        # // "redistribute-vendor-data-per-org" db-cleanup job
+                        "http://mu.semte.ch/vocabularies/ext/Vendor",
                       ] } } ] },
 
       # // BBCDR
@@ -440,31 +443,6 @@ defmodule Acl.UserGroups.Config do
                         "http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen",
                         "https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator",
                         "http://lblod.data.gift/vocabularies/organisatie/HelftVerkiezing",
-                      ] } }
-                ] },
-
-      # // public vendor data.
-      %GroupSpec{
-        name: "o-vendor-ere-mandaat-r",
-        useage: [:read ],
-        access: access_by_role_for_single_graph( "LoketLB-eredienstMandaatGebruiker" ),
-        graphs: [ %GraphSpec{
-                    graph: "http://mu.semte.ch/graphs/id/public-vendor-data",
-                    constraint: %ResourceConstraint{
-                      resource_types: [
-                        "http://mu.semte.ch/vocabularies/ext/Vendor"
-                      ] } }
-                ] },
-
-      %GroupSpec{
-        name: "o-vendor-ere-bedienaar-r",
-        useage: [:read ],
-        access: access_by_role_for_single_graph( "LoketLB-eredienstBedienaarGebruiker" ),
-        graphs: [ %GraphSpec{
-                    graph: "http://mu.semte.ch/graphs/id/public-vendor-data",
-                    constraint: %ResourceConstraint{
-                      resource_types: [
-                        "http://mu.semte.ch/vocabularies/ext/Vendor"
                       ] } }
                 ] },
 

--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -167,7 +167,10 @@
 (define-graph org ("http://mu.semte.ch/graphs/organizations/")
   ("foaf:Person" -> _)
   ("foaf:OnlineAccount" -> _)
-  ("adms:Identifier" -> _))
+  ("adms:Identifier" -> _)
+  ;; own vendor data, redistributed per organisation by the
+  ;; "redistribute-vendor-data-per-org" db-cleanup job
+  ("ext:Vendor" -> _))
 
 (define-graph o-bbcdr-rw ("http://mu.semte.ch/graphs/organizations/")
   ("ext:bbcdr/Report" -> _)
@@ -200,9 +203,6 @@
 (define-graph o-toezicht-vendor-management-rw ("http://mu.semte.ch/graphs/automatic-submission")
   ("ext:Vendor" x> "http://mu.semte.ch/vocabularies/account/keyHash")
   ("besluit:Bestuurseenheid" -> _))
-
-(define-graph public-vendor-data-r ("http://mu.semte.ch/graphs/id/public-vendor-data")
-  ("ext:Vendor" -> _))
 
 (define-graph o-toezicht-vendor-management-authenticated-rw ("http://mu.semte.ch/graphs/authenticated/public")
   ("besluit:Bestuurseenheid" -> "ext:viewOnlyModules"))
@@ -480,14 +480,6 @@
 (grant (read)
   :to-graph (o-vendor-api-r)
   :for-allowed-group "access-for-vendor-api")
-
-(grant (read)
-  :to-graph (public-vendor-data-r)
-  :for-allowed-group "LoketLB-eredienstMandaatGebruiker")
-
-(grant (read)
-  :to-graph (public-vendor-data-r)
-  :for-allowed-group "LoketLB-eredienstBedienaarGebruiker")
 
 (grant (read write)
   :to-graph (sessions)

--- a/config/migrations/2026/20260603120000-clear-public-vendor-data-graph.sparql
+++ b/config/migrations/2026/20260603120000-clear-public-vendor-data-graph.sparql
@@ -1,0 +1,10 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/id/public-vendor-data> {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/id/public-vendor-data> {
+    ?s ?p ?o .
+  }
+}

--- a/config/migrations/2026/20260603120200-initial-redistribute-vendor-data-per-org.sparql
+++ b/config/migrations/2026/20260603120200-initial-redistribute-vendor-data-per-org.sparql
@@ -1,0 +1,25 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+
+INSERT {
+  GRAPH ?orgGraph {
+    ?vendor a ext:Vendor, foaf:Agent ;
+      mu:uuid ?uuid ;
+      foaf:name ?name ;
+      muAccount:canActOnBehalfOf ?org .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+    ?vendor a ext:Vendor ;
+      mu:uuid ?uuid ;
+      foaf:name ?name ;
+      muAccount:canActOnBehalfOf ?org .
+  }
+  GRAPH ?orgInfoGraph {
+    ?org mu:uuid ?orgUuid .
+  }
+  BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?orgUuid)) AS ?orgGraph)
+}

--- a/config/migrations/2026/cleanup-jobs/20260603120100-redistribute-vendor-data-per-org-cleanup-job/20260603120100-redistribute-vendor-data-per-org-cleanup-job.graph
+++ b/config/migrations/2026/cleanup-jobs/20260603120100-redistribute-vendor-data-per-org-cleanup-job/20260603120100-redistribute-vendor-data-per-org-cleanup-job.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2026/cleanup-jobs/20260603120100-redistribute-vendor-data-per-org-cleanup-job/20260603120100-redistribute-vendor-data-per-org-cleanup-job.ttl
+++ b/config/migrations/2026/cleanup-jobs/20260603120100-redistribute-vendor-data-per-org-cleanup-job/20260603120100-redistribute-vendor-data-per-org-cleanup-job.ttl
@@ -1,0 +1,49 @@
+@prefix cleanup:  <http://mu.semte.ch/vocabularies/ext/cleanup/> .
+@prefix mu:       <http://mu.semte.ch/vocabularies/core/> .
+@prefix dcterms:  <http://purl.org/dc/terms/> .
+
+<http://data.lblod.info/id/cleanup-job/cdf450a5-b4b6-4e19-b538-f778451f14b9> a cleanup:Job ;
+  mu:uuid "cdf450a5-b4b6-4e19-b538-f778451f14b9" ;
+  dcterms:title "Redistribute vendor data per organisation" ;
+  dcterms:description "Full resync, run as a single DELETE/INSERT. The DELETE branch clears every ext:Vendor in the per-organisation graphs (organizations/<org-uuid>); the INSERT branch re-copies each vendor (type, mu:uuid, foaf:name, and only its muAccount:canActOnBehalfOf link to that organisation) from the automatic-submission source graph. An organisation therefore only ever sees vendors acting on its own behalf, and never that another organisation uses the same vendor. The credential predicates muAccount:key and muAccount:keyHash are never copied." ;
+  cleanup:randomQuery """
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+
+    DELETE {
+      GRAPH ?staleGraph {
+        ?staleVendor ?staleP ?staleO .
+      }
+    }
+    INSERT {
+      GRAPH ?orgGraph {
+        ?vendor a ext:Vendor, foaf:Agent ;
+          mu:uuid ?uuid ;
+          foaf:name ?name ;
+          muAccount:canActOnBehalfOf ?org .
+      }
+    }
+    WHERE {
+      {
+        GRAPH ?staleGraph {
+          ?staleVendor a ext:Vendor ;
+            ?staleP ?staleO .
+        }
+        FILTER(STRSTARTS(STR(?staleGraph), "http://mu.semte.ch/graphs/organizations/"))
+      }
+      UNION
+      {
+        GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+          ?vendor a ext:Vendor ;
+            mu:uuid ?uuid ;
+            foaf:name ?name ;
+            muAccount:canActOnBehalfOf ?org .
+        }
+        ?org mu:uuid ?orgUuid .
+        BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?orgUuid)) AS ?orgGraph)
+      }
+    }
+  """ ;
+  cleanup:cronPattern "0 5 * * *" .

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -96,14 +96,6 @@
     {
       "variables": [],
       "name": "o-admin-rwf"
-    },
-    {
-      "variables": [],
-      "name": "o-vendor-ere-bedienaar-r"
-    },
-    {
-      "variables": [],
-      "name": "o-vendor-ere-mandaat-r"
     }
   ],
   "eager_indexing_groups": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
 
 services:
   loket:
-    image: lblod/frontend-loket:1.12.0
+    image: lblod/frontend-loket:1.13.0
     environment:
       EMBER_FEATURE_NEW_LOKET: "true"
     links:


### PR DESCRIPTION
Re-engineering the vendor data. We removed the one graph with 'public' vendor data, and now run a background job to update per org their corresponding vendor. So we don't need to do anything special in the frontend. 