### PR TITLE
[WIP] mu-cli script to restore virtuoso -> will be moved later to the docker-image of virtuoso

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,11 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  project-scripts:
+    image: semtech/mu-scripts:1.0.0
+    volumes:
+      - ./scripts/:/app/scripts/
+    restart: "no"
   migrations:
     image: semtech/mu-migrations-service:0.9.0
     links:

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.1",
+  "scripts": [
+    {
+      "documentation": {
+        "command": "restore-backup",
+        "description": "Restore the Virtuoso triplestore from an online backup in data/db/backups (made with `mu script virtuoso create-backup`). The `virtuoso` service MUST be stopped first. DESTRUCTIVE: replaces the current database.\n Parameters:\n  prefix: backup prefix up to the numeric suffix (auto-detected when a single backup set is present)\n  --yes : skip the confirmation prompt",
+        "arguments": ["prefix", "--yes"]
+      },
+      "environment": {
+        "image": "redpencil/virtuoso:1.2.2",
+        "interactive": true,
+        "join_networks": false,
+        "script": "restore-virtuoso-backup/run.sh"
+      },
+      "mounts": {
+        "app": "/project/"
+      }
+    }
+  ]
+}

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -4,8 +4,8 @@
     {
       "documentation": {
         "command": "restore-backup",
-        "description": "Restore the Virtuoso triplestore from an online backup in data/db/backups (made with `mu script virtuoso create-backup`). The `virtuoso` service MUST be stopped first. DESTRUCTIVE: replaces the current database.\n Parameters:\n  prefix: backup prefix up to the numeric suffix (auto-detected when a single backup set is present)\n  --yes : skip the confirmation prompt",
-        "arguments": ["prefix", "--yes"]
+        "description": "Restore the Virtuoso triplestore from an backup in data/db/backups. The `virtuoso` service MUST be stopped first. REPLACES the current database.\n Parameters:\n  prefix: backup prefix up to the numeric suffix (auto-detected when a single backup set is present)",
+        "arguments": ["prefix"]
       },
       "environment": {
         "image": "redpencil/virtuoso:1.2.2",

--- a/scripts/restore-virtuoso-backup/README.md
+++ b/scripts/restore-virtuoso-backup/README.md
@@ -1,11 +1,10 @@
 # restore-virtuoso-backup
 
 Restore the Virtuoso triplestore from an online `.bp` backup in `data/db/backups/`
-(created by `mu script virtuoso create-backup`). The image ships `create-backup` but no
-restore of its own.
 
-**Destructive** — replaces the current database in `data/db`. Stop the `virtuoso` service
-first.
+:warning: REPLACES the current database in `data/db`. :warning:
+
+Stop the `virtuoso` service first.
 
 ## Usage
 
@@ -14,17 +13,10 @@ From the project root:
 ```bash
 docker compose stop virtuoso
 
-mu script project-scripts restore-backup                  # auto-detect a single backup set
-mu script project-scripts restore-backup <prefix> --yes   # pin a set / skip the prompt
+mu script project-scripts restore-backup
+mu script project-scripts restore-backup <prefix>
 
 docker compose up -d virtuoso
-```
-
-Without mu-cli, run the container directly:
-
-```bash
-docker run --rm -it -v "$PWD":/project redpencil/virtuoso:1.2.2 \
-  bash /project/scripts/restore-virtuoso-backup/run.sh [<prefix>] [--yes]
 ```
 
 ## Parameters
@@ -32,6 +24,5 @@ docker run --rm -it -v "$PWD":/project redpencil/virtuoso:1.2.2 \
 | Arg | Meaning |
 |-----|---------|
 | `prefix` | Backup prefix up to the numeric suffix (e.g. `backup_20260609_120000_`). Auto-detected when `data/db/backups/` holds one set; required if it holds several. |
-| `--yes` | Skip the confirmation prompt. |
 
 Pinned to `redpencil/virtuoso:1.2.2` to match the `virtuoso` service — bump both together.

--- a/scripts/restore-virtuoso-backup/README.md
+++ b/scripts/restore-virtuoso-backup/README.md
@@ -1,0 +1,37 @@
+# restore-virtuoso-backup
+
+Restore the Virtuoso triplestore from an online `.bp` backup in `data/db/backups/`
+(created by `mu script virtuoso create-backup`). The image ships `create-backup` but no
+restore of its own.
+
+**Destructive** — replaces the current database in `data/db`. Stop the `virtuoso` service
+first.
+
+## Usage
+
+From the project root:
+
+```bash
+docker compose stop virtuoso
+
+mu script project-scripts restore-backup                  # auto-detect a single backup set
+mu script project-scripts restore-backup <prefix> --yes   # pin a set / skip the prompt
+
+docker compose up -d virtuoso
+```
+
+Without mu-cli, run the container directly:
+
+```bash
+docker run --rm -it -v "$PWD":/project redpencil/virtuoso:1.2.2 \
+  bash /project/scripts/restore-virtuoso-backup/run.sh [<prefix>] [--yes]
+```
+
+## Parameters
+
+| Arg | Meaning |
+|-----|---------|
+| `prefix` | Backup prefix up to the numeric suffix (e.g. `backup_20260609_120000_`). Auto-detected when `data/db/backups/` holds one set; required if it holds several. |
+| `--yes` | Skip the confirmation prompt. |
+
+Pinned to `redpencil/virtuoso:1.2.2` to match the `virtuoso` service — bump both together.

--- a/scripts/restore-virtuoso-backup/run.sh
+++ b/scripts/restore-virtuoso-backup/run.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Restore the Virtuoso triplestore from an online backup (the .bp files in
+# data/db/backups, as produced by `mu script virtuoso create-backup`).
+#
+# Runs offline in a one-off redpencil/virtuoso container (same image as the
+# `virtuoso` service) with the project mounted at /project. The live `virtuoso`
+# service MUST be stopped first:   docker compose stop virtuoso
+#
+# DESTRUCTIVE: deletes the current database in data/db and rebuilds it from the
+# backup. See ./README.md for usage.
+set -euo pipefail
+
+PROJECT="${PROJECT_DIR:-/project}"
+DATADIR="$PROJECT/data/db"
+BACKUPS="$DATADIR/backups"
+INI="${VIRTUOSO_INI:-$PROJECT/config/virtuoso/virtuoso.ini}"
+
+# --- args: optional [prefix] and optional --yes (skip confirmation) ----------
+PREFIX=""
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) FORCE=1 ;;
+    *)        PREFIX="$arg" ;;
+  esac
+done
+
+# --- sanity checks -----------------------------------------------------------
+[ -d "$DATADIR" ] || { echo "ERROR: $DATADIR not found (run from the project root)."; exit 1; }
+[ -f "$INI" ]     || { echo "ERROR: virtuoso.ini not found at $INI."; exit 1; }
+[ -d "$BACKUPS" ] || { echo "ERROR: no backups folder at $BACKUPS."; exit 1; }
+
+if [ -e "$DATADIR/virtuoso.lck" ]; then
+  echo "ERROR: $DATADIR/virtuoso.lck is present — the database looks like it is still running."
+  echo "       Stop it first:   docker compose stop virtuoso"
+  echo "       (If you are certain it is stopped, remove the stale lock file and retry.)"
+  exit 1
+fi
+
+# --- resolve the backup prefix ----------------------------------------------
+shopt -s nullglob
+bpfiles=("$BACKUPS"/*.bp)
+shopt -u nullglob
+[ "${#bpfiles[@]}" -gt 0 ] || { echo "ERROR: no .bp backup files found in $BACKUPS."; exit 1; }
+
+if [ -z "$PREFIX" ]; then
+  # Derive the prefix = filename up to the trailing numeric suffix (e.g.
+  # backup_20260609_120000_3.bp -> backup_20260609_120000_).
+  declare -A seen=()
+  for f in "${bpfiles[@]}"; do
+    base="${f##*/}"
+    seen["$(printf '%s' "$base" | sed -E 's/[0-9]+\.bp$//')"]=1
+  done
+  prefixes=("${!seen[@]}")
+  if [ "${#prefixes[@]}" -gt 1 ]; then
+    echo "ERROR: multiple backup sets found — pass one explicitly as the prefix:"
+    printf '   %s\n' "${prefixes[@]}"
+    exit 1
+  fi
+  PREFIX="${prefixes[0]}"
+fi
+
+shopt -s nullglob
+match=("$BACKUPS/$PREFIX"*.bp)
+shopt -u nullglob
+[ "${#match[@]}" -gt 0 ] || { echo "ERROR: no files matching ${PREFIX}*.bp in $BACKUPS."; exit 1; }
+
+echo "Backup set : $PREFIX  (${#match[@]} .bp files)"
+echo "Target     : $DATADIR"
+
+# --- confirm (destructive) ---------------------------------------------------
+if [ "$FORCE" -ne 1 ]; then
+  if ! read -r -p "This DELETES the current database and restores '$PREFIX'. Type 'yes' to continue: " CONFIRM; then
+    echo "Aborted (no input — pass --yes to skip this prompt)."; exit 1
+  fi
+  [ "$CONFIRM" = "yes" ] || { echo "Aborted."; exit 1; }
+fi
+
+# --- remove the current database (Method 1 prerequisite) ---------------------
+echo "Removing current database files..."
+rm -f "$DATADIR"/virtuoso.db \
+      "$DATADIR"/virtuoso.trx \
+      "$DATADIR"/virtuoso.pxa \
+      "$DATADIR"/virtuoso-temp.db \
+      "$DATADIR"/.dba_pwd_set \
+      "$DATADIR"/.backup_restored
+
+# --- restore -----------------------------------------------------------------
+# The live virtuoso.ini points the database files at absolute paths inside the
+# image (/usr/local/.../db, symlinked to /data). In this one-off container the
+# host data dir is at $DATADIR instead, so rewrite the paths onto it — the
+# rebuilt database then lands in ./data/db on the host, where the real service
+# will find it on next start.
+RESTORE_INI=/tmp/restore.ini
+cp "$INI" "$RESTORE_INI"
+crudini --set "$RESTORE_INI" Database     DatabaseFile       "$DATADIR/virtuoso.db"
+crudini --set "$RESTORE_INI" Database     ErrorLogFile       "$DATADIR/virtuoso.log"
+crudini --set "$RESTORE_INI" Database     LockFile           "$DATADIR/virtuoso.lck"
+crudini --set "$RESTORE_INI" Database     TransactionFile    "$DATADIR/virtuoso.trx"
+crudini --set "$RESTORE_INI" Database     xa_persistent_file "$DATADIR/virtuoso.pxa"
+crudini --set "$RESTORE_INI" TempDatabase DatabaseFile       "$DATADIR/virtuoso-temp.db"
+crudini --set "$RESTORE_INI" TempDatabase TransactionFile    "$DATADIR/virtuoso-temp.trx"
+
+echo "Restoring..."
+cd "$BACKUPS"
+virtuoso-t +restore-backup "$PREFIX" +configfile "$RESTORE_INI"
+
+# --- stop toLoad/ from re-seeding the restored database ----------------------
+# On startup the entrypoint imports data/db/toLoad/ when .data_loaded is absent.
+# A restored backup is already complete, so guard against a duplicate import.
+if [ -d "$DATADIR/toLoad" ] && [ -n "$(ls -A "$DATADIR/toLoad" 2>/dev/null)" ]; then
+  touch "$DATADIR/.data_loaded"
+  echo "NOTE: created data/db/.data_loaded so the toLoad/ seed is NOT re-imported on top of"
+  echo "      the restored database. Delete it if you DO want toLoad re-loaded on next start."
+fi
+
+echo
+echo "Restore complete. Start the database again:"
+echo "   docker compose up -d virtuoso"

--- a/scripts/restore-virtuoso-backup/run.sh
+++ b/scripts/restore-virtuoso-backup/run.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
-# Restore the Virtuoso triplestore from an online backup (the .bp files in
-# data/db/backups, as produced by `mu script virtuoso create-backup`).
-#
-# Runs offline in a one-off redpencil/virtuoso container (same image as the
-# `virtuoso` service) with the project mounted at /project. The live `virtuoso`
-# service MUST be stopped first:   docker compose stop virtuoso
-#
-# DESTRUCTIVE: deletes the current database in data/db and rebuilds it from the
-# backup. See ./README.md for usage.
+# Restore Virtuoso from a .bp backup in data/db/backups. Destructive: replaces
+# the current database. Stop the virtuoso service first. See ./README.md.
 set -euo pipefail
 
 PROJECT="${PROJECT_DIR:-/project}"
@@ -15,7 +8,7 @@ DATADIR="$PROJECT/data/db"
 BACKUPS="$DATADIR/backups"
 INI="${VIRTUOSO_INI:-$PROJECT/config/virtuoso/virtuoso.ini}"
 
-# --- args: optional [prefix] and optional --yes (skip confirmation) ----------
+# args: optional prefix, optional --yes
 PREFIX=""
 FORCE=0
 for arg in "$@"; do
@@ -25,7 +18,6 @@ for arg in "$@"; do
   esac
 done
 
-# --- sanity checks -----------------------------------------------------------
 [ -d "$DATADIR" ] || { echo "ERROR: $DATADIR not found (run from the project root)."; exit 1; }
 [ -f "$INI" ]     || { echo "ERROR: virtuoso.ini not found at $INI."; exit 1; }
 [ -d "$BACKUPS" ] || { echo "ERROR: no backups folder at $BACKUPS."; exit 1; }
@@ -37,15 +29,14 @@ if [ -e "$DATADIR/virtuoso.lck" ]; then
   exit 1
 fi
 
-# --- resolve the backup prefix ----------------------------------------------
+# resolve the backup prefix
 shopt -s nullglob
 bpfiles=("$BACKUPS"/*.bp)
 shopt -u nullglob
 [ "${#bpfiles[@]}" -gt 0 ] || { echo "ERROR: no .bp backup files found in $BACKUPS."; exit 1; }
 
 if [ -z "$PREFIX" ]; then
-  # Derive the prefix = filename up to the trailing numeric suffix (e.g.
-  # backup_20260609_120000_3.bp -> backup_20260609_120000_).
+  # prefix = filename up to the trailing numeric suffix (backup_..._3.bp -> backup_..._)
   declare -A seen=()
   for f in "${bpfiles[@]}"; do
     base="${f##*/}"
@@ -68,7 +59,6 @@ shopt -u nullglob
 echo "Backup set : $PREFIX  (${#match[@]} .bp files)"
 echo "Target     : $DATADIR"
 
-# --- confirm (destructive) ---------------------------------------------------
 if [ "$FORCE" -ne 1 ]; then
   if ! read -r -p "This DELETES the current database and restores '$PREFIX'. Type 'yes' to continue: " CONFIRM; then
     echo "Aborted (no input — pass --yes to skip this prompt)."; exit 1
@@ -76,7 +66,6 @@ if [ "$FORCE" -ne 1 ]; then
   [ "$CONFIRM" = "yes" ] || { echo "Aborted."; exit 1; }
 fi
 
-# --- remove the current database (Method 1 prerequisite) ---------------------
 echo "Removing current database files..."
 rm -f "$DATADIR"/virtuoso.db \
       "$DATADIR"/virtuoso.trx \
@@ -85,12 +74,8 @@ rm -f "$DATADIR"/virtuoso.db \
       "$DATADIR"/.dba_pwd_set \
       "$DATADIR"/.backup_restored
 
-# --- restore -----------------------------------------------------------------
-# The live virtuoso.ini points the database files at absolute paths inside the
-# image (/usr/local/.../db, symlinked to /data). In this one-off container the
-# host data dir is at $DATADIR instead, so rewrite the paths onto it — the
-# rebuilt database then lands in ./data/db on the host, where the real service
-# will find it on next start.
+# Rewrite the ini's DB paths onto $DATADIR so the rebuilt files land in ./data/db
+# (the live ini points them at absolute in-image paths).
 RESTORE_INI=/tmp/restore.ini
 cp "$INI" "$RESTORE_INI"
 crudini --set "$RESTORE_INI" Database     DatabaseFile       "$DATADIR/virtuoso.db"
@@ -105,9 +90,8 @@ echo "Restoring..."
 cd "$BACKUPS"
 virtuoso-t +restore-backup "$PREFIX" +configfile "$RESTORE_INI"
 
-# --- stop toLoad/ from re-seeding the restored database ----------------------
-# On startup the entrypoint imports data/db/toLoad/ when .data_loaded is absent.
-# A restored backup is already complete, so guard against a duplicate import.
+# Entrypoint re-imports toLoad/ when .data_loaded is absent; the restore is
+# already complete, so set the marker to skip it.
 if [ -d "$DATADIR/toLoad" ] && [ -n "$(ls -A "$DATADIR/toLoad" 2>/dev/null)" ]; then
   touch "$DATADIR/.data_loaded"
   echo "NOTE: created data/db/.data_loaded so the toLoad/ seed is NOT re-imported on top of"

--- a/scripts/restore-virtuoso-backup/run.sh
+++ b/scripts/restore-virtuoso-backup/run.sh
@@ -8,15 +8,8 @@ DATADIR="$PROJECT/data/db"
 BACKUPS="$DATADIR/backups"
 INI="${VIRTUOSO_INI:-$PROJECT/config/virtuoso/virtuoso.ini}"
 
-# args: optional prefix, optional --yes
-PREFIX=""
-FORCE=0
-for arg in "$@"; do
-  case "$arg" in
-    --yes|-y) FORCE=1 ;;
-    *)        PREFIX="$arg" ;;
-  esac
-done
+# args: optional prefix
+PREFIX="${1:-}"
 
 [ -d "$DATADIR" ] || { echo "ERROR: $DATADIR not found (run from the project root)."; exit 1; }
 [ -f "$INI" ]     || { echo "ERROR: virtuoso.ini not found at $INI."; exit 1; }
@@ -59,12 +52,10 @@ shopt -u nullglob
 echo "Backup set : $PREFIX  (${#match[@]} .bp files)"
 echo "Target     : $DATADIR"
 
-if [ "$FORCE" -ne 1 ]; then
-  if ! read -r -p "This DELETES the current database and restores '$PREFIX'. Type 'yes' to continue: " CONFIRM; then
-    echo "Aborted (no input — pass --yes to skip this prompt)."; exit 1
-  fi
-  [ "$CONFIRM" = "yes" ] || { echo "Aborted."; exit 1; }
+if ! read -r -p "This DELETES the current database and restores '$PREFIX'. Type 'yes' to continue: " CONFIRM; then
+  echo "Aborted (no input)."; exit 1
 fi
+[ "$CONFIRM" = "yes" ] || { echo "Aborted."; exit 1; }
 
 echo "Removing current database files..."
 rm -f "$DATADIR"/virtuoso.db \


### PR DESCRIPTION
In context of [DL-7413] a mu-cli script was create to restore a dabase, PROVIDED that the db/backups file are available. To run: `mu script project-scripts restore-backup`