### PR TITLE
VDDS: specific org graph for vendor data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Unreleased
+
+- VDDS: optimise query for vendor and organisation info. A needed speedup after re-distrubition of vendor info in [PR #741](https://github.com/lblod/app-digitaal-loket/pull/741)! No ticket.
+
 # v1.224.0 (2026-06-22)
 
 - Add Cross Referencing rules on the BesluitType and BesluitDocumentType [DL-7202] [DL-7204] [DL-7325]

--- a/config/vendor-data/model.ttl
+++ b/config/vendor-data/model.ttl
@@ -40,13 +40,16 @@ meb:Submission
       ${subject}
         pav:createdBy ?organisation ;
         pav:providedBy ?vendor .
-      ?vendor
-        a foaf:Agent ;
-        muAccount:canActOnBehalfOf ?organisation ;
-        mu:uuid ?vendorUuid .
       ?organisation
         a besluit:Bestuurseenheid ;
         mu:uuid ?organisationUuid .
+      BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?organisationUuid)) AS ?orgGraph)
+      GRAPH ?orgGraph {
+        ?vendor
+          a foaf:Agent ;
+          muAccount:canActOnBehalfOf ?organisation ;
+          mu:uuid ?vendorUuid .
+      }
     }
   """ ;
   vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-toezichtGebruiker" ;

--- a/config/vendor-data/model.ttl
+++ b/config/vendor-data/model.ttl
@@ -43,8 +43,7 @@ meb:Submission
       ?organisation
         a besluit:Bestuurseenheid ;
         mu:uuid ?organisationUuid .
-      BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?organisationUuid)) AS ?orgGraph)
-      GRAPH ?orgGraph {
+      GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
         ?vendor
           a foaf:Agent ;
           muAccount:canActOnBehalfOf ?organisation ;

--- a/config/vendor-data/model.ttl
+++ b/config/vendor-data/model.ttl
@@ -75,13 +75,15 @@ meb:Submission
       ${subject}
         schema:sender ?organisation ;
         pav:providedBy ?vendor .
-      ?vendor
-        a foaf:Agent ;
-        muAccount:canActOnBehalfOf ?organisation ;
-        mu:uuid ?vendorUuid .
       ?organisation
         a besluit:Bestuurseenheid ;
         mu:uuid ?organisationUuid .
+      GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+        ?vendor
+          a foaf:Agent ;
+          muAccount:canActOnBehalfOf ?organisation ;
+          mu:uuid ?vendorUuid .
+      }
     }
   """ ;
   vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-toezichtGebruiker" ;
@@ -112,13 +114,15 @@ task:error
       ${subject}
         schema:sender ?organisation ;
         pav:providedBy ?vendor .
-      ?vendor
-        a foaf:Agent ;
-        muAccount:canActOnBehalfOf ?organisation ;
-        mu:uuid ?vendorUuid .
       ?organisation
         a besluit:Bestuurseenheid ;
         mu:uuid ?organisationUuid .
+      GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+        ?vendor
+          a foaf:Agent ;
+          muAccount:canActOnBehalfOf ?organisation ;
+          mu:uuid ?vendorUuid .
+      }
     }
   """ ;
   vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-berichtenGebruiker" ;
@@ -183,13 +187,15 @@ nie:dataSource
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject} schema:recipient ?organisation .
-      ?vendor
-        a foaf:Agent ;
-        muAccount:canActOnBehalfOf ?organisation ;
-        mu:uuid ?vendorUuid .
       ?organisation
         a besluit:Bestuurseenheid ;
         mu:uuid ?organisationUuid .
+      GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+        ?vendor
+          a foaf:Agent ;
+          muAccount:canActOnBehalfOf ?organisation ;
+          mu:uuid ?vendorUuid .
+      }
     }
   """ ;
   vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-berichtenGebruiker" ;
@@ -222,13 +228,15 @@ nie:dataSource
     WHERE {
       ${subject}
         schema:sender ?organisation .
-      ?vendor
-        a foaf:Agent ;
-        muAccount:canActOnBehalfOf ?organisation ;
-        mu:uuid ?vendorUuid .
       ?organisation
         a besluit:Bestuurseenheid ;
         mu:uuid ?organisationUuid .
+      GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+        ?vendor
+          a foaf:Agent ;
+          muAccount:canActOnBehalfOf ?organisation ;
+          mu:uuid ?vendorUuid .
+      }
     }
   """ ;
   vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-berichtenGebruiker" ;
@@ -262,13 +270,15 @@ nie:dataSource
     WHERE {
       ${subject}
         schema:recipient ?organisation .
-      ?vendor
-        a foaf:Agent ;
-        muAccount:canActOnBehalfOf ?organisation ;
-        mu:uuid ?vendorUuid .
       ?organisation
         a besluit:Bestuurseenheid ;
         mu:uuid ?organisationUuid .
+      GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+        ?vendor
+          a foaf:Agent ;
+          muAccount:canActOnBehalfOf ?organisation ;
+          mu:uuid ?vendorUuid .
+      }
     }
   """ ;
   vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-berichtenGebruiker" ;


### PR DESCRIPTION
Select vendor data from the specific organisation graph, instead of the full triplestore. This is needed after redistribution of vendor data in PR https://github.com/lblod/app-digitaal-loket/pull/741.

Without this change, the VDDS is really slow. The query for retrieving organisation and vendor data takes multiple seconds to finish. Healing would take days and regular processing would be unnecessarily heavy.

To test, use up to date test data, run healing on the VDDS and see if Submissions are really being processed. (Make sure you don't see the message

```
HEALING: No target graph found for subject <http://data.lblod.info/submissions/[a uuid...]>. Skipping.
```

too often in the logs. Some occurrences of this message could be normal.)