### PR TITLE
DL-7401: Make ldes-graph not public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
 ```
 drc restart database identifier
 ```
-
+Then search should be re-indexed
+```
+mu script search manage-indexes # follow the steps there. Re-index "public-services"
+```
 # v1.223.1
 - Fix dispatcher rules. Postfix: [DL-7316].
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 # Unreleased
 
 - Add Cross Referencing rules on the BesluitType and BesluitDocumentType [DL-7202] [DL-7204] [DL-7325]
+- Make ldes-graph not public [DL-7401]
+
+## Deploy notes
+```
+drc restart database identifier
+```
 
 # v1.223.1
 - Fix dispatcher rules. Postfix: [DL-7316].

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -215,23 +215,7 @@ defmodule Acl.UserGroups.Config do
                     graph: "http://mu.semte.ch/graphs/sessions",
                     constraint: %ResourceFormatConstraint{
                       resource_prefix: "http://mu.semte.ch/sessions/"
-                    } },
-                  %GraphSpec{
-                    graph: "http://mu.semte.ch/graphs/ipdc/ldes-data",
-                    constraint: %ResourceConstraint{
-                      resource_types: [
-                        "https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#InstancePublicServiceSnapshot",
-                        "https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#FinancialAdvantage",
-                        "http://schema.org/WebSite",
-                        "http://data.europa.eu/m8g/Requirement",
-                        "http://data.europa.eu/m8g/Cost",
-                        "http://data.europa.eu/m8g/Evidence",
-                        "http://schema.org/ContactPoint",
-                        "http://www.w3.org/ns/locn#Address",
-                        "http://purl.org/vocab/cpsv#Rule",
-                        "http://data.europa.eu/eli/ontology#LegalResource"
-                        ]
-                   }}] },
+                    } }] },
       %GroupSpec{
         name: "public-r",
         useage: [:read],
@@ -280,7 +264,23 @@ defmodule Acl.UserGroups.Config do
                         "http://xmlns.com/foaf/0.1/Person",
                         "http://xmlns.com/foaf/0.1/OnlineAccount",
                         "http://www.w3.org/ns/adms#Identifier",
-                      ] } } ] },
+                      ] } },
+                  %GraphSpec{
+                    graph: "http://mu.semte.ch/graphs/ipdc/ldes-data",
+                    constraint: %ResourceConstraint{
+                      resource_types: [
+                        "https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#InstancePublicServiceSnapshot",
+                        "https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#FinancialAdvantage",
+                        "http://schema.org/WebSite",
+                        "http://data.europa.eu/m8g/Requirement",
+                        "http://data.europa.eu/m8g/Cost",
+                        "http://data.europa.eu/m8g/Evidence",
+                        "http://schema.org/ContactPoint",
+                        "http://www.w3.org/ns/locn#Address",
+                        "http://purl.org/vocab/cpsv#Rule",
+                        "http://data.europa.eu/eli/ontology#LegalResource"
+                        ]
+                   }} ] },
 
       # // BBCDR
       %GroupSpec{

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -229,7 +229,23 @@ defmodule Acl.UserGroups.Config do
                        predicates: %NoPredicates{
                          except: [
                            "http://mu.semte.ch/vocabularies/ext/viewOnlyModules"
-                         ] } } } ] },
+                         ] } } },
+                  %GraphSpec{
+                    graph: "http://mu.semte.ch/graphs/ipdc/ldes-data",
+                    constraint: %ResourceConstraint{
+                      resource_types: [
+                        "https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#InstancePublicServiceSnapshot",
+                        "https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#FinancialAdvantage",
+                        "http://schema.org/WebSite",
+                        "http://data.europa.eu/m8g/Requirement",
+                        "http://data.europa.eu/m8g/Cost",
+                        "http://data.europa.eu/m8g/Evidence",
+                        "http://schema.org/ContactPoint",
+                        "http://www.w3.org/ns/locn#Address",
+                        "http://purl.org/vocab/cpsv#Rule",
+                        "http://data.europa.eu/eli/ontology#LegalResource"
+                        ]
+                   }} ] },
     %GroupSpec{
         name: "public-wf",
         useage: [:write, :read_for_write],
@@ -264,23 +280,7 @@ defmodule Acl.UserGroups.Config do
                         "http://xmlns.com/foaf/0.1/Person",
                         "http://xmlns.com/foaf/0.1/OnlineAccount",
                         "http://www.w3.org/ns/adms#Identifier",
-                      ] } },
-                  %GraphSpec{
-                    graph: "http://mu.semte.ch/graphs/ipdc/ldes-data",
-                    constraint: %ResourceConstraint{
-                      resource_types: [
-                        "https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#InstancePublicServiceSnapshot",
-                        "https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#FinancialAdvantage",
-                        "http://schema.org/WebSite",
-                        "http://data.europa.eu/m8g/Requirement",
-                        "http://data.europa.eu/m8g/Cost",
-                        "http://data.europa.eu/m8g/Evidence",
-                        "http://schema.org/ContactPoint",
-                        "http://www.w3.org/ns/locn#Address",
-                        "http://purl.org/vocab/cpsv#Rule",
-                        "http://data.europa.eu/eli/ontology#LegalResource"
-                        ]
-                   }} ] },
+                      ] } } ] },
 
       # // BBCDR
       %GroupSpec{

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -215,7 +215,21 @@ defmodule Acl.UserGroups.Config do
                     graph: "http://mu.semte.ch/graphs/sessions",
                     constraint: %ResourceFormatConstraint{
                       resource_prefix: "http://mu.semte.ch/sessions/"
-                    } },
+                    } }] },
+      %GroupSpec{
+        name: "public-r",
+        useage: [:read],
+        access: is_authenticated(),
+        graphs: [%GraphSpec{
+                    graph: "http://mu.semte.ch/graphs/authenticated/public",
+                    constraint: %ResourceConstraint{
+                       resource_types: [
+                         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
+                       ],
+                       predicates: %NoPredicates{
+                         except: [
+                           "http://mu.semte.ch/vocabularies/ext/viewOnlyModules"
+                         ] } } },
                   %GraphSpec{
                     graph: "http://mu.semte.ch/graphs/ipdc/ldes-data",
                     constraint: %ResourceConstraint{
@@ -231,21 +245,7 @@ defmodule Acl.UserGroups.Config do
                         "http://purl.org/vocab/cpsv#Rule",
                         "http://data.europa.eu/eli/ontology#LegalResource"
                         ]
-                   }}] },
-      %GroupSpec{
-        name: "public-r",
-        useage: [:read],
-        access: is_authenticated(),
-        graphs: [%GraphSpec{
-                    graph: "http://mu.semte.ch/graphs/authenticated/public",
-                    constraint: %ResourceConstraint{
-                       resource_types: [
-                         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
-                       ],
-                       predicates: %NoPredicates{
-                         except: [
-                           "http://mu.semte.ch/vocabularies/ext/viewOnlyModules"
-                         ] } } } ] },
+                   }} ] },
     %GroupSpec{
         name: "public-wf",
         useage: [:write, :read_for_write],

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -215,21 +215,7 @@ defmodule Acl.UserGroups.Config do
                     graph: "http://mu.semte.ch/graphs/sessions",
                     constraint: %ResourceFormatConstraint{
                       resource_prefix: "http://mu.semte.ch/sessions/"
-                    } }] },
-      %GroupSpec{
-        name: "public-r",
-        useage: [:read],
-        access: is_authenticated(),
-        graphs: [%GraphSpec{
-                    graph: "http://mu.semte.ch/graphs/authenticated/public",
-                    constraint: %ResourceConstraint{
-                       resource_types: [
-                         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
-                       ],
-                       predicates: %NoPredicates{
-                         except: [
-                           "http://mu.semte.ch/vocabularies/ext/viewOnlyModules"
-                         ] } } },
+                    } },
                   %GraphSpec{
                     graph: "http://mu.semte.ch/graphs/ipdc/ldes-data",
                     constraint: %ResourceConstraint{
@@ -245,7 +231,21 @@ defmodule Acl.UserGroups.Config do
                         "http://purl.org/vocab/cpsv#Rule",
                         "http://data.europa.eu/eli/ontology#LegalResource"
                         ]
-                   }} ] },
+                   }}] },
+      %GroupSpec{
+        name: "public-r",
+        useage: [:read],
+        access: is_authenticated(),
+        graphs: [%GraphSpec{
+                    graph: "http://mu.semte.ch/graphs/authenticated/public",
+                    constraint: %ResourceConstraint{
+                       resource_types: [
+                         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
+                       ],
+                       predicates: %NoPredicates{
+                         except: [
+                           "http://mu.semte.ch/vocabularies/ext/viewOnlyModules"
+                         ] } } } ] },
     %GroupSpec{
         name: "public-wf",
         useage: [:write, :read_for_write],

--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -431,7 +431,7 @@
 
 (grant (read)
   :to-graph (public sessions ipdc)
-  :for-allowed-group "public")
+  :for-allowed-group "logged-in-or-impersonating")
 
 (grant (read)
   :to-graph (public-r)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
     logging: *default-logging
   identifier:
     image: semtech/mu-identifier:1.10.1
+    environment:
+      DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER: '[{"variables":[],"name":"clean"}, {"variables":[],"name":"public"}, {"variables":[],"name":"lmb-public"}]'
     labels:
       - "logging=true"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
   identifier:
     image: semtech/mu-identifier:1.10.1
     environment:
-      DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER: '[{"variables":[],"name":"clean"}, {"variables":[],"name":"public"}, {"variables":[],"name":"lmb-public"}]'
+      DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER: "[{\"variables\":[],\"name\":\"clean\"}, {\"variables\":[],\"name\":\"public\"}]"
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
Restrict access to the ipdc-ldes graph by removing it from the public grant and limiting it to logged-in/impersonating.

### Testing
Verify that:

1. Unauthenticated requests no longer returns data
2. Authenticated requests still returns data as expected

Note: Felix said re-index might be needed but when I tested locally it worked without having to do this, after restarting the services. 

### Ticket
DL-7401